### PR TITLE
chore(deps): use pysnmp-pyasn1 1.2.0b14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 dependencies = [
     "pysnmp-pysmi >=1.0.4,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
-    "pysnmp-pyasn1 >=1.2.0b9,<2.0.0",
+    "pysnmp-pyasn1 >=1.2.0b12,<2.0.0",
 ]
 
 [project.urls]
@@ -57,9 +57,6 @@ show_missing = true
 
 [tool.coverage.xml]
 output = "coverage.xml"
-
-[tool.uv.sources]
-pysnmp-pyasn1 = { git = "https://github.com/pysnmp/pyasn1", tag = "v1.2.0-beta.9" }
 
 [build-system]
 requires = ["hatchling>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 dependencies = [
     "pysnmp-pysmi >=1.0.4,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
-    "pysnmp-pyasn1 >=1.2.0b12,<2.0.0",
+    "pysnmp-pyasn1 >=1.2.0b14,<2.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 dependencies = [
     "pysnmp-pysmi >=1.0.4,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
-    "pysnmp-pyasn1 >=1.1.3,<2.0.0",
+    "pysnmp-pyasn1 >=1.2.0b9,<2.0.0",
 ]
 
 [project.urls]
@@ -57,6 +57,9 @@ show_missing = true
 
 [tool.coverage.xml]
 output = "coverage.xml"
+
+[tool.uv.sources]
+pysnmp-pyasn1 = { git = "https://github.com/pysnmp/pyasn1", tag = "v1.2.0-beta.9" }
 
 [build-system]
 requires = ["hatchling>=1.0.0"]

--- a/pysnmp/entity/rfc3413/cmdrsp.py
+++ b/pysnmp/entity/rfc3413/cmdrsp.py
@@ -270,7 +270,7 @@ class CommandResponderBase:
             execCtx["securityName"],
             execCtx["securityLevel"],
             execCtx["contextName"],
-            execCtx["pdu"].getTagSet(),
+            execCtx["pdu"].tagSet,
         )
         try:
             snmpEngine.accessControlModel[self.acmID].isAccessAllowed(
@@ -314,7 +314,7 @@ class CommandResponderBase:
             if (
                 securityModel == 1
                 and syntax is not None
-                and self._counter64Type == syntax.getTagSet()
+                and self._counter64Type == syntax.tagSet
                 and self._getNextRequestType == pduType
             ):
                 # This will cause MibTree to skip this OID-value

--- a/pysnmp/error.py
+++ b/pysnmp/error.py
@@ -37,4 +37,4 @@ class PySnmpError(Exception):
         if msg:
             args = (msg,) + args[1:]
 
-        Exception.__init__(self, *args)
+        super().__init__(*args)

--- a/pysnmp/proto/api/v1.py
+++ b/pysnmp/proto/api/v1.py
@@ -40,7 +40,7 @@ class VarBindAPI:
         if val is None:
             val = null
         varBind.setComponentByPosition(1).getComponentByPosition(1).setComponentByType(
-            val.getTagSet(),
+            val.tagSet,
             val,
             verifyConstraints=False,
             matchTags=False,
@@ -300,7 +300,7 @@ class MessageAPI:
     @staticmethod
     def setPDU(msg, value):
         msg.setComponentByPosition(2).getComponentByPosition(2).setComponentByType(
-            value.getTagSet(),
+            value.tagSet,
             value,
             verifyConstraints=False,
             matchTags=False,

--- a/pysnmp/proto/rfc1155.py
+++ b/pysnmp/proto/rfc1155.py
@@ -52,7 +52,7 @@ class NetworkAddress(univ.Choice):
         and itself as the component value.
 
         :param value: (Optional) the component value.
-        :type value: :py:obj:`pyasn1.type.base.Asn1ItemBase`
+        :type value: :py:obj:`pyasn1.type.base.Asn1Type`
         :return: the cloned instance.
         :rtype: :py:obj:`pysnmp.proto.rfc1155.NetworkAddress`
         :raise: :py:obj:`pysnmp.smi.error.SmiError`:
@@ -131,7 +131,7 @@ class TypeCoercionHackMixIn:  # XXX keep this old-style class till pyasn1 types 
             if idx >= len(componentType):
                 raise PyAsn1Error("Component type error out of range")
             t = componentType[idx].getType()
-            if not t.getTagSet().isSuperTagSetOf(value.getTagSet()):
+            if not t.tagSet.isSuperTagSetOf(value.tagSet):
                 raise PyAsn1Error(f"Component type error {t!r} vs {value!r}")
 
 

--- a/pysnmp/proto/rfc1902.py
+++ b/pysnmp/proto/rfc1902.py
@@ -645,7 +645,7 @@ class Bits(OctetString):
             return OctetString.prettyIn(self, bits)  # raw bitstring
         octets = []
         for bit in bits:  # tuple of named bits
-            v = self.namedValues.getValue(bit)
+            v = self.namedValues[bit]
             if v is None:
                 raise error.ProtocolError("Unknown named bit %s" % bit)
             d, m = divmod(v, 8)
@@ -662,7 +662,7 @@ class Bits(OctetString):
             j = 7
             while j >= 0:
                 if v & (0x01 << j):
-                    name = self.namedValues.getName(i * 8 + 7 - j)
+                    name = self.namedValues[i * 8 + 7 - j]
                     if name is None:
                         name = f"UnknownBit-{i * 8 + 7 - j}"
                     names.append(name)

--- a/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
@@ -153,11 +153,11 @@ class InetAddress(TextualConvention, OctetString):
     subtypeSpec = OctetString.subtypeSpec + ValueSizeConstraint(0, 255)
 
     typeMap = {
-        InetAddressType.namedValues.getValue("ipv4"): InetAddressIPv4(),
-        InetAddressType.namedValues.getValue("ipv6"): InetAddressIPv6(),
-        InetAddressType.namedValues.getValue("ipv4z"): InetAddressIPv4z(),
-        InetAddressType.namedValues.getValue("ipv6z"): InetAddressIPv6z(),
-        InetAddressType.namedValues.getValue("dns"): InetAddressDNS(),
+        InetAddressType.namedValues["ipv4"]: InetAddressIPv4(),
+        InetAddressType.namedValues["ipv6"]: InetAddressIPv6(),
+        InetAddressType.namedValues["ipv4z"]: InetAddressIPv4z(),
+        InetAddressType.namedValues["ipv6z"]: InetAddressIPv6z(),
+        InetAddressType.namedValues["dns"]: InetAddressDNS(),
     }
 
     @classmethod

--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -1100,11 +1100,11 @@ class MibTableRow(MibTree):
     # some subtypes may be implicitly tagged what renders base tag
     # unavailable.
 
-    __intBaseTag = Integer.tagSet.getBaseTag()
-    __strBaseTag = OctetString.tagSet.getBaseTag()
-    __oidBaseTag = ObjectIdentifier.tagSet.getBaseTag()
+    __intBaseTag = Integer.tagSet.baseTag
+    __strBaseTag = OctetString.tagSet.baseTag
+    __oidBaseTag = ObjectIdentifier.tagSet.baseTag
     __ipaddrTagSet = IpAddress.tagSet
-    __bitsBaseTag = Bits.tagSet.getBaseTag()
+    __bitsBaseTag = Bits.tagSet.baseTag
 
     def setFromName(self, obj, value, impliedFlag=None, parentIndices=None):
         if not value:
@@ -1113,10 +1113,10 @@ class MibTableRow(MibTree):
             return obj.cloneFromName(
                 value, impliedFlag, parentRow=self, parentIndices=parentIndices
             )
-        baseTag = obj.getTagSet().getBaseTag()
+        baseTag = obj.tagSet.baseTag
         if baseTag == self.__intBaseTag:
             return obj.clone(value[0]), value[1:]
-        elif self.__ipaddrTagSet.isSuperTagSetOf(obj.getTagSet()):
+        elif self.__ipaddrTagSet.isSuperTagSetOf(obj.tagSet):
             return obj.clone(".".join([str(x) for x in value[:4]])), value[4:]
         elif baseTag == self.__strBaseTag:
             # rfc1902, 7.7
@@ -1141,11 +1141,11 @@ class MibTableRow(MibTree):
     def getAsName(self, obj, impliedFlag=None, parentIndices=None):
         if hasattr(obj, "cloneAsName"):
             return obj.cloneAsName(impliedFlag, parentRow=self, parentIndices=parentIndices)
-        baseTag = obj.getTagSet().getBaseTag()
+        baseTag = obj.tagSet.baseTag
         if baseTag == self.__intBaseTag:
             # noinspection PyRedundantParentheses
             return (int(obj),)
-        elif self.__ipaddrTagSet.isSuperTagSetOf(obj.getTagSet()):
+        elif self.__ipaddrTagSet.isSuperTagSetOf(obj.tagSet):
             return obj.asNumbers()
         elif baseTag == self.__strBaseTag:
             if impliedFlag or obj.isFixedLength():
@@ -1306,7 +1306,7 @@ class MibTableRow(MibTree):
                 if mibNode.isOptional():
                     continue
                 colNode = mibNode.getNode(mibNode.name + name[len(self.name) + 1 :])
-                if not colNode.syntax.hasValue():
+                if not colNode.syntax.isValue:
                     raise error.InconsistentValueError(
                         msg="Row consistency check failed for %r" % colNode
                     )

--- a/pysnmp/smi/mibs/SNMPv2-TC.py
+++ b/pysnmp/smi/mibs/SNMPv2-TC.py
@@ -76,7 +76,7 @@ class TextualConvention:
         """Implements DISPLAY-HINT evaluation"""
         if self.displayHint and (
             self.__integer.isSuperTypeOf(self, matchConstraints=False)
-            and not self.getNamedValues()
+            and not self.namedValues
             or self.__unsigned32.isSuperTypeOf(self, matchConstraints=False)
             or self.__timeticks.isSuperTypeOf(self, matchConstraints=False)
         ):
@@ -219,7 +219,7 @@ class TextualConvention:
 
         if self.displayHint and (
             self.__integer.isSuperTypeOf(self, matchConstraints=False)
-            and self.getNamedValues()
+            and self.namedValues
             or self.__unsigned32.isSuperTypeOf(self, matchConstraints=False)
             or self.__timeticks.isSuperTypeOf(self, matchConstraints=False)
         ):
@@ -515,8 +515,8 @@ class RowStatus(TextualConvention, Integer):
         # resolve new instance value
         excValue, newState = self.stateMatrix.get(
             (
-                value.hasValue() and value or self.stNotExists,
-                self.hasValue() and self or self.stNotExists,
+                value.isValue and value or self.stNotExists,
+                self.isValue and self or self.stNotExists,
             ),
             (MibOperationError, None),
         )

--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -7,7 +7,7 @@
 import functools
 
 from pyasn1.error import PyAsn1Error
-from pyasn1.type.base import AbstractSimpleAsn1Item
+from pyasn1.type.base import SimpleAsn1Type
 
 from pysnmp import debug
 from pysnmp.proto import rfc1902, rfc1905
@@ -860,7 +860,7 @@ class ObjectType:
         mibNode = self.__args[0].getMibNode()
 
         if not isinstance(mibNode, (MibScalar, MibTableColumn)):
-            if ignoreErrors and not isinstance(self.__args[1], AbstractSimpleAsn1Item):
+            if ignoreErrors and not isinstance(self.__args[1], SimpleAsn1Type):
                 raise SmiError(
                     f"MIB object {self.__args[0]!r} is not OBJECT-TYPE (MIB not loaded?)"
                 )
@@ -893,7 +893,7 @@ class ObjectType:
                 e,
             )
 
-            if not ignoreErrors or not isinstance(self.__args[1], AbstractSimpleAsn1Item):
+            if not ignoreErrors or not isinstance(self.__args[1], SimpleAsn1Type):
                 raise SmiError(err)
 
         if rfc1902.ObjectIdentifier().isSuperTypeOf(self.__args[1], matchConstraints=False):

--- a/tests/test_smi.py
+++ b/tests/test_smi.py
@@ -649,7 +649,7 @@ class TestOptionalTableColumns:
         row.writeCommit(rowStatus.name + suffix, 1, 0, (None, None))
 
         optionalInstance = optionalValue.getNode(optionalValue.name + suffix)
-        assert not optionalInstance.syntax.hasValue()
+        assert not optionalInstance.syntax.isValue
 
     def test_mandatory_unset_column_rejects_row_activation(self):
         row, _, rowStatus, suffix = _build_optional_row(False)

--- a/uv.lock
+++ b/uv.lock
@@ -789,12 +789,8 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pyasn1"
-version = "1.1.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/76bf79245c0954633ebefe6fb29ed85d80bffe9104b0619d1d0cd935e01c/pysnmp-pyasn1-1.1.3.tar.gz", hash = "sha256:fc559133ec6717e9d96dd4bd69c981310b23364dc2280a9b5f40f684fb6b4b8a", size = 126546, upload-time = "2023-02-21T15:44:13.659Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/13/70b61502dad89369a3e5fe5edd77f166bf5642e50db69245828ee671188e/pysnmp_pyasn1-1.1.3-py3-none-any.whl", hash = "sha256:d9a471b058adb9f2c3ce3aa85f800f2beef1a86c03b08d182a5653c9880fbd5e", size = 77568, upload-time = "2023-02-21T15:44:15.167Z" },
-]
+version = "1.2.0b9"
+source = { git = "https://github.com/pysnmp/pyasn1?tag=v1.2.0-beta.9#144d7a241cfc23e3a829746e4e74ee84363031b8" }
 
 [[package]]
 name = "pysnmp-pysmi"
@@ -811,7 +807,7 @@ wheels = [
 
 [[package]]
 name = "pysnmplib"
-version = "5.0.24"
+version = "6.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "pycryptodomex" },
@@ -836,7 +832,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.2.0,<8.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0,<2.0.0" },
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
-    { name = "pysnmp-pyasn1", specifier = ">=1.1.3,<2.0.0" },
+    { name = "pysnmp-pyasn1", git = "https://github.com/pysnmp/pyasn1?tag=v1.2.0-beta.9" },
     { name = "pysnmp-pysmi", specifier = ">=1.0.4,<3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=6.2.5,<9.0.0" },
     { name = "pytest-codecov", marker = "extra == 'dev'", specifier = ">=0.4.0,<1.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -789,8 +789,12 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pyasn1"
-version = "1.2.0b9"
-source = { git = "https://github.com/pysnmp/pyasn1?tag=v1.2.0-beta.9#144d7a241cfc23e3a829746e4e74ee84363031b8" }
+version = "1.2.0b12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/be/eb44e91097e1cffbef9da2ca5f1d2e309d25603e83a58e0afe12e89cc5f7/pysnmp_pyasn1-1.2.0b12.tar.gz", hash = "sha256:3e35eb6fb5d85524e635eda542c8bdc1e92d180d662d70332981e577f65cae17", size = 272847, upload-time = "2026-09-02T14:51:50.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/01/4e90f30cc9688a6c1aa688be4641fb77c43fb8f79b5fa98928943b9bc7f4/pysnmp_pyasn1-1.2.0b12-py3-none-any.whl", hash = "sha256:fada836418e929078d38c5f76da8da58be98058259bb2688a96ba4bb31c61bcf", size = 96476, upload-time = "2026-09-02T14:51:48.789Z" },
+]
 
 [[package]]
 name = "pysnmp-pysmi"
@@ -832,7 +836,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.2.0,<8.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0,<2.0.0" },
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
-    { name = "pysnmp-pyasn1", git = "https://github.com/pysnmp/pyasn1?tag=v1.2.0-beta.9" },
+    { name = "pysnmp-pyasn1", specifier = ">=1.2.0b12,<2.0.0" },
     { name = "pysnmp-pysmi", specifier = ">=1.0.4,<3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=6.2.5,<9.0.0" },
     { name = "pytest-codecov", marker = "extra == 'dev'", specifier = ">=0.4.0,<1.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -789,11 +789,11 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pyasn1"
-version = "1.2.0b12"
+version = "1.2.0b14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/be/eb44e91097e1cffbef9da2ca5f1d2e309d25603e83a58e0afe12e89cc5f7/pysnmp_pyasn1-1.2.0b12.tar.gz", hash = "sha256:3e35eb6fb5d85524e635eda542c8bdc1e92d180d662d70332981e577f65cae17", size = 272847, upload-time = "2026-09-02T14:51:50.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/a3/39d3024262c4a48bc7cb52b637da897cd9a3a03c34f1aa10e213a59945a3/pysnmp_pyasn1-1.2.0b14.tar.gz", hash = "sha256:dece37e12d30021027ca2c2683ba50339aae46a1c7be5a3c57efcd969e39009e", size = 285030, upload-time = "2026-09-02T16:16:28.877Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/01/4e90f30cc9688a6c1aa688be4641fb77c43fb8f79b5fa98928943b9bc7f4/pysnmp_pyasn1-1.2.0b12-py3-none-any.whl", hash = "sha256:fada836418e929078d38c5f76da8da58be98058259bb2688a96ba4bb31c61bcf", size = 96476, upload-time = "2026-09-02T14:51:48.789Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1b/95f92221d33355997e3a95681728204846ae3c0f81363d2f6c5019c7a262/pysnmp_pyasn1-1.2.0b14-py3-none-any.whl", hash = "sha256:417df3132f30a58795ba33c16475b9a753e0e816863880bfe7577ed01f9abead", size = 102236, upload-time = "2026-09-02T16:16:27.67Z" },
 ]
 
 [[package]]
@@ -836,7 +836,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.2.0,<8.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0,<2.0.0" },
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
-    { name = "pysnmp-pyasn1", specifier = ">=1.2.0b12,<2.0.0" },
+    { name = "pysnmp-pyasn1", specifier = ">=1.2.0b14,<2.0.0" },
     { name = "pysnmp-pysmi", specifier = ">=1.0.4,<3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=6.2.5,<9.0.0" },
     { name = "pytest-codecov", marker = "extra == 'dev'", specifier = ">=0.4.0,<1.0.0" },


### PR DESCRIPTION
## What

Moves the `pysnmp-pyasn1` dependency to the latest beta, `1.2.0b12` (on PyPI), and updates pysnmp to the API that beta ships.

## Why the code changes

The 1.2.0 line removes the long-deprecated pyasn1 accessor methods and the pre-`SimpleAsn1Type` class aliases. Without these
changes the test suite does not even collect — `pysnmp/smi/rfc1902.py` fails at import.

| Removed | Replacement |
| --- | --- |
| `AbstractSimpleAsn1Item` | `SimpleAsn1Type` |
| `.getTagSet()` | `.tagSet` |
| `.getBaseTag()` | `.baseTag` |
| `.hasValue()` | `.isValue` |
| `.getNamedValues()` | `.namedValues` |
| `NamedValues.getValue(name)` / `.getName(num)` | `NamedValues[key]` (bidirectional) |

Separately, `PySnmpError.__init__` called `Exception.__init__` directly. `ProtocolError` and `SmiError` are
`(PySnmpError, PyAsn1Error)` mixins, so that skipped `PyAsn1Error.__init__` and left `self.context` unset — and 1.2.0's
`PyAsn1Error.__str__` reads it, making every `str(err)` raise `AttributeError`. Now delegates through `super()`.

## Tests

`uv run pytest tests/` → **857 passed, 12 skipped, 2 xfailed, 5 xpassed** — identical counts to `next` on 1.1.3.
`uv run ruff check pysnmp/` → clean.

## Follow-up, not in this PR

Warnings go 50 → 211. All of them are the beta's new `DeprecationWarning` on `str()` for `OctetString` subclasses
(`DisplayString` 17, `OctetString` 7, `SnmpAdminString` 1, `Null` 1) — a future release returns hex instead of
iso-8859-1 text. Worth a dedicated pass over the call sites and tests before 1.2.0 goes stable.

## Note

`1.2.0b12` is a pre-release. `uv` resolves it because the lower bound is itself a pre-release, but downstreams using
plain `pip install pysnmplib` need `--pre` to get it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with current PyASN1 APIs across ASN.1 handling, protocol validation, named values, tags, and MIB processing.
  - Preserved existing behavior for unknown or invalid values.
  - Corrected exception initialization for more consistent error handling.

- **Dependency Updates**
  - Raised the minimum supported `pysnmp-pyasn1` version to 1.2.0b14 while retaining compatibility with versions below 2.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->