### PR TITLE
fix: tolerate undecodable OID values and hostile BER on the receive path

### DIFF
--- a/pysnmp/proto/api/verdec.py
+++ b/pysnmp/proto/api/verdec.py
@@ -29,3 +29,9 @@ def decodeMessageVersion(wholeMsg):
         return ver
     except PyAsn1Error:
         raise ProtocolError("Invalid BER at SNMP version component")
+    except (TypeError, ValueError) as exc:
+        # Malformed substrate can drive the BER decoder into paths that raise
+        # plain Python exceptions rather than PyAsn1Error. This is the first
+        # thing an untrusted datagram touches, so nothing but ProtocolError may
+        # escape here.
+        raise ProtocolError(f"Malformed BER at SNMP version component: {exc}")

--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -897,7 +897,16 @@ class ObjectType:
                 raise SmiError(err)
 
         if rfc1902.ObjectIdentifier().isSuperTypeOf(self.__args[1], matchConstraints=False):
-            self.__args[1] = ObjectIdentity(self.__args[1]).resolveWithMib(mibViewController)
+            # An OBJECT IDENTIFIER value is resolved purely to render it by MIB
+            # name. The value is opaque payload chosen by the peer, so a RowPointer
+            # whose index this MIB view cannot decode must not fail the varbind --
+            # it stays an unresolved ObjectIdentifier.
+            try:
+                self.__args[1] = ObjectIdentity(self.__args[1]).resolveWithMib(mibViewController)
+            except SmiError as e:
+                debug.logger & debug.flagMIB and debug.logger(
+                    f"resolveWithMib: value {self.__args[1]!r} of {self.__args[0]!r} left unresolved: {e}"
+                )
 
         self.__state |= self.stClean
 

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -378,6 +378,23 @@ class TestVerdec:
         with pytest.raises(proto_error.ProtocolError):
             verdec.decodeMessageVersion(b"\x00\x00\x00")
 
+    @pytest.mark.parametrize(
+        "substrate",
+        [
+            pytest.param(b"\x68\x00\x37\x15", id="constructed-app-tag"),
+            pytest.param(b"", id="empty"),
+            pytest.param(b"\x30", id="tag-only"),
+            pytest.param(b"\x30\x82", id="truncated-length"),
+            pytest.param(b"\x30\x80", id="indefinite-length"),
+            pytest.param(b"\x30\x02\x00\x00", id="eoo-as-version"),
+            pytest.param(b"\x30\x84\xff\xff\xff\xff\x02\x01\x01", id="oversized-length"),
+        ],
+    )
+    def test_hostile_substrate_raises_protocol_error(self, substrate):
+        """Nothing but ProtocolError may escape the first parse of a datagram."""
+        with pytest.raises(proto_error.ProtocolError):
+            verdec.decodeMessageVersion(substrate)
+
 
 class TestProtoError:
     def test_protocol_error(self):

--- a/tests/test_smi.py
+++ b/tests/test_smi.py
@@ -7,7 +7,7 @@ from pyasn1.type.constraint import SingleValueConstraint, ValueRangeConstraint
 from pyasn1.type.namedval import NamedValues
 
 from pysnmp.entity.engine import SnmpEngine
-from pysnmp.proto.rfc1902 import Integer, Integer32, OctetString
+from pysnmp.proto.rfc1902 import Integer, Integer32, ObjectIdentifier, OctetString
 from pysnmp.smi import builder, error, exval, indices, view
 from pysnmp.smi.rfc1902 import ObjectIdentity, ObjectType
 
@@ -421,6 +421,50 @@ class TestObjectType:
             assert isinstance(ot.getUnits(), str)
         except error.SmiError:
             pytest.skip("SNMP-TARGET-MIB snmpTargetAddrTimeout not available")
+
+
+@pytest.fixture(scope="module")
+def usm_view():
+    mibBuilder = builder.MibBuilder()
+    mibBuilder.loadModules("SNMP-USER-BASED-SM-MIB", "SNMPv2-MIB")
+    return view.MibViewController(mibBuilder)
+
+
+class TestObjectTypeRowPointerValues:
+    """An OBJECT IDENTIFIER *value* is resolved only to render it by MIB name.
+
+    A peer is free to return a RowPointer whose index this MIB view cannot decode;
+    that must not fail the varbind and abort the surrounding walk.
+    """
+
+    # usmUserEntry INDEX is { usmUserEngineID, usmUserName }, both variable-length
+    # OCTET STRINGs and therefore length-prefixed in the instance OID.
+    USM_USER_STATUS = "1.3.6.1.6.3.15.1.2.2.1.13"
+    # engineID length octet says 5 but 8 sub-ids follow, leaving excess sub-ids
+    UNDECODABLE = USM_USER_STATUS + ".5.128.0.0.0.1.2.3.4.3.97.98.99"
+    DECODABLE = USM_USER_STATUS + ".5.128.0.0.0.1.3.97.98.99"
+
+    def test_undecodable_row_pointer_resolves_standalone_raises(self, usm_view):
+        """Guard the premise: resolving it as an ObjectIdentity does raise."""
+        with pytest.raises(error.SmiError):
+            ObjectIdentity(self.UNDECODABLE).resolveWithMib(usm_view)
+
+    @pytest.mark.parametrize("ignore_errors", [True, False])
+    def test_undecodable_row_pointer_value_is_tolerated(self, usm_view, ignore_errors):
+        ot = ObjectType(
+            ObjectIdentity("SNMPv2-MIB", "sysObjectID", 0),
+            ObjectIdentifier(self.UNDECODABLE),
+        )
+        ot.resolveWithMib(usm_view, ignoreErrors=ignore_errors)
+        assert ot[1].prettyPrint() == self.UNDECODABLE
+
+    def test_decodable_row_pointer_value_still_resolves(self, usm_view):
+        ot = ObjectType(
+            ObjectIdentity("SNMPv2-MIB", "sysObjectID", 0),
+            ObjectIdentifier(self.DECODABLE),
+        )
+        ot.resolveWithMib(usm_view, ignoreErrors=False)
+        assert ot[1].prettyPrint() == 'SNMP-USER-BASED-SM-MIB::usmUserStatus."0x8000000001"."abc"'
 
 
 class TestBundledMibs:


### PR DESCRIPTION
Closes #57. Closes #82.

## #57 — one bad RowPointer aborts an entire walk

`ObjectType.resolveWithMib()` re-resolved any OBJECT IDENTIFIER *value* as an
`ObjectIdentity`, which runs full MIB index decoding:

```python
if rfc1902.ObjectIdentifier().isSuperTypeOf(self.__args[1], matchConstraints=False):
    self.__args[1] = ObjectIdentity(self.__args[1]).resolveWithMib(mibViewController)
```

Unconditional, and it ignored `ignoreErrors` entirely. The reporter walked
`IP-MIB::ipAddressTable`; `ipAddressPrefix` is a RowPointer into
`ipAddressPrefixTable`, and their device returned one whose `InetAddress` length
octet does not match the sub-ids that follow. Decoding raised
`Excessive instance identifier sub-OIDs left at MibTableRow(...)` and killed the
whole `bulkCmd`.

Resolving a *value* is cosmetic — it exists so the value renders as a MIB name.
It is never required for the request to be correct, and the value is payload the
peer chose, not something the caller addressed. It is now best-effort: on
`SmiError` the plain `ObjectIdentifier` is kept and a debug line is logged.

Reproduced with bundled MIBs only (`usmUserEntry`, whose INDEX is two
variable-length OCTET STRINGs, so both are length-prefixed exactly like
`InetAddress`):

| | before | after |
|---|---|---|
| `ignoreErrors=True` | `SmiError` | `sysObjectID.0 = 1.3.6.1.6.3.15.1.2.2.1.13.5.128...` |
| `ignoreErrors=False` | `SmiError` | same |
| well-formed pointer | resolves | resolves (unchanged) |

## #82 — unhandled TypeError from a 4-byte datagram

`decodeMessageVersion()` caught only `PyAsn1Error`. The reporter's own sample
input still crashes on `next`:

```
$ xxd id.000000.txt
00000000: 6800 3715                                h.7.

TypeError: ConstructedAsn1Type.clone() takes 1 positional argument but 2 were given
  pysnmp/proto/api/verdec.py:15 in decodeMessageVersion
  pyasn1/codec/ber/decoder.py:75 in _createComponent -> asn1Spec.clone(value)
```

It leaks all the way out of `MsgAndPduDispatcher.receiveMessage()`. This is the
first code an untrusted UDP datagram touches, so `TypeError`/`ValueError` are now
converted to `ProtocolError` like every other parse failure — the fix the
reporter proposed. `receiveMessage()` already drops `ProtocolError` silently, so
all seven hostile samples now return normally.

The underlying `clone()` misuse is a `pysnmp-pyasn1` decoder bug; this change
stops it reaching the socket loop regardless.

## Tests

- `TestObjectTypeRowPointerValues` — 4 cases, including a guard asserting the
  standalone `ObjectIdentity` resolution still raises, so the test cannot pass
  vacuously.
- `TestVerdec::test_hostile_substrate_raises_protocol_error` — 7 parametrized
  substrates including the reporter's bytes.

857 → 868 passed, 12 skipped, 2 xfailed, 5 xpassed. Warning count unchanged at
50. `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed BER messages now produce consistent protocol errors instead of exposing underlying parsing exceptions.
  * OID values that cannot be resolved during display are preserved in their original form, while valid values continue to resolve normally.
* **Tests**
  * Added coverage for malformed message formats and resolvable or unresolvable OID values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->