### PR TITLE
fix(release): repair version replacement and prerelease version parsing

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -32,8 +32,8 @@
             "files": [
               "pysnmp/__init__.py"
             ],
-            "from": "__version__ ?= '.*'",
-            "to": "__version__ = '${nextRelease.version}'",
+            "from": "^__version__ ?=.*",
+            "to": "__version__ = \"${nextRelease.version}\"",
             "results": [
               {
                 "file": "pysnmp/__init__.py",
@@ -48,7 +48,7 @@
             "files": [
               "pyproject.toml"
             ],
-            "from": "version ?=.*",
+            "from": "^version ?=.*",
             "to": "version = \"${nextRelease.version}\"",
             "results": [
               {

--- a/pysnmp/__init__.py
+++ b/pysnmp/__init__.py
@@ -3,8 +3,8 @@ __version__ = "5.0.24"
 # another variable is required to prevent semantic release from updating version in more than one place
 main_version = __version__
 # backward compatibility
-# for beta versions, integer casting throws an exception, so string part must be cut off
-if "beta" in __version__:
-    main_version = __version__.split("-beta")[0]
+# for pre-release versions, integer casting throws an exception, so the
+# pre-release and build metadata parts must be cut off
+main_version = __version__.split("-")[0].split("+")[0]
 version = tuple(int(x) for x in main_version.split("."))
 majorVersionId = version[0]


### PR DESCRIPTION
Fixes the `Build Release` failure on `next` ([run 33400323763](https://github.com/pysnmp/pysnmp/actions/runs/33400323763)).

Semantic-release correctly resolved `6.0.0-next.1`, then died in `prepare`:

```
Failed step "prepare" of plugin "semantic-release-replace-plugin"
Error: Expected match not found!
  "file": "pysnmp/__init__.py",
- "hasChanged": false,  "numMatches": 0,  "numReplacements": 0,
+ "hasChanged": true,   "numMatches": 1,  "numReplacements": 1,
```

No tag, GitHub release, or PyPI upload was produced — it failed before `publish`.

## Two defects

**1. `.releaserc` replacement regexes.** The plugin compiles `from` via `new RegExp(from, "gm")`, so these are real regexes matched per line.

| file | old `from` | matches | why |
|---|---|---|---|
| `pysnmp/__init__.py` | `__version__ ?= '.*'` | **0** | ruff format (#118) normalized `'5.0.24'` → `"5.0.24"`; the pattern hardcodes single quotes |
| `pyproject.toml` | `version ?=.*` | **3** | unanchored — also hits `target-version = "py310"` and `python_version = "3.10"` |

Both are declared as `numMatches: 1`, so each throws. Anchoring with `^` gives exactly 1 match in each file. The `__init__.py` replacement now emits double quotes so the release commit stays ruff-format clean.

**2. `pysnmp/__init__.py` prerelease parsing — would have shipped an unimportable package.**

```python
if "beta" in __version__:
    main_version = __version__.split("-beta")[0]
version = tuple(int(x) for x in main_version.split("."))
```

Only `-beta` was stripped. On the new `next` channel `__version__` becomes `6.0.0-next.1`, so `main_version.split(".")` yields `["6", "0", "0-next", "1"]` and `int("0-next")` raises `ValueError` **at import time**. Now cut at the first `-` or `+`, which covers every prerelease and build-metadata form.

## Verification

Ran the actual `semantic-release-replace-plugin` `prepare()` against copies of the real files with `nextRelease.version = "6.0.0-next.1"`:

```
PREPARE OK
  pysnmp/__init__.py -> __version__ = "6.0.0-next.1"
  pyproject.toml     -> version = "6.0.0-next.1"
```

Version tuple parsing across shapes:

```
5.0.24        -> (5, 0, 24)     6.0.0-next.1  -> (6, 0, 0)
5.0.24-beta.1 -> (5, 0, 24)     7.1.2-rc.3    -> (7, 1, 2)
6.0.0         -> (6, 0, 0)      6.0.0+build.5 -> (6, 0, 0)
```

`857 passed, 12 skipped, 2 xfailed, 5 xpassed` — unchanged from baseline. pre-commit clean.

Typed `fix:` so it does not stack a second major; the `feat!:` from #119 already records the major bump. Merging this re-runs the release on `next` and should publish `6.0.0-next.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved version parsing for pre-release and build metadata, ensuring the base version is reported consistently across release types.
  - Fixed release version updates to work reliably with different spacing and quote styles in project version declarations.

- **Maintenance**
  - Improved release automation reliability without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->