### PR TITLE
chore(ci): remove trufflehog secret-scan job

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -21,20 +21,6 @@ jobs:
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.6.3/scripts/download-actionlint.bash)
       - uses: pre-commit/action@v3.0.1
 
-  review_secrets:
-    name: security-detect-secrets
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: false
-          fetch-depth: "0"
-      - name: Trufflehog Actions Scan
-        uses: edplato/trufflehog-actions-scan@v0.9j-beta
-        with:
-          scanArguments: "--max_depth 30 -x .github/workflows/exclude-patterns.txt"
-
   semgrep:
     runs-on: ubuntu-latest
     name: security-sast-semgrep
@@ -56,7 +42,6 @@ jobs:
     environment: release    
     needs:
       #- pre-commit
-      #- review_secrets
       - semgrep
       #- run-unit-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/exclude-patterns.txt
+++ b/.github/workflows/exclude-patterns.txt
@@ -1,5 +1,0 @@
-.github/workflows/
-deps/.*
-.*\.lock
-tests/
-examples/


### PR DESCRIPTION
Drops the `security-detect-secrets` (trufflehog) CI job — secret scanning is handled by another tool. Also removes the now-unused `exclude-patterns.txt` and the commented `review_secrets` entry in `publish.needs`.