### PR TITLE
chore: add Python 3.14 trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Communications",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
CI already runs unit-tests on 3.14 (`unit-tests (3.14)` passes on PR #108), but `pyproject.toml` did not advertise it. Adds the missing `Programming Language :: Python :: 3.14` classifier so PyPI metadata matches the tested matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Python 3.14 to the project’s supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->