### PR TITLE
feat!: 6.0 API removals and Python 3.10 baseline

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -17,6 +17,8 @@
   branches: [
     "+([0-9])?(.{+([0-9]),x}).x",
     "main",
+    { name: "next", prerelease: "next", channel: "next"
+    },
     { name: "develop", prerelease: "beta", channel: "beta"
     },
   ],

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -56,6 +56,7 @@ Documentation
 
    /docs/tutorial
    /docs/api-reference
+   /docs/breaking-changes
    /docs/security-considerations
    /docs/smi-table-api
    /docs/device-report

--- a/docs/source/docs/breaking-changes.rst
+++ b/docs/source/docs/breaking-changes.rst
@@ -1,0 +1,87 @@
+
+.. _breaking-changes:
+
+Breaking Changes
+================
+
+This release is not backwards compatible with the 5.0 series. The changes
+below require source modifications in applications that used the removed
+interfaces. See :doc:`/changelog` for the complete list of changes.
+
+Python 3.10 is the minimum supported version
+--------------------------------------------
+
+Support for Python 3.9 and earlier has been dropped, along with the
+Python 2-era compatibility fallbacks that surrounded it (``imp``, the
+``md5``/``sha`` modules, ``socket.inet_ntop`` shims and the Python 2.6
+compatibility directory).
+
+``asyncore`` and ``asynsock`` have been removed
+-----------------------------------------------
+
+The ``asyncore`` module was removed from the standard library in Python
+3.12. Every carrier and high-level API built on it has been deleted
+rather than deprecated:
+
+* ``pysnmp.carrier.asyncore`` and ``pysnmp.carrier.asynsock``
+* ``pysnmp.hlapi.asyncore``
+* the 61 ``asyncore`` example scripts and their documentation
+
+Applications must use the ``asyncio`` carriers and
+``pysnmp.hlapi.asyncio`` instead. The synchronous ``pysnmp.hlapi``
+one-liner interface remains available and now runs on ``asyncio``
+internally.
+
+``pyasn1.compat.octets`` is no longer used
+-------------------------------------------
+
+All uses of the ``pyasn1.compat.octets`` shim were replaced with native
+Python 3 equivalents across the codebase. Code that imported
+``str2octs``, ``octs2str`` or their siblings from PySNMP modules should
+encode and decode with Latin-1 directly.
+
+``pycryptodomex`` is now an optional dependency
+------------------------------------------------
+
+``Cryptodome.Cipher`` imports are resolved lazily. PySNMP imports and
+serves SNMPv1, SNMPv2c and the SNMPv3 noAuthNoPriv and authNoPriv
+security levels without ``pycryptodomex`` installed. Configuring a
+privacy protocol without it now raises ``PySnmpError`` naming the
+missing package at configuration time, rather than failing later during
+packet processing.
+
+Deployments that use SNMPv3 privacy must install the extra explicitly.
+
+Weak-crypto warnings are emitted at configuration time
+-------------------------------------------------------
+
+``addV3User`` now emits ``PySnmpWeakCryptoWarning`` for DES, 3DES and
+HMAC-MD5, and ``PySnmpNonStandardCryptoWarning`` for the
+Reeder/Blumenthal AES-192/256 variants. Applications that run with
+warnings configured as errors will need to filter these explicitly. See
+:doc:`/docs/security-considerations` for the recommended configuration.
+
+``pysmi`` API calls use snake_case
+------------------------------------
+
+PySNMP now calls the snake_case ``pysmi`` API and the ``pysmi``
+dependency pin was widened to allow 2.x. Applications that pass custom
+``pysmi`` objects into the MIB compiler must target the same API.
+
+Corrected behaviour that may change results
+--------------------------------------------
+
+These are bug fixes, but they change observable behaviour for callers
+that depended on the broken semantics:
+
+* ``CommunityData.clone()`` and ``UsmUserData.clone()`` no longer discard
+  falsy non-``None`` arguments such as ``mpModel=0``, ``contextName=''``,
+  ``authKey=b''`` and ``authKeyType=0``.
+* ``ObjectIdentity.__ge__`` and ``__le__`` no longer delegate to ``>``
+  and ``<``.
+* VACM candidate selection was corrected for matching and ``any``
+  security models, permitted security levels, exact contexts and longest
+  prefixes.
+* SNMP value conversion always clones proxied values into the
+  destination ASN.1 type.
+* ``ObjectIdentity.__nonzero__`` was removed.


### PR DESCRIPTION
## Why

None of the 119 commits on `next` carry a `BREAKING CHANGE:` footer or a `!` type suffix. The asyncore removal only says `Breaking change:` in a body line, which the angular preset does not parse as a note. As it stands, cutting a release from `next` would produce a **minor**, not a major — despite `next` having removed the entire `asyncore`/`asynsock` surface, dropped Python 3.9, and made `pycryptodomex` optional.

## What

**No runtime code changes.** Three files:

- `docs/source/docs/breaking-changes.rst` (new) — migration page enumerating the removed interfaces, sourced from the existing `CHANGELOG.md` entries. Gives the marker commit real content so it survives a squash-merge, and makes the migration path discoverable outside the changelog.
- `docs/source/contents.rst` — register the page in the Documentation toctree.
- `.releaserc` — add `next` as a prerelease branch on the `next` channel, alongside the existing `develop`/`beta` entry.

The commit message carries the `BREAKING CHANGE:` footer that forces the major bump.

## Verification

`@semantic-release/commit-analyzer` run against this commit message returns:

```
RELEASE TYPE: major
```

Sphinx builds clean under the CI flags:

```
sphinx-build -W -b html docs/source docs/build/html
build succeeded.
```

## Consequence of merging

Merging this to `next` makes `next` a release branch. The next push to `next` will run semantic-release and publish **`6.0.0-next.1`** to PyPI on the `next` dist-tag, plus a GitHub prerelease. Current version is 5.0.24.

If that publish should not happen yet, hold this PR — or drop the `.releaserc` hunk and merge only the docs + footer, which keeps the major bump queued for the eventual `next` → `main` merge without publishing a prerelease.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a dedicated breaking-changes guide to the documentation.
  - Documented the minimum supported Python version, removed interfaces and examples, updated API naming, optional cryptography handling, security warnings, and behavior changes.

- **Release Management**
  - Added support for publishing prereleases through the `next` release channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->