### PR TITLE
Asyncio hlapi fixes and example updates

### DIFF
--- a/examples/hlapi/asyncio/agent/ntforg/default-v1-trap.py
+++ b/examples/hlapi/asyncio/agent/ntforg/default-v1-trap.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 SNMPv1 TRAP with defaults
 +++++++++++++++++++++++++
@@ -26,7 +27,7 @@ from pysnmp.hlapi.asyncio import *
 
 async def run():
     snmpEngine = SnmpEngine()
-    trap_result = await sendNotification(
+    errorIndication, errorStatus, errorIndex, varBinds = await sendNotification(
         snmpEngine,
         CommunityData("public", mpModel=0),
         UdpTransportTarget(("localhost", 161)),
@@ -37,7 +38,6 @@ async def run():
             ("1.3.6.1.2.1.1.1.0", OctetString("my system")),
         ),
     )
-    errorIndication, errorStatus, errorIndex, varBinds = await trap_result
     if errorIndication:
         print(errorIndication)
 

--- a/examples/hlapi/asyncio/agent/ntforg/multiple-notifications-at-once.py
+++ b/examples/hlapi/asyncio/agent/ntforg/multiple-notifications-at-once.py
@@ -32,7 +32,7 @@ async def sendone(snmpEngine, hostname, notifyType):
     (errorIndication, errorStatus, errorIndex, varBinds) = await sendNotification(
         snmpEngine,
         CommunityData("public", tag=hostname),
-        UdpTransportTarget((hostname, 161), tagList=hostname),
+        UdpTransportTarget((hostname, 162), tagList=hostname),
         ContextData(),
         notifyType,
         NotificationType(ObjectIdentity("1.3.6.1.6.3.1.1.6.1.0")).addVarBinds(

--- a/examples/hlapi/asyncio/manager/cmdgen/getbulk-to-eom.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/getbulk-to-eom.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Bulk walk MIB
 +++++++++++++
@@ -24,7 +25,7 @@ from pysnmp.hlapi.asyncio import *
 async def run(varBinds):
     snmpEngine = SnmpEngine()
     while True:
-        bulk_task = await bulkCmd(
+        errorIndication, errorStatus, errorIndex, varBindTable = await bulkCmd(
             snmpEngine,
             CommunityData("public"),
             UdpTransportTarget(("localhost", 161)),
@@ -33,7 +34,6 @@ async def run(varBinds):
             50,
             *varBinds
         )
-        (errorIndication, errorStatus, errorIndex, varBindTable) = await bulk_task
         if errorIndication:
             print(errorIndication)
             break

--- a/examples/hlapi/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Concurrent queries
 ++++++++++++++++++
@@ -22,7 +23,7 @@ from pysnmp.hlapi.asyncio import *
 
 
 async def getone(snmpEngine, hostname):
-    get_result = await getCmd(
+    errorIndication, errorStatus, errorIndex, varBinds = await getCmd(
         snmpEngine,
         CommunityData("public"),
         UdpTransportTarget(hostname),
@@ -30,7 +31,6 @@ async def getone(snmpEngine, hostname):
         ObjectType(ObjectIdentity("SNMPv2-MIB", "sysDescr", 0)),
     )
 
-    errorIndication, errorStatus, errorIndex, varBinds = await get_result
     if errorIndication:
         print(errorIndication)
     elif errorStatus:
@@ -47,12 +47,13 @@ async def getone(snmpEngine, hostname):
 
 snmpEngine = SnmpEngine()
 
-asyncio.run(
-    asyncio.wait(
-        [
-            getone(snmpEngine, ("localhost", 161)),
-            getone(snmpEngine, ("localhost", 162)),
-            getone(snmpEngine, ("localhost", 163)),
-        ]
+
+async def main():
+    await asyncio.gather(
+        getone(snmpEngine, ("localhost", 161)),
+        getone(snmpEngine, ("localhost", 162)),
+        getone(snmpEngine, ("localhost", 163)),
     )
-)
+
+
+asyncio.run(main())

--- a/examples/hlapi/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py
@@ -32,7 +32,7 @@ async def getone(snmpEngine, hostname):
     )
 
     if errorIndication:
-        print(errorIndication)
+        print(f'{hostname}: {errorIndication}')
     elif errorStatus:
         print(
             "{} at {}".format(
@@ -51,7 +51,7 @@ snmpEngine = SnmpEngine()
 async def main():
     await asyncio.gather(
         getone(snmpEngine, ("localhost", 161)),
-        getone(snmpEngine, ("localhost", 162)),
+        getone(snmpEngine, ("localhost6", 161)),
         getone(snmpEngine, ("localhost", 163)),
     )
 

--- a/examples/hlapi/asyncio/manager/cmdgen/multiple-sequential-queries.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/multiple-sequential-queries.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Sequential queries
 ++++++++++++++++++
@@ -22,7 +23,7 @@ from pysnmp.hlapi.asyncio import *
 
 
 async def getone(snmpEngine, hostname):
-    result_get = await getCmd(
+    errorIndication, errorStatus, errorIndex, varBinds = await getCmd(
         snmpEngine,
         CommunityData("public"),
         UdpTransportTarget(hostname),
@@ -30,7 +31,6 @@ async def getone(snmpEngine, hostname):
         ObjectType(ObjectIdentity("SNMPv2-MIB", "sysDescr", 0)),
     )
 
-    errorIndication, errorStatus, errorIndex, varBinds = await result_get
     if errorIndication:
         print(errorIndication)
     elif errorStatus:

--- a/examples/hlapi/asyncio/manager/cmdgen/multiple-sequential-queries.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/multiple-sequential-queries.py
@@ -32,7 +32,7 @@ async def getone(snmpEngine, hostname):
     )
 
     if errorIndication:
-        print(errorIndication)
+        print(f'{hostname}: {errorIndication}')
     elif errorStatus:
         print(
             "{} at {}".format(
@@ -53,5 +53,5 @@ async def getall(snmpEngine, hostnames):
 snmpEngine = SnmpEngine()
 
 asyncio.run(
-    getall(snmpEngine, [("localhost", 161), ("localhost", 162), ("localhost", 163)])
+    getall(snmpEngine, [("localhost", 161), ("localhost6", 161), ("localhost", 163)])
 )

--- a/examples/hlapi/asyncio/manager/cmdgen/v1-get.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/v1-get.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 SNMPv1
 ++++++
@@ -21,7 +22,7 @@ from pysnmp.hlapi.asyncio import *
 
 async def run():
     snmpEngine = SnmpEngine()
-    get_result = await getCmd(
+    errorIndication, errorStatus, errorIndex, varBinds = await getCmd(
         snmpEngine,
         CommunityData("public", mpModel=0),
         UdpTransportTarget(("localhost", 161)),
@@ -29,7 +30,6 @@ async def run():
         ObjectType(ObjectIdentity("SNMPv2-MIB", "sysDescr", 0)),
     )
 
-    errorIndication, errorStatus, errorIndex, varBinds = await get_result
     if errorIndication:
         print(errorIndication)
     elif errorStatus:

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -55,12 +55,9 @@ isEndOfMib = lambda x: not cmdgen.getNextVarBinds(x)[1]
 
 async def getCmd(snmpEngine, authData, transportTarget, contextData,
            *varBinds, **options):
-    r"""Creates a generator to perform SNMP GET query.
+    r"""Perform SNMP GET.
 
-    When iterator gets advanced by :py:mod:`asyncio` main loop,
-    SNMP GET request is send (:RFC:`1905#section-4.2.1`).
-    The iterator yields :py:class:`asyncio.get_running_loop().create_future()` which gets done whenever
-    response arrives or error occurs.
+    (:RFC:`1905#section-4.2.1`)
 
     Parameters
     ----------
@@ -88,7 +85,7 @@ async def getCmd(snmpEngine, authData, transportTarget, contextData,
             * `lookupMib` - load MIB and resolve response MIB variables at
               the cost of slightly reduced performance. Default is `True`.
 
-    Yields
+    Returns
     ------
     errorIndication : str
         True value indicates SNMP engine error.
@@ -119,7 +116,7 @@ async def getCmd(snmpEngine, authData, transportTarget, contextData,
     ...         ContextData(),
     ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0))
     ...     )
-    ...     errorIndication, errorStatus, errorIndex, varBinds = await result_get
+    ...     errorIndication, errorStatus, errorIndex, varBinds = result_get
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
     >>>
     >>> asyncio.get_event_loop().run_until_complete(run())
@@ -156,17 +153,14 @@ async def getCmd(snmpEngine, authData, transportTarget, contextData,
         vbProcessor.makeVarBinds(snmpEngine, varBinds), __cbFun,
         (options.get('lookupMib', True), future)
     )
-    return future
+    return await future
 
 
 async def setCmd(snmpEngine, authData, transportTarget, contextData,
            *varBinds, **options):
-    r"""Creates a generator to perform SNMP SET query.
+    r"""Perform SNMP SET.
 
-    When iterator gets advanced by :py:mod:`asyncio` main loop,
-    SNMP SET request is send (:RFC:`1905#section-4.2.5`).
-    The iterator yields :py:class:`asyncio.get_running_loop().create_future()` which gets done whenever
-    response arrives or error occurs.
+    (:RFC:`1905#section-4.2.5`)
 
     Parameters
     ----------
@@ -194,7 +188,7 @@ async def setCmd(snmpEngine, authData, transportTarget, contextData,
             * `lookupMib` - load MIB and resolve response MIB variables at
               the cost of slightly reduced performance. Default is `True`.
 
-    Yields
+    Returns
     ------
     errorIndication : str
         True value indicates SNMP engine error.
@@ -218,7 +212,7 @@ async def setCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from pysnmp.hlapi.asyncio import *
     >>>
     >>> async def run():
-    ...     errorIndication, errorStatus, errorIndex, varBinds = yield setCmd(
+    ...     errorIndication, errorStatus, errorIndex, varBinds = await setCmd(
     ...         SnmpEngine(),
     ...         CommunityData('public'),
     ...         UdpTransportTarget(('demo.snmplabs.com', 161)),
@@ -261,17 +255,14 @@ async def setCmd(snmpEngine, authData, transportTarget, contextData,
         vbProcessor.makeVarBinds(snmpEngine, varBinds), __cbFun,
         (options.get('lookupMib', True), future)
     )
-    return future
+    return await future
 
 
 async def nextCmd(snmpEngine, authData, transportTarget, contextData,
             *varBinds, **options):
-    r"""Creates a generator to perform SNMP GETNEXT query.
+    r"""Perform SNMP GETNEXT.
 
-    When iterator gets advanced by :py:mod:`asyncio` main loop,
-    SNMP GETNEXT request is send (:RFC:`1905#section-4.2.2`).
-    The iterator yields :py:class:`asyncio.get_running_loop().create_future()` which gets done whenever
-    response arrives or error occurs.
+    (:RFC:`1905#section-4.2.2`)
 
     Parameters
     ----------
@@ -299,7 +290,7 @@ async def nextCmd(snmpEngine, authData, transportTarget, contextData,
             * `lookupMib` - load MIB and resolve response MIB variables at
               the cost of slightly reduced performance. Default is `True`.
 
-    Yields
+    Returns
     ------
     errorIndication : str
         True value indicates SNMP engine error.
@@ -327,7 +318,7 @@ async def nextCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from pysnmp.hlapi.asyncio import *
     >>>
     >>> async def run():
-    ...     errorIndication, errorStatus, errorIndex, varBinds = yield nextCmd(
+    ...     errorIndication, errorStatus, errorIndex, varBinds = await nextCmd(
     ...         SnmpEngine(),
     ...         CommunityData('public'),
     ...         UdpTransportTarget(('demo.snmplabs.com', 161)),
@@ -372,17 +363,14 @@ async def nextCmd(snmpEngine, authData, transportTarget, contextData,
         vbProcessor.makeVarBinds(snmpEngine, varBinds), __cbFun,
         (options.get('lookupMib', True), future)
     )
-    return future
+    return await future
 
 
 async def bulkCmd(snmpEngine, authData, transportTarget, contextData,
             nonRepeaters, maxRepetitions, *varBinds, **options):
-    r"""Creates a generator to perform SNMP GETBULK query.
+    r"""Perform SNMP GETBULK.
 
-    When iterator gets advanced by :py:mod:`asyncio` main loop,
-    SNMP GETBULK request is send (:RFC:`1905#section-4.2.3`).
-    The iterator yields :py:class:`asyncio.get_running_loop().create_future()` which gets done whenever
-    response arrives or error occurs.
+    (:RFC:`1905#section-4.2.3`)
 
     Parameters
     ----------
@@ -420,8 +408,8 @@ async def bulkCmd(snmpEngine, authData, transportTarget, contextData,
             * `lookupMib` - load MIB and resolve response MIB variables at
               the cost of slightly reduced performance. Default is `True`.
 
-    Yields
-    ------
+    Returns
+    -------
     errorIndication : str
         True value indicates SNMP engine error.
     errorStatus : str
@@ -474,7 +462,7 @@ async def bulkCmd(snmpEngine, authData, transportTarget, contextData,
     ...         0, 2,
     ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'system'))
     ...     )
-    ...     errorIndication, errorStatus, errorIndex, varBinds = await result_bulk
+    ...     errorIndication, errorStatus, errorIndex, varBinds = result_bulk
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
     >>>
     >>> asyncio.run(run())
@@ -513,4 +501,4 @@ async def bulkCmd(snmpEngine, authData, transportTarget, contextData,
         vbProcessor.makeVarBinds(snmpEngine, varBinds), __cbFun,
         (options.get('lookupMib', True), future)
     )
-    return future
+    return await future

--- a/pysnmp/hlapi/asyncio/ntforg.py
+++ b/pysnmp/hlapi/asyncio/ntforg.py
@@ -29,12 +29,7 @@ lcd = NotificationOriginatorLcdConfigurator()
 
 async def sendNotification(snmpEngine, authData, transportTarget, contextData,
                      notifyType, varBinds, **options):
-    r"""Creates a generator to send SNMP notification.
-
-    When iterator gets advanced by :py:mod:`asyncio` main loop,
-    SNMP TRAP or INFORM notification is send (:RFC:`1905#section-4.2.6`).
-    The iterator yields :py:class:`asyncio.get_running_loop().create_future()` which gets done whenever
-    response arrives or error occurs.
+    r"""Send SNMP notification.
 
     Parameters
     ----------
@@ -70,7 +65,7 @@ async def sendNotification(snmpEngine, authData, transportTarget, contextData,
             * `lookupMib` - load MIB and resolve response MIB variables at
               the cost of slightly reduced performance. Default is `True`.
 
-    Yields
+    Result
     ------
     errorIndication : str
         True value indicates SNMP engine error.
@@ -88,13 +83,6 @@ async def sendNotification(snmpEngine, authData, transportTarget, contextData,
         Or its derivative indicating that an error occurred while
         performing SNMP operation.
 
-    Notes
-    -----
-    The `sendNotification` generator will be exhausted immidiately unless
-    an instance of :py:class:`~pysnmp.smi.rfc1902.NotificationType` class
-    or a sequence of :py:class:`~pysnmp.smi.rfc1902.ObjectType` `varBinds`
-    are send back into running generator (supported since Python 2.6).
-
     Examples
     --------
     >>> import asyncio
@@ -108,7 +96,7 @@ async def sendNotification(snmpEngine, authData, transportTarget, contextData,
     ...         ContextData(),
     ...         'trap',
     ...         NotificationType(ObjectIdentity('IF-MIB', 'linkDown')))
-    ...     errorIndication, errorStatus, errorIndex, varBinds = await send_result
+    ...     errorIndication, errorStatus, errorIndex, varBinds = send_result
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
     ...
     >>> asyncio.run(run())
@@ -159,4 +147,4 @@ async def sendNotification(snmpEngine, authData, transportTarget, contextData,
         loop = asyncio.get_event_loop()
         loop.call_soon(__trapFun, future)
 
-    return future
+    return await future


### PR DESCRIPTION
Hi, 

Our application broke when we picked up the "@coroutine" -> "async def" changes (for python 3.11).

The api didn't need to change, so can I propose these changes, which avoid needing the application to do a double await (which has no value)?
I updated all the examples so they work, below is a log of them working on fedora37 (python 3.11)

Also would you like me to run black to reformat? I saw it in the precommit hooks but when I tried it it made lots of changes which made it hard to see the "real" changes.

Regards,
Trevor Taylor

--------------------------
- with:
  snmpd on localhost and localhost6 port 161
  another snmpd on localhost and localhost6 port 163
  snmptrapd on localhost and localhost port 162

[xju@fed37 pysnmp]$ uname -a
Linux fed37 6.0.7-301.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Nov 4 18:35:48 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
[xju@fed37 pysnmp]$ python --version
Python 3.11.0
[xju@fed37 pysnmp]$ git show |grep 'commit '
commit de6063b89083e062d8713a5002677fed4fcd43bf
[xju@fed37 pysnmp]$ git status
On branch asyncio-fixes
Your branch is up to date with 'origin/asyncio-fixes'.

nothing to commit, working tree clean
[xju@fed37 pysnmp]$ find examples/hlapi -name '*.py' | ( while [ $?  = 0 ] && read n ; do echo $n  && PYTHONPATH=. $n ; done || ( echo "FAILED $n"; false ) )
examples/hlapi/asyncio/agent/ntforg/default-v1-trap.py
examples/hlapi/asyncio/agent/ntforg/multiple-notifications-at-once.py
SNMPv2-MIB::sysUpTime.0 = 2
SNMPv2-MIB::snmpTrapOID.0 = SNMPv2-MIB::snmpSetSerialNo.0
SNMPv2-MIB::sysDescr.0 = my system
examples/hlapi/asyncio/manager/cmdgen/getbulk-to-eom.py
SNMPv2-SMI::mib-2.25.1.1.0 = 834742
SNMPv2-SMI::mib-2.25.1.1.0 = 834744
SNMPv2-SMI::mib-2.25.1.2.0 = 0x07e7020c0c2d27002b0b00
SNMPv2-SMI::mib-2.25.1.2.0 = 0x07e7020c0c2d27002b0b00
SNMPv2-SMI::mib-2.25.1.3.0 = 393216
SNMPv2-SMI::mib-2.25.1.3.0 = 393216
SNMPv2-SMI::mib-2.25.1.4.0 = BOOT_IMAGE=(hd0,gpt2)/vmlinuz-6.0.7-301.fc37.x86_64 root=UUID=ed29781f-49e4-44b4-9a48-371af0d070e5 ro rootflags=subvol=root rhgb
SNMPv2-SMI::mib-2.25.1.4.0 = BOOT_IMAGE=(hd0,gpt2)/vmlinuz-6.0.7-301.fc37.x86_64 root=UUID=ed29781f-49e4-44b4-9a48-371af0d070e5 ro rootflags=subvol=root rhgb
SNMPv2-SMI::mib-2.25.1.5.0 = 7
SNMPv2-SMI::mib-2.25.1.5.0 = 7
SNMPv2-SMI::mib-2.25.1.6.0 = 213
SNMPv2-SMI::mib-2.25.1.6.0 = 213
SNMPv2-SMI::mib-2.25.1.7.0 = 0
SNMPv2-SMI::mib-2.25.1.7.0 = 0
SNMPv2-SMI::mib-2.25.1.7.0 = No more variables left in this MIB View
SNMPv2-SMI::mib-2.25.1.7.0 = No more variables left in this MIB View
examples/hlapi/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py
SNMPv2-MIB::sysDescr.0 = Linux fed37 6.0.7-301.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Nov 4 18:35:48 UTC 2022 x86_64
SNMPv2-MIB::sysDescr.0 = Linux fed37 6.0.7-301.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Nov 4 18:35:48 UTC 2022 x86_64
SNMPv2-MIB::sysDescr.0 = Linux fed37 6.0.7-301.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Nov 4 18:35:48 UTC 2022 x86_64
examples/hlapi/asyncio/manager/cmdgen/multiple-sequential-queries.py
SNMPv2-MIB::sysDescr.0 = Linux fed37 6.0.7-301.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Nov 4 18:35:48 UTC 2022 x86_64
SNMPv2-MIB::sysDescr.0 = Linux fed37 6.0.7-301.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Nov 4 18:35:48 UTC 2022 x86_64
SNMPv2-MIB::sysDescr.0 = Linux fed37 6.0.7-301.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Nov 4 18:35:48 UTC 2022 x86_64
examples/hlapi/asyncio/manager/cmdgen/v1-get.py
SNMPv2-MIB::sysDescr.0 = Linux fed37 6.0.7-301.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Nov 4 18:35:48 UTC 2022 x86_64
[xju@fed37 pysnmp]$

