### PR TITLE
Remove backward compatible imports

### DIFF
--- a/examples/smi/manager/builder.py
+++ b/examples/smi/manager/builder.py
@@ -11,41 +11,17 @@ import marshal
 import time
 import traceback
 
-try:
-    import importlib
-
-    try:
-        PY_MAGIC_NUMBER = importlib.util.MAGIC_NUMBER
-        SOURCE_SUFFIXES = importlib.machinery.SOURCE_SUFFIXES
-        BYTECODE_SUFFIXES = importlib.machinery.BYTECODE_SUFFIXES
-
-    except Exception:
-        raise ImportError()
-
-except ImportError:
-    import imp
-
-    PY_MAGIC_NUMBER = imp.get_magic()
-    SOURCE_SUFFIXES = [s[0] for s in imp.get_suffixes() if s[2] == imp.PY_SOURCE]
-    BYTECODE_SUFFIXES = [s[0] for s in imp.get_suffixes() if s[2] == imp.PY_COMPILED]
-
-PY_SUFFIXES = SOURCE_SUFFIXES + BYTECODE_SUFFIXES
-
-try:
-    from errno import ENOENT
-except ImportError:
-    ENOENT = -1
+from errno import ENOENT
+from importlib.machinery import SOURCE_SUFFIXES, BYTECODE_SUFFIXES
+from importlib.util import MAGIC_NUMBER as PY_MAGIC_NUMBER
 
 from pysnmp import version as pysnmp_version
 from pysnmp.smi import error
 from pysnmp import debug
 
-if sys.version_info[0] <= 2:
-    import types
+PY_SUFFIXES = SOURCE_SUFFIXES + BYTECODE_SUFFIXES
 
-    classTypes = (types.ClassType, type)
-else:
-    classTypes = (type,)
+classTypes = (type,)
 
 
 class __AbstractMibSource:

--- a/pysnmp/proto/secmod/eso/priv/aesbase.py
+++ b/pysnmp/proto/secmod/eso/priv/aesbase.py
@@ -10,15 +10,7 @@ from pysnmp.proto.secmod.rfc7860.auth import hmacsha2
 from pysnmp.proto.secmod.rfc3414 import localkey
 from pysnmp.proto import error
 from math import ceil
-
-try:
-    from hashlib import md5, sha1
-except ImportError:
-    import md5
-    import sha
-
-    md5 = md5.new
-    sha1 = sha.new
+from hashlib import md5, sha1
 
 
 class AbstractAesBlumenthal(aes.Aes):

--- a/pysnmp/proto/secmod/eso/priv/des3.py
+++ b/pysnmp/proto/secmod/eso/priv/des3.py
@@ -13,15 +13,7 @@ from pysnmp.proto import errind, error
 from pyasn1.type import univ
 from pyasn1.compat.octets import null
 from math import ceil
-
-try:
-    from hashlib import md5, sha1
-except ImportError:
-    import md5
-    import sha
-
-    md5 = md5.new
-    sha1 = sha.new
+from hashlib import md5, sha1
 
 try:
     from Cryptodome.Cipher import DES3

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
@@ -4,12 +4,7 @@
 # Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
 # License: http://snmplabs.com/pysnmp/license.html
 #
-try:
-    from hashlib import md5
-except ImportError:
-    import md5
-
-    md5 = md5.new
+from hashlib import md5
 from pyasn1.type import univ
 from pysnmp.proto.secmod.rfc3414.auth import base
 from pysnmp.proto.secmod.rfc3414 import localkey

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
@@ -4,12 +4,7 @@
 # Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
 # License: http://snmplabs.com/pysnmp/license.html
 #
-try:
-    from hashlib import sha1
-except ImportError:
-    import sha
-
-    sha1 = sha.new
+from hashlib import sha1
 from pyasn1.type import univ
 from pysnmp.proto.secmod.rfc3414.auth import base
 from pysnmp.proto.secmod.rfc3414 import localkey

--- a/pysnmp/proto/secmod/rfc3414/localkey.py
+++ b/pysnmp/proto/secmod/rfc3414/localkey.py
@@ -4,16 +4,7 @@
 # Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
 # License: http://snmplabs.com/pysnmp/license.html
 #
-try:
-    from hashlib import md5, sha1
-
-except ImportError:
-    import md5
-    import sha
-
-    md5 = md5.new
-    sha1 = sha.new
-
+from hashlib import md5, sha1
 from pyasn1.type import univ
 
 

--- a/pysnmp/proto/secmod/rfc3414/priv/des.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/des.py
@@ -11,19 +11,12 @@ from pysnmp.proto.secmod.rfc3414 import localkey
 from pysnmp.proto.secmod.rfc7860.auth import hmacsha2
 from pysnmp.proto import errind, error
 from pyasn1.type import univ
+from hashlib import md5, sha1
 
 try:
     from Cryptodome.Cipher import DES
 except ImportError:
     DES = None
-try:
-    from hashlib import md5, sha1
-except ImportError:
-    import md5
-    import sha
-
-    md5 = md5.new
-    sha1 = sha.new
 
 random.seed()
 

--- a/pysnmp/proto/secmod/rfc3826/priv/aes.py
+++ b/pysnmp/proto/secmod/rfc3826/priv/aes.py
@@ -11,19 +11,12 @@ from pysnmp.proto.secmod.rfc3414.auth import hmacmd5, hmacsha
 from pysnmp.proto.secmod.rfc7860.auth import hmacsha2
 from pysnmp.proto.secmod.rfc3414 import localkey
 from pysnmp.proto import errind, error
+from hashlib import md5, sha1
 
 try:
     from Cryptodome.Cipher import AES
 except ImportError:
     AES = None
-try:
-    from hashlib import md5, sha1
-except ImportError:
-    import md5
-    import sha
-
-    md5 = md5.new
-    sha1 = sha.new
 
 random.seed()
 

--- a/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
+++ b/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
@@ -6,17 +6,7 @@
 #
 import sys
 import hmac
-try:
-    from hashlib import sha224, sha256, sha384, sha512
-
-except ImportError:
-
-    class NotAvailable:
-        def __call__(self, *args, **kwargs):
-            raise errind.authenticationError
-
-    sha224 = sha256 = sha384 = sha512 = NotAvailable()
-
+from hashlib import sha224, sha256, sha384, sha512
 from pyasn1.type import univ
 from pysnmp.proto.secmod.rfc3414.auth import base
 from pysnmp.proto.secmod.rfc3414 import localkey

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -11,36 +11,15 @@ import marshal
 import time
 import traceback
 
-try:
-    import importlib
-
-    try:
-        PY_MAGIC_NUMBER = importlib.util.MAGIC_NUMBER
-        SOURCE_SUFFIXES = importlib.machinery.SOURCE_SUFFIXES
-        BYTECODE_SUFFIXES = importlib.machinery.BYTECODE_SUFFIXES
-
-    except Exception:
-        raise ImportError()
-
-except ImportError:
-    import imp
-
-    PY_MAGIC_NUMBER = imp.get_magic()
-    SOURCE_SUFFIXES = [s[0] for s in imp.get_suffixes()
-                       if s[2] == imp.PY_SOURCE]
-    BYTECODE_SUFFIXES = [s[0] for s in imp.get_suffixes()
-                         if s[2] == imp.PY_COMPILED]
-
-PY_SUFFIXES = SOURCE_SUFFIXES + BYTECODE_SUFFIXES
-
-try:
-    from errno import ENOENT
-except ImportError:
-    ENOENT = -1
+from errno import ENOENT
+from importlib.machinery import SOURCE_SUFFIXES, BYTECODE_SUFFIXES
+from importlib.util import MAGIC_NUMBER as PY_MAGIC_NUMBER
 
 from pysnmp import version as pysnmp_version
 from pysnmp.smi import error
 from pysnmp import debug
+
+PY_SUFFIXES = SOURCE_SUFFIXES + BYTECODE_SUFFIXES
 
 classTypes = (type,)
 


### PR DESCRIPTION
These standard library imports are now guaranteed to be valid.

- [`importlib.machinery.SOURCE_SUFFIXES`](https://docs.python.org/3.8/library/importlib.html#importlib.machinery.SOURCE_SUFFIXES) (Python 3.3)
- [`importlib.machinery.BYTECODE_SUFFIXES`](https://docs.python.org/3.8/library/importlib.html#importlib.machinery.BYTECODE_SUFFIXES) (Python 3.3)
- [`importlib.util.MAGIC_NUMBER`](https://docs.python.org/3.8/library/importlib.html#importlib.util.MAGIC_NUMBER) (Python 3.4)
- [`errno.ENOENT`](https://docs.python.org/3.8/library/errno.html#errno.ENOENT) (since forever)
- `hashlib.md5`, `hashlib.sha1` ([Python 2.5](https://docs.python.org/3.8/whatsnew/2.5.html?highlight=sha384#the-hashlib-package))