### PR TITLE
fix(release): use dev placeholder version so replace plugin always applies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pysnmplib"
-version = "6.0.0-rc.1"
+version = "6.0.0-dev.0"
 description = "Pure-Python SNMP v1/v2c/v3 engine"
 authors = [
     { name = "omrozowicz", email = "omrozowicz@splunk.com" },

--- a/pysnmp/__init__.py
+++ b/pysnmp/__init__.py
@@ -1,5 +1,5 @@
 # http://www.python.org/dev/peps/pep-0396/
-__version__ = "6.0.0-rc.1"
+__version__ = "6.0.0-dev.0"
 # another variable is required to prevent semantic release from updating version in more than one place
 main_version = __version__
 # backward compatibility


### PR DESCRIPTION
Follow-up to #121.

The committed version was set to `6.0.0-rc.1` — exactly what semantic-release computes as the next version on `next`.
`semantic-release-replace-plugin` then found the file already correct: `numMatches: 1` but `numReplacements: 0`,
which violates the `results` assertion in `.releaserc` and aborts the release.

Committed version is now `6.0.0-dev.0` (PEP 440 `6.0.0.dev0`), which can never collide with a computed release
version, so the replacement always applies.

Verified locally: `pip install -e .` succeeds, `pysnmp.version == (6, 0, 0)`, and both regexes yield 1 match /
1 replacement against `6.0.0-rc.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to `6.0.0-dev.0`.
  * Synchronized the displayed version across project metadata and runtime information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->