### PR TITLE
chore: add Python 3.14 trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Communications",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
Adds `Programming Language :: Python :: 3.14` to the classifier list in `pyproject.toml`.

CI already runs the unit-test matrix on 3.14; this only syncs package metadata. No change to `requires-python`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Python 3.14 to the list of supported package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->