### PR TITLE
ci: allow manual prerelease or GA release dispatch from main

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -8,6 +8,13 @@ on:
       - "develop"
   pull_request:
     branches: [main, next, develop]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Release to cut (main only)"
+        type: choice
+        options: [prerelease, ga]
+        default: prerelease
 
 jobs:
   pre-commit:
@@ -37,7 +44,9 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    environment: release    
+    environment: release
+    env:
+      DRY: ${{ github.event_name != 'workflow_dispatch' && github.ref_name == 'main' }}
     needs:
       - pre-commit
       - semgrep
@@ -59,11 +68,16 @@ jobs:
           version: "latest"
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"          
+          node-version: "20"
+      - name: Cut prerelease from main
+        if: github.ref_name == 'main' && github.event.inputs.release_type == 'prerelease'
+        run: |
+          sed -i 's/^    "main",$/    { name: "main", prerelease: "rc" },/' .releaserc
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4.0.0
         id: semantic   # Need an `id` for output variables
         with:
+          dry_run: ${{ env.DRY }}
           #semantic_version: 19.0.5
           extra_plugins: |
             semantic-release-replace-plugin
@@ -73,11 +87,16 @@ jobs:
             @semantic-release/exec@6.0.3               
         env:
           GITHUB_TOKEN: ${{ secrets.SEMREL_TOKEN }}
+      - name: Build dev preview
+        if: env.DRY == 'true' && steps.semantic.outputs.new_release_version != ''
+        run: |
+          sed -i "s/^version *=.*/version = \"${{ steps.semantic.outputs.new_release_version }}.dev${{ github.run_number }}\"/" pyproject.toml
+          uv build
       - name: Publish package distributions to PyPI
-        if: steps.semantic.outputs.new_release_published == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1          
+        if: env.DRY != 'true' && steps.semantic.outputs.new_release_published == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
       - uses: actions/upload-artifact@v4
-        if: steps.semantic.outputs.new_release_published == 'true'
+        if: hashFiles('dist/*') != ''
         with:
           name: dist
           path: dist


### PR DESCRIPTION
## What

Makes `main` able to cut either a prerelease (`-rc.N`) or a GA release, on demand, instead of releasing automatically on every push.

- **Push to `main`** → semantic-release runs in `dry_run`. No tag, no GitHub release, no PyPI. Builds a `X.Y.Z.dev<run_number>` preview wheel and uploads it as a workflow artifact.
- **`workflow_dispatch` on `main`** → real release. `release_type: prerelease` patches `.releaserc` so `main` releases as `rc`; `release_type: ga` releases stable.
- **`next` / `develop`** → unchanged. Still auto-publish `rc` / `beta` on push.

## Notes

- RC numbering continues across a `next` → `main` merge **only if the merge preserves history** (merge commit, not squash). `v6.0.0-rc.1` / `rc.2` must stay reachable from `main`, otherwise semantic-release recomputes from `v5.0.24` and retries an existing tag.
- Don't dispatch `prerelease` from `main` while `next` is still cutting rc's — both would claim the same tag namespace. Drop `next` from `.releaserc` when `main` takes over the rc channel.
- The `prerelease` path rewrites `.releaserc` with `sed`, which is coupled to that file's current formatting.
- Publishing already uses Trusted Publishing (OIDC), so PEP 740 attestations are emitted automatically. No signing or SBOM changes needed here.
- The `release` environment can carry required reviewers if you want a second approval gate on GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for manually selecting prerelease or general-availability releases.
  - Added development release previews that build packages without publishing them to PyPI.

- **Improvements**
  - Release artifacts are now uploaded whenever they are successfully generated.
  - Automated releases publish only when a new release is detected, reducing unnecessary publication attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->