### PR TITLE
refactor: stop tripping pyasn1's OCTET STRING str() deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ dev = [
     "ruff >=0.4.0,<1.0.0",
 ]
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    # str() on an OCTET STRING decodes it as text; pyasn1 deprecates that and
+    # will return the hexadecimal representation instead. Keep pysnmp off it.
+    "error:str\\(\\) on .* decodes the payload as text:DeprecationWarning",
+]
+
 [tool.coverage.run]
 branch = true
 source = ["pysnmp"]

--- a/pysnmp/debug.py
+++ b/pysnmp/debug.py
@@ -115,6 +115,19 @@ def setLogger(newLogger):
     logger = newLogger
 
 
+def prettify(value):
+    """Render a value for debug output.
+
+    ASN.1 objects are rendered with .prettyPrint() -- str() on an OCTET
+    STRING decodes the payload as text, which pyasn1 deprecates. Anything
+    else falls back to str().
+    """
+    prettyPrint = getattr(value, "prettyPrint", None)
+    if callable(prettyPrint):
+        return prettyPrint()
+    return str(value)
+
+
 def hexdump(octets):
     return " ".join(
         [

--- a/pysnmp/entity/config.py
+++ b/pysnmp/entity/config.py
@@ -189,7 +189,14 @@ def addV1System(
         'communityIndex "%s" communityName "%s" securityName "%s" '
         'contextEngineId "%s" contextName "%s" transportTag '
         '"%s"'
-        % (communityIndex, communityName, securityName, contextEngineId, contextName, transportTag)
+        % (
+            communityIndex,
+            debug.prettify(communityName),
+            debug.prettify(securityName),
+            debug.prettify(contextEngineId),
+            debug.prettify(contextName),
+            debug.prettify(transportTag),
+        )
     )
 
 
@@ -405,7 +412,7 @@ def delV3User(
     debug.logger & debug.flagSM and debug.logger(
         "delV3User: deleted table entries by index "
         'userName "%s" securityEngineId '
-        '"%s"' % (userName, securityEngineId.prettyPrint())
+        '"%s"' % (debug.prettify(userName), securityEngineId.prettyPrint())
     )
 
     # Drop all derived rows

--- a/pysnmp/entity/rfc3413/ntforg.py
+++ b/pysnmp/entity/rfc3413/ntforg.py
@@ -390,7 +390,7 @@ class NotificationOriginator:
         notificationHandle = getNextHandle()
 
         debug.logger & debug.flagApp and debug.logger(
-            f"sendVarBinds: notificationHandle {notificationHandle}, notifyTag {notifyTag}, notifyType {notifyType}"
+            f"sendVarBinds: notificationHandle {notificationHandle}, notifyTag {debug.prettify(notifyTag)}, notifyType {notifyType}"
         )
 
         varBinds = [(v2c.ObjectIdentifier(x), y) for x, y in varBinds]
@@ -484,7 +484,7 @@ class NotificationOriginator:
                         continue
 
             debug.logger & debug.flagApp and debug.logger(
-                f"sendVarBinds: notificationHandle {notificationHandle}, notifyTag {notifyTag} yields: transportDomain {transportDomain}, transportAddress {transportAddress!r}, securityModel {securityModel}, securityName {securityName}, securityLevel {securityLevel}"
+                f"sendVarBinds: notificationHandle {notificationHandle}, notifyTag {debug.prettify(notifyTag)} yields: transportDomain {transportDomain}, transportAddress {transportAddress!r}, securityModel {securityModel}, securityName {debug.prettify(securityName)}, securityLevel {securityLevel}"
             )
 
             trapOidVal = varBinds[1][1]
@@ -508,12 +508,12 @@ class NotificationOriginator:
                     )
 
                     debug.logger & debug.flagApp and debug.logger(
-                        f"sendVarBinds: ACL succeeded for OID {varName} securityName {securityName}"
+                        f"sendVarBinds: ACL succeeded for OID {varName} securityName {debug.prettify(securityName)}"
                     )
 
                 except error.StatusInformation:
                     debug.logger & debug.flagApp and debug.logger(
-                        f"sendVarBinds: ACL denied access for OID {varName} securityName {securityName}, "
+                        f"sendVarBinds: ACL denied access for OID {varName} securityName {debug.prettify(securityName)}, "
                         f"skipping notification for target {targetAddrName}"
                     )
                     vacmDenied = True

--- a/pysnmp/hlapi/asyncio/device.py
+++ b/pysnmp/hlapi/asyncio/device.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any, NamedTuple
 
 from pysnmp.hlapi.asyncio.cmdgen import getCmd, nextCmd
+from pysnmp.proto.rfc1902 import OctetString
 from pysnmp.proto.rfc1905 import EndOfMibView, NoSuchInstance, NoSuchObject
 from pysnmp.smi.rfc1902 import ObjectIdentity, ObjectType
 
@@ -169,7 +170,7 @@ async def get_device_report(
                     SysOREntry(
                         index=previous_index,
                         or_id=str(values[1]),
-                        or_descr=str(values[2]),
+                        or_descr=values[2].prettyPrint(),
                         or_uptime=int(values[3]),
                     )
                 )
@@ -180,7 +181,11 @@ async def get_device_report(
 
     def as_text(field: str) -> str | None:
         value = results.get(field)
-        return str(value) if value is not None else None
+        if value is None:
+            return None
+        # str() on an OCTET STRING is deprecated by pyasn1; .prettyPrint()
+        # yields the text when it is printable and hexadecimal otherwise.
+        return value.prettyPrint() if isinstance(value, OctetString) else str(value)
 
     def as_integer(field: str) -> int | None:
         value = results.get(field)

--- a/pysnmp/proto/acmod/rfc3415.py
+++ b/pysnmp/proto/acmod/rfc3415.py
@@ -157,7 +157,14 @@ class Vacm:
             "isAccessAllowed: securityModel %s, securityName %s, "
             "securityLevel %s, viewType %s, contextName %s for "
             "variableName %s"
-            % (securityModel, securityName, securityLevel, viewType, contextName, variableName)
+            % (
+                securityModel,
+                debug.prettify(securityName),
+                securityLevel,
+                viewType,
+                debug.prettify(contextName),
+                variableName,
+            )
         )
 
         # Rebuild contextName map if changed

--- a/pysnmp/proto/rfc3412.py
+++ b/pysnmp/proto/rfc3412.py
@@ -130,7 +130,7 @@ class MsgAndPduDispatcher:
             raise error.StatusInformation(errorIndication=errind.unsupportedMsgProcessingModel)
 
         debug.logger & debug.flagDsp and debug.logger(
-            f"sendPdu: securityName {securityName}, PDU\n{PDU.prettyPrint()}"
+            f"sendPdu: securityName {debug.prettify(securityName)}, PDU\n{PDU.prettyPrint()}"
         )
 
         # 4.1.1.3

--- a/pysnmp/proto/secmod/rfc2576.py
+++ b/pysnmp/proto/secmod/rfc2576.py
@@ -194,7 +194,10 @@ class SnmpV1SecurityModel(base.AbstractSecurityModel):
                     )
                     targetAddrTAddress = tuple(TransportAddressIPv6(targetAddrTAddress))
                 elif targetAddrTDomain[: len(unix.snmpLocalDomain)] == unix.snmpLocalDomain:
-                    targetAddrTAddress = str(targetAddrTAddress)
+                    # A local-domain TAddress carries a filesystem path
+                    targetAddrTAddress = targetAddrTAddress.asOctets().decode(
+                        targetAddrTAddress.encoding
+                    )
 
                 targetAddr = targetAddrTDomain, targetAddrTAddress
                 targetAddrTagList = snmpTargetAddrTagList.getNode(
@@ -377,12 +380,12 @@ class SnmpV1SecurityModel(base.AbstractSecurityModel):
                 candidateSecurityNames.sort(
                     key=lambda x, m=self.__nameToModelMap, v=self.securityModelID: (
                         not int(x[0] in m and v in m[x[0]]),
-                        str(x[0]),
+                        x[0].asOctets(),
                     )
                 )
                 chosenSecurityName = candidateSecurityNames[0]  # min()
                 debug.logger & debug.flagSM and debug.logger(
-                    f"_com2sec: securityName candidates for communityName '{communityName}' are {candidateSecurityNames}; choosing securityName '{chosenSecurityName[0]}'"
+                    f"_com2sec: securityName candidates for communityName '{debug.prettify(communityName)}' are {candidateSecurityNames}; choosing securityName '{debug.prettify(chosenSecurityName[0])}'"
                 )
                 return chosenSecurityName
 

--- a/pysnmp/proto/secmod/rfc3414/service.py
+++ b/pysnmp/proto/secmod/rfc3414/service.py
@@ -329,14 +329,14 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
                 'securityEngineID "%s" and  securityName "%s" found by '
                 'securityStateReference "%s" '
                 % (
-                    usmUserName,
-                    usmUserSecurityName,
+                    debug.prettify(usmUserName),
+                    debug.prettify(usmUserSecurityName),
                     usmUserAuthProtocol,
                     usmUserAuthKeyLocalized and usmUserAuthKeyLocalized.prettyPrint(),
                     usmUserPrivProtocol,
                     usmUserPrivKeyLocalized and usmUserPrivKeyLocalized.prettyPrint(),
                     securityEngineID.prettyPrint(),
-                    securityName,
+                    debug.prettify(securityName),
                     securityStateReference,
                 )
             )
@@ -382,14 +382,14 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
                     'usmUserPrivKeyLocalized "%s" by '
                     'securityEngineID "%s" and  securityName "%s"'
                     % (
-                        usmUserName,
-                        usmUserSecurityName,
+                        debug.prettify(usmUserName),
+                        debug.prettify(usmUserSecurityName),
                         usmUserAuthProtocol,
                         usmUserAuthKeyLocalized and usmUserAuthKeyLocalized.prettyPrint(),
                         usmUserPrivProtocol,
                         usmUserPrivKeyLocalized and usmUserPrivKeyLocalized.prettyPrint(),
                         securityEngineID.prettyPrint(),
-                        securityName,
+                        debug.prettify(securityName),
                     )
                 )
 
@@ -423,14 +423,14 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
                             'usmUserPrivKeyLocalized "%s" for '
                             'securityEngineID "%s" and  securityName "%s"'
                             % (
-                                usmUserName,
-                                usmUserSecurityName,
+                                debug.prettify(usmUserName),
+                                debug.prettify(usmUserSecurityName),
                                 usmUserAuthProtocol,
                                 usmUserAuthKeyLocalized and usmUserAuthKeyLocalized.prettyPrint(),
                                 usmUserPrivProtocol,
                                 usmUserPrivKeyLocalized and usmUserPrivKeyLocalized.prettyPrint(),
                                 securityEngineID.prettyPrint(),
-                                securityName,
+                                debug.prettify(securityName),
                             )
                         )
 
@@ -438,7 +438,11 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
                         debug.logger & debug.flagSM and debug.logger(
                             "__generateRequestOrResponseMsg: failed to clone "
                             'USM user for securityEngineID "%s" securityName '
-                            '"%s"' % (securityEngineID, securityName)
+                            '"%s"'
+                            % (
+                                debug.prettify(securityEngineID),
+                                debug.prettify(securityName),
+                            )
                         )
 
                         reportUnknownName = True
@@ -805,7 +809,7 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
         )
 
         debug.logger & debug.flagSM and debug.logger(
-            f"processIncomingMsg: cache write securityStateReference {securityStateReference} by msgUserName {securityParameters.getComponentByPosition(3)}"
+            f"processIncomingMsg: cache write securityStateReference {securityStateReference} by msgUserName {debug.prettify(securityParameters.getComponentByPosition(3))}"
         )
 
         scopedPduData = msg.getComponentByPosition(3)
@@ -1017,7 +1021,7 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
                 )
                 usmStatsUnsupportedSecLevels.syntax += 1
                 debug.logger & debug.flagSM and debug.logger(
-                    f"processIncomingMsg: reporting inappropriate security level for user {msgUserName}: {badSecIndication}"
+                    f"processIncomingMsg: reporting inappropriate security level for user {debug.prettify(msgUserName)}: {badSecIndication}"
                 )
                 _raise_usm_error(
                     errind.unsupportedSecurityLevel,
@@ -1255,7 +1259,7 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
         securityName = usmUserSecurityName
 
         debug.logger & debug.flagSM and debug.logger(
-            f"processIncomingMsg: cached msgUserName {msgUserName} info by securityStateReference {securityStateReference}"
+            f"processIncomingMsg: cached msgUserName {debug.prettify(msgUserName)} info by securityStateReference {securityStateReference}"
         )
 
         # Delayed to include details

--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -1030,22 +1030,25 @@ class MibTableColumn(MibScalar):
 
     def writeTest(self, name, val, idx, acInfo):
         # Besides common checks, request row creation on no-instance
+        rowOpException = None
         try:
             # First try the instance
             MibScalar.writeTest(self, name, val, idx, acInfo)
         # ...otherwise proceed with creating new column
         except (error.NoSuchInstanceError, error.RowCreationWanted) as excValue:
+            rowOpException = excValue
             if isinstance(excValue, error.RowCreationWanted):
                 self.__rowOpWanted[name] = excValue
             else:
                 self.__rowOpWanted[name] = error.RowCreationWanted()
             self.createTest(name, val, idx, acInfo)
-        except error.RowDestructionWanted:
+        except error.RowDestructionWanted as excValue:
+            rowOpException = excValue
             self.__rowOpWanted[name] = error.RowDestructionWanted()
             self.destroyTest(name, val, idx, acInfo)
         if name in self.__rowOpWanted:
             debug.logger & debug.flagIns and debug.logger(
-                f"{self.__rowOpWanted[name]} flagged by {name}={val!r}, exception {excValue}"
+                f"{self.__rowOpWanted[name]} flagged by {name}={val!r}, exception {rowOpException}"
             )
             raise self.__rowOpWanted[name]
 

--- a/tests/test_auth_priv_matrix.py
+++ b/tests/test_auth_priv_matrix.py
@@ -147,7 +147,7 @@ def _get_value(result):
     error_indication, error_status, error_index, var_binds = result
     assert error_indication is None, f"errorIndication: {error_indication}"
     assert not error_status, f"errorStatus: {error_status} at index {error_index}"
-    return str(var_binds[0][1])
+    return var_binds[0][1].prettyPrint()
 
 
 # --- Individual combination tests ---

--- a/tests/test_iana_pen_tool.py
+++ b/tests/test_iana_pen_tool.py
@@ -125,6 +125,6 @@ class TestGenerateMibModule:
         pen_1, pen_20408 = mib_builder.importSymbols(module_name, "pen_1", "pen_20408")
 
         assert pen_1.name == (1, 3, 6, 1, 4, 1, 1)
-        assert str(pen_1.syntax) == "ISO"
+        assert pen_1.syntax.prettyPrint() == "ISO"
         assert pen_20408.name == (1, 3, 6, 1, 4, 1, 20408)
-        assert str(pen_20408.syntax) == "PySNMP Project"
+        assert pen_20408.syntax.prettyPrint() == "PySNMP Project"

--- a/tests/test_netsnmp_integration.py
+++ b/tests/test_netsnmp_integration.py
@@ -207,7 +207,7 @@ def test_real_interface_row_is_indexed():
     var_binds = _get_one(IF_DESCR_1, IF_ADMIN_STATUS_1)
     assert str(var_binds[0][0]) == IF_DESCR_1
     assert str(var_binds[1][0]) == IF_ADMIN_STATUS_1
-    assert str(var_binds[0][1]).strip() != "", "ifDescr.1 was empty"
+    assert var_binds[0][1].prettyPrint().strip() != "", "ifDescr.1 was empty"
     assert int(var_binds[1][1]) in (1, 2, 3), (
         f"ifAdminStatus.1 must be up(1)/down(2)/testing(3), got {var_binds[1][1]}"
     )
@@ -224,10 +224,10 @@ def test_system_identity_is_well_formed():
     assert str(var_binds[0][0]) == SYS_DESCR
     assert str(var_binds[1][0]) == SYS_OBJECT_ID
     assert str(var_binds[2][0]) == SYS_NAME
-    assert str(var_binds[0][1]).strip() != "", "sysDescr.0 was empty"
-    assert str(var_binds[1][1]).strip() != "", "sysObjectID.0 was empty"
-    assert str(var_binds[2][1]) == f"pysnmp-ci-{profile()}", (
-        f"sysName.0 mismatch: {var_binds[2][1]}"
+    assert var_binds[0][1].prettyPrint().strip() != "", "sysDescr.0 was empty"
+    assert var_binds[1][1].prettyPrint().strip() != "", "sysObjectID.0 was empty"
+    assert var_binds[2][1].asOctets() == f"pysnmp-ci-{profile()}".encode(), (
+        f"sysName.0 mismatch: {var_binds[2][1].prettyPrint()}"
     )
 
 
@@ -367,10 +367,12 @@ def test_set_syslocation_roundtrip():
     marker = OctetString(f"pysnmp-ci-{profile()}-set-marker")
     try:
         set_location(marker)
-        assert str(get_location()) == str(marker), "sysLocation.0 did not take the SET value"
+        assert get_location().asOctets() == marker.asOctets(), (
+            "sysLocation.0 did not take the SET value"
+        )
     finally:
         set_location(original)
-        assert str(get_location()) == str(original), "sysLocation.0 was not restored"
+        assert get_location().asOctets() == original.asOctets(), "sysLocation.0 was not restored"
 
 
 # --- transport dispatching ------------------------------------------------

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -41,7 +41,7 @@ class TestRfc1902Types:
 
     def test_octet_string_creation(self):
         val = rfc1902.OctetString("hello")
-        assert str(val) == "hello"
+        assert val.asOctets() == b"hello"
 
     def test_octet_string_hexvalue(self):
         val = rfc1902.OctetString(hexValue="deadbeef")
@@ -49,7 +49,7 @@ class TestRfc1902Types:
 
     def test_octet_string_concat(self):
         val = rfc1902.OctetString("hello") + " world"
-        assert str(val) == "hello world"
+        assert val.asOctets() == b"hello world"
 
     def test_object_identifier(self):
         oid = rfc1902.ObjectIdentifier((1, 3, 6, 1))
@@ -85,7 +85,7 @@ class TestRfc1902Types:
 
     def test_null(self):
         val = rfc1902.Null("")
-        assert str(val) == ""
+        assert val.asOctets() == b""
 
     def test_bits(self):
         val = rfc1902.Bits()
@@ -438,14 +438,14 @@ class TestProxyRfc2576:
         assert v2Pdu is not None
         v2VarBinds = v2c.apiPDU.getVarBinds(v2Pdu)
         assert len(v2VarBinds) == 2
-        assert str(v2VarBinds[0][1]) == "test value"
+        assert v2VarBinds[0][1].asOctets() == b"test value"
         assert tuple(v2VarBinds[1][1]) == (1, 3, 6)
 
         v1Pdu2 = rfc2576.v2ToV1(v2Pdu, v1Pdu)
         assert v1Pdu2 is not None
         v1VarBinds2 = v1.apiPDU.getVarBinds(v1Pdu2)
         assert len(v1VarBinds2) == 2
-        assert str(v1VarBinds2[0][1]) == "test value"
+        assert v1VarBinds2[0][1].asOctets() == b"test value"
         assert tuple(v1VarBinds2[1][1]) == (1, 3, 6)
 
     def test_v1_to_v2_counter(self):
@@ -493,7 +493,7 @@ class TestProxyRfc2576:
         v2Pdu = rfc2576.v1ToV2(v1Pdu)
         v2VarBinds = v2c.apiPDU.getVarBinds(v2Pdu)
 
-        assert str(v2VarBinds[0][1]) == "hello"
+        assert v2VarBinds[0][1].asOctets() == b"hello"
         assert type(v2VarBinds[0][1]) is v2c.OctetString
 
     def test_v1_to_v2_rejects_integer_outside_integer32_range(self):
@@ -604,7 +604,7 @@ class TestV2cMessageAPI:
         msg = rfc1901.Message()
         v2c.apiMessage.setDefaults(msg)
         v2c.apiMessage.setCommunity(msg, "public")
-        assert str(v2c.apiMessage.getCommunity(msg)) == "public"
+        assert v2c.apiMessage.getCommunity(msg).asOctets() == b"public"
 
     def test_message_get_set_pdu(self):
         msg = rfc1901.Message()
@@ -635,7 +635,7 @@ class TestV1MessageAPI:
         msg = rfc1157.Message()
         v1.apiMessage.setDefaults(msg)
         v1.apiMessage.setCommunity(msg, "public")
-        assert str(v1.apiMessage.getCommunity(msg)) == "public"
+        assert v1.apiMessage.getCommunity(msg).asOctets() == b"public"
 
 
 class TestProxyRfc2576PduMapping:

--- a/tests/test_snmpsim_integration.py
+++ b/tests/test_snmpsim_integration.py
@@ -20,8 +20,8 @@ def get_value(result):
     assert error_indication is None
     assert not error_status
     assert not error_index
-    print(f"  SNMP response: OID={var_binds[0][0]} value={var_binds[0][1]}")
-    return str(var_binds[0][1])
+    print(f"  SNMP response: OID={var_binds[0][0]} value={var_binds[0][1].prettyPrint()}")
+    return var_binds[0][1].prettyPrint()
 
 
 def test_snmpsim_v1(snmpsim_endpoint):

--- a/tests/test_snmpsim_manager.py
+++ b/tests/test_snmpsim_manager.py
@@ -29,6 +29,17 @@ from pysnmp.hlapi.asyncio import (
 from pysnmp.hlapi.asyncio import (
     nextCmd as asyncio_nextCmd,
 )
+from pysnmp.proto.rfc1902 import OctetString
+
+
+def as_text(value):
+    """Render a var-bind value as text.
+
+    str() on an OCTET STRING is deprecated by pyasn1; .prettyPrint() gives
+    the text when it is printable and hexadecimal otherwise.
+    """
+    return value.prettyPrint() if isinstance(value, OctetString) else str(value)
+
 
 SYS_DESCR = "1.3.6.1.2.1.1.1.0"
 SYS_OBJECTID = "1.3.6.1.2.1.1.2.0"
@@ -46,8 +57,8 @@ def get_value(result):
     assert error_indication is None
     assert not error_status
     assert not error_index
-    print(f"  SNMP response: OID={var_binds[0][0]} value={var_binds[0][1]}")
-    return str(var_binds[0][1])
+    print(f"  SNMP response: OID={var_binds[0][0]} value={as_text(var_binds[0][1])}")
+    return as_text(var_binds[0][1])
 
 
 def get_all_values(result):
@@ -56,8 +67,8 @@ def get_all_values(result):
     assert not error_status
     assert not error_index
     for vb in var_binds:
-        print(f"  SNMP response: OID={vb[0]} value={vb[1]}")
-    return [str(vb[1]) for vb in var_binds]
+        print(f"  SNMP response: OID={vb[0]} value={as_text(vb[1])}")
+    return [as_text(vb[1]) for vb in var_binds]
 
 
 # ---- Versioned GET tests (synchronous asyncio facade) ----
@@ -108,7 +119,7 @@ class TestSyncGetV1:
         elif error_status:
             print(f"  SNMP PDU error: {error_status} at index {error_index}")
         else:
-            print(f"  SNMP response: OID={var_binds[0][0]} value={var_binds[0][1]}")
+            print(f"  SNMP response: OID={var_binds[0][0]} value={as_text(var_binds[0][1])}")
         assert error_indication is None
 
     def test_get_multiple(self, snmpsim_endpoint):
@@ -218,8 +229,8 @@ class TestSyncNextV2c:
                 print(f"  SNMP error: {error_indication}")
                 break
             for vb in var_binds:
-                print(f"  SNMP response: OID={vb[0]} value={vb[1]}")
-                results.append(str(vb[1]))
+                print(f"  SNMP response: OID={vb[0]} value={as_text(vb[1])}")
+                results.append(as_text(vb[1]))
             if len(results) >= 5:
                 break
         assert len(results) > 0
@@ -259,8 +270,8 @@ class TestSyncBulkV2c:
                 print(f"  SNMP error: {error_indication}")
                 break
             for vb in var_binds:
-                print(f"  SNMP response: OID={vb[0]} value={vb[1]}")
-                results.append(str(vb[1]))
+                print(f"  SNMP response: OID={vb[0]} value={as_text(vb[1])}")
+                results.append(as_text(vb[1]))
             if len(results) >= 10:
                 break
         assert len(results) > 0
@@ -375,7 +386,7 @@ class TestAsyncioNextV2c:
         assert len(var_binds) > 0
         for row in var_binds:
             for vb in row:
-                print(f"  SNMP response: OID={vb[0]} value={vb[1]}")
+                print(f"  SNMP response: OID={vb[0]} value={as_text(vb[1])}")
 
 
 class TestAsyncioBulkV2c:
@@ -399,7 +410,7 @@ class TestAsyncioBulkV2c:
         assert error_indication is None
         for vb in var_binds:
             for row in vb:
-                print(f"  SNMP response: OID={row[0]} value={row[1]}")
+                print(f"  SNMP response: OID={row[0]} value={as_text(row[1])}")
         assert len(var_binds) > 0
 
 


### PR DESCRIPTION
pyasn1 1.2.0 deprecates text decoding in `OctetString.__str__()` — a future release returns the hexadecimal
representation instead. This replaces every internal `str()`/f-string rendering of an OCTET STRING with the
accessor that states the intent, and locks the result in so it cannot regress.

## How the sites were found

`str()` fires from f-strings and `%s` too, and most of pysnmp's are in debug logs that short-circuit unless
debugging is on — so the suite only saw 3 library sites. Re-running it with `pysnmp.debug` fully enabled and
`-W always::DeprecationWarning` raised that to **15**. All 15 are fixed; the audit run is now clean.

## Changes

- **`debug.prettify(value)`** — renders a value for debug output: `.prettyPrint()` for ASN.1 objects, `str()`
  otherwise. Community names, security names, context IDs and user names reach the debug logs as either a
  plain `str` or an ASN.1 object depending on how the caller configured them, so those sites go through it.
  Where the type is already known the existing direct `.prettyPrint()` style is kept.
- **`rfc2576`** — a local-domain `TAddress` is decoded with the type's own codec (it carries a filesystem
  path, so it stays text); `securityName` candidates now sort on `.asOctets()`, which orders identically to
  the old text sort for every codec involved.
- **`device.py`** — OCTET STRING fields render with `.prettyPrint()` (text when printable, hex otherwise,
  instead of raising `UnicodeDecodeError` on binary), while OIDs stay on `str()` so `sysObjectID` keeps its
  dotted form rather than becoming MIB-resolved.
- **Tests** — assert on `.asOctets()` for payload equality and `.prettyPrint()` for display.
- **`filterwarnings`** — a new `[tool.pytest.ini_options]` rule turns *this* deprecation into an error, so a
  reintroduced `str()` fails the suite. Verified: a throwaway `str(OctetString("hi"))` test fails on it.

## Drive-by bug fix

`MibTableColumn.writeTest()` interpolated `excValue` into its debug line, but Python unbinds an
`except ... as` name at the end of the block. With debug enabled, every write to a conditionally-created
column raised `UnboundLocalError` — 109 of 857 tests. The exception is now captured in a separate local.
This was blocking the audit run, which is how it surfaced.

## Verification

- `857 passed, 12 skipped, 2 xfailed, 5 xpassed` — with debug off *and* with `pysnmp.debug` fully on.
- Zero `DeprecationWarning`s under the debug-enabled audit run (was 15 library + 23 test sites).
- `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved rendering of SNMP values, names, communities, contexts, and notification details in diagnostic output.
  - Local-domain SNMP target addresses are now displayed as decoded filesystem paths using their declared encoding.
  - Improved handling and reporting of row-operation exceptions during MIB table updates.
  - Added a public utility for consistently formatting values with custom pretty-print support and safe string fallback.

- **Tests**
  - Expanded coverage for text rendering, byte-oriented values, protocol exchanges, and authentication scenarios.
  - Configured tests to catch a specific OCTET STRING decoding deprecation warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->