### PR TITLE
Add Support for Python 3.14 CI checks

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,10 @@ def snmpsim_endpoint(tmp_path_factory):
             [
                 sys.executable,
                 str(simulator),
+                # Keep the data directory scoped to this engine. Without an
+                # explicit engine ID, snmpsim also scans its bundled sample
+                # data, whose cold-cache indexing can exceed the CI timeout.
+                "--v3-engine-id=auto",
                 "--data-dir={}".format(data_dir),
                 "--cache-dir={}".format(work_dir / "cache"),
                 "--v3-user=00000",

--- a/tests/test_auth_priv_matrix.py
+++ b/tests/test_auth_priv_matrix.py
@@ -88,6 +88,10 @@ def _start_snmpsim(tmp_path, auth_proto, priv_proto, auth_key, priv_key):
     cmd = [
         sys.executable,
         str(simulator),
+        # Keep the data directory scoped to this engine. Without an explicit
+        # engine ID, snmpsim also scans its bundled sample data, whose
+        # cold-cache indexing can exceed the CI timeout.
+        "--v3-engine-id=auto",
         "--data-dir={}".format(data_dir),
         "--cache-dir={}".format(work_dir / "cache"),
         "--v3-user=testuser",


### PR DESCRIPTION
Move from deprecated pysnmp.carrier.asynsock