### PR TITLE
fix: performance issue in OrderedDict

### DIFF
--- a/pysnmp/smi/indices.py
+++ b/pysnmp/smi/indices.py
@@ -20,16 +20,16 @@ class OrderedDict(dict):
             self.update(**kwargs)
 
     def __setitem__(self, key, value):
-        super().__setitem__(key, value)
-        if key not in self.__keys:
+        if key not in self:
             self.__keys.append(key)
             self.__dirty = True
+        super().__setitem__(key, value)
 
     def __delitem__(self, key):
-        super().__delitem__(key)
-        if key in self.__keys:
+        if key in self:
             self.__keys.remove(key)
             self.__dirty = True
+        super().__delitem__(key)
 
     def clear(self):
         super().clear()


### PR DESCRIPTION
When loading large MIB values, __setitem__ is here a performance painful
point. Condition "if key not in self.__keys" performs a linear scan of a
list, and this list can be big. Checking is key is already in dict is
faster.

On a micro-benchmark (time to run SNMP queries on a device, after a
fresh startup) this simple patch move performances from 30s to only 3s