### PR TITLE
fix(release): use PEP 440-compatible rc prerelease identifier

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -17,7 +17,7 @@
   branches: [
     "+([0-9])?(.{+([0-9]),x}).x",
     "main",
-    { name: "next", prerelease: "next", channel: "next"
+    { name: "next", prerelease: "rc", channel: "next"
     },
     { name: "develop", prerelease: "beta", channel: "beta"
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pysnmplib"
-version = "6.0.0-next.1"
+version = "6.0.0-rc.1"
 description = "Pure-Python SNMP v1/v2c/v3 engine"
 authors = [
     { name = "omrozowicz", email = "omrozowicz@splunk.com" },

--- a/pysnmp/__init__.py
+++ b/pysnmp/__init__.py
@@ -1,5 +1,5 @@
 # http://www.python.org/dev/peps/pep-0396/
-__version__ = "6.0.0-next.1"
+__version__ = "6.0.0-rc.1"
 # another variable is required to prevent semantic release from updating version in more than one place
 main_version = __version__
 # backward compatibility


### PR DESCRIPTION
`prerelease: "next"` produced `6.0.0-next.1`, which is not a valid PEP 440 version. Hatchling rejects it, so `pip install -e .` fails and Tests / Coverage / Net-SNMP Integration all break on `next`.

- `.releaserc`: next branch prerelease id `next` -> `rc` (channel stays `next`)
- Repaired the committed version in `pyproject.toml` and `pysnmp/__init__.py` to `6.0.0-rc.1`

`6.0.0-rc.1` normalizes to `6.0.0rc1` under PEP 440 and the existing `split("-")` in `pysnmp/__init__.py` still yields `(6, 0, 0)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the upcoming release designation from `next` to release candidate (`rc`).
  * Version updated to `6.0.0-rc.1`.
  * The existing `next` release channel remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->