### PR TITLE
fix: code ident

### DIFF
--- a/pysnmp/carrier/sockmsg.py
+++ b/pysnmp/carrier/sockmsg.py
@@ -29,92 +29,92 @@ uint32_t = ctypes.c_uint32
 in_addr_t = uint32_t
 
 
-    class in_addr(ctypes.Structure):
-        _fields_ = [('s_addr', in_addr_t)]
+class in_addr(ctypes.Structure):
+    _fields_ = [('s_addr', in_addr_t)]
 
 
-    class in6_addr_U(ctypes.Union):
-        _fields_ = [
-            ('__u6_addr8', ctypes.c_uint8 * 16),
-            ('__u6_addr16', ctypes.c_uint16 * 8),
-            ('__u6_addr32', ctypes.c_uint32 * 4),
-        ]
+class in6_addr_U(ctypes.Union):
+    _fields_ = [
+        ('__u6_addr8', ctypes.c_uint8 * 16),
+        ('__u6_addr16', ctypes.c_uint16 * 8),
+        ('__u6_addr32', ctypes.c_uint32 * 4),
+    ]
 
 
-    class in6_addr(ctypes.Structure):
-        _fields_ = [
-            ('__in6_u', in6_addr_U),
-        ]
+class in6_addr(ctypes.Structure):
+    _fields_ = [
+        ('__in6_u', in6_addr_U),
+    ]
 
 
-    class in_pktinfo(ctypes.Structure):
-        _fields_ = [
-            ('ipi_ifindex', ctypes.c_int),
-            ('ipi_spec_dst', in_addr),
-            ('ipi_addr', in_addr),
-        ]
+class in_pktinfo(ctypes.Structure):
+    _fields_ = [
+        ('ipi_ifindex', ctypes.c_int),
+        ('ipi_spec_dst', in_addr),
+        ('ipi_addr', in_addr),
+    ]
 
 
-    class in6_pktinfo(ctypes.Structure):
-        _fields_ = [
-            ('ipi6_addr', in6_addr),
-            ('ipi6_ifindex', ctypes.c_uint),
-        ]
+class in6_pktinfo(ctypes.Structure):
+    _fields_ = [
+        ('ipi6_addr', in6_addr),
+        ('ipi6_ifindex', ctypes.c_uint),
+    ]
 
 
-    def getRecvFrom(addressType):
+def getRecvFrom(addressType):
 
-        def recvfrom(s, sz):
-            _to = None
+    def recvfrom(s, sz):
+        _to = None
 
-            data, ancdata, msg_flags, _from = s.recvmsg(sz, socket.CMSG_LEN(sz))
+        data, ancdata, msg_flags, _from = s.recvmsg(sz, socket.CMSG_LEN(sz))
 
-            for anc in ancdata:
-                if anc[0] == socket.SOL_IP and anc[1] == socket.IP_PKTINFO:
-                    addr = in_pktinfo.from_buffer_copy(anc[2])
-                    addr = ipaddress.IPv4Address(memoryview(addr.ipi_addr).tobytes())
-                    _to = (str(addr), s.getsockname()[1])
-                    break
+        for anc in ancdata:
+            if anc[0] == socket.SOL_IP and anc[1] == socket.IP_PKTINFO:
+                addr = in_pktinfo.from_buffer_copy(anc[2])
+                addr = ipaddress.IPv4Address(memoryview(addr.ipi_addr).tobytes())
+                _to = (str(addr), s.getsockname()[1])
+                break
 
-                elif anc[0] == socket.SOL_IPV6 and anc[1] == socket.IPV6_PKTINFO:
-                    addr = in6_pktinfo.from_buffer_copy(anc[2])
-                    addr = ipaddress.ip_address(memoryview(addr.ipi6_addr).tobytes())
-                    _to = (str(addr), s.getsockname()[1])
-                    break
+            elif anc[0] == socket.SOL_IPV6 and anc[1] == socket.IPV6_PKTINFO:
+                addr = in6_pktinfo.from_buffer_copy(anc[2])
+                addr = ipaddress.ip_address(memoryview(addr.ipi6_addr).tobytes())
+                _to = (str(addr), s.getsockname()[1])
+                break
 
-            debug.logger & debug.flagIO and debug.logger(
-                'recvfrom: received %d octets from %s to %s; '
-                'iov blob %r' % (len(data), _from, _to, ancdata))
+        debug.logger & debug.flagIO and debug.logger(
+            'recvfrom: received %d octets from %s to %s; '
+            'iov blob %r' % (len(data), _from, _to, ancdata))
 
-            return data, addressType(_from).setLocalAddress(_to)
+        return data, addressType(_from).setLocalAddress(_to)
 
-        return recvfrom
+    return recvfrom
 
 
-    def getSendTo(addressType):
+def getSendTo(addressType):
 
-        def sendto(s, _data, _to):
-            ancdata = []
-            if type(_to) == addressType:
-                addr = ipaddress.ip_address(_to.getLocalAddress()[0])
+    def sendto(s, _data, _to):
+        ancdata = []
+        if type(_to) == addressType:
+            addr = ipaddress.ip_address(_to.getLocalAddress()[0])
 
-            else:
-                addr = ipaddress.ip_address(s.getsockname()[0])
+        else:
+            addr = ipaddress.ip_address(s.getsockname()[0])
 
-            if type(addr) == ipaddress.IPv4Address:
-                _f = in_pktinfo()
-                _f.ipi_spec_dst = in_addr.from_buffer_copy(addr.packed)
-                ancdata = [(socket.SOL_IP, socket.IP_PKTINFO, memoryview(_f).tobytes())]
+        if type(addr) == ipaddress.IPv4Address:
+            _f = in_pktinfo()
+            _f.ipi_spec_dst = in_addr.from_buffer_copy(addr.packed)
+            ancdata = [(socket.SOL_IP, socket.IP_PKTINFO, memoryview(_f).tobytes())]
 
-            elif s.family == socket.AF_INET6 and type(addr) == ipaddress.IPv6Address:
-                _f = in6_pktinfo()
-                _f.ipi6_addr = in6_addr.from_buffer_copy(addr.packed)
-                ancdata = [(socket.SOL_IPV6, socket.IPV6_PKTINFO, memoryview(_f).tobytes())]
+        elif s.family == socket.AF_INET6 and type(addr) == ipaddress.IPv6Address:
+            _f = in6_pktinfo()
+            _f.ipi6_addr = in6_addr.from_buffer_copy(addr.packed)
+            ancdata = [(socket.SOL_IPV6, socket.IPV6_PKTINFO, memoryview(_f).tobytes())]
 
-            debug.logger & debug.flagIO and debug.logger(
-                'sendto: sending %d octets to %s; address %r; '
-                'iov blob %r' % (len(_data), _to, addr, ancdata))
+        debug.logger & debug.flagIO and debug.logger(
+            'sendto: sending %d octets to %s; address %r; '
+            'iov blob %r' % (len(_data), _to, addr, ancdata))
 
-            return s.sendmsg([_data], ancdata, 0, _to)
+        return s.sendmsg([_data], ancdata, 0, _to)
 
-        return sendto
+    return sendto


### PR DESCRIPTION
Fix of a bug:
```
File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/omrozowicz/Documents/snmp/splunk-connect-for-snmp/splunk_connect_for_snmp/traps.py", line 12, in <module>
    from pysnmp.entity import config, engine
  File "/Users/omrozowicz/Documents/snmp/splunk-connect-for-snmp/venv2/lib/python3.10/site-packages/pysnmp/entity/config.py", line 8, in <module>
    from pysnmp.carrier.asyncore.dgram import udp, udp6, unix
  File "/Users/omrozowicz/Documents/snmp/splunk-connect-for-snmp/venv2/lib/python3.10/site-packages/pysnmp/carrier/asyncore/dgram/udp.py", line 9, in <module>
    from pysnmp.carrier.asyncore.dgram.base import DgramSocketTransport
  File "/Users/omrozowicz/Documents/snmp/splunk-connect-for-snmp/venv2/lib/python3.10/site-packages/pysnmp/carrier/asyncore/dgram/base.py", line 11, in <module>
    from pysnmp.carrier import sockfix, sockmsg, error
  File "/Users/omrozowicz/Documents/snmp/splunk-connect-for-snmp/venv2/lib/python3.10/site-packages/pysnmp/carrier/sockmsg.py", line 32
    class in_addr(ctypes.Structure):
IndentationError: unexpected indent
```