### PR TITLE
chore(deps): bump pysnmp-pyasn1 to 1.2.0-rc.1

### DIFF
--- a/.github/copilot/copilot-instructions.md
+++ b/.github/copilot/copilot-instructions.md
@@ -27,7 +27,7 @@ Before generating code, scan the codebase to identify:
    - Never suggest features not available in the detected framework versions
 
 3. **Library Versions**: Note the exact versions of key libraries and dependencies
-   - Runtime dependencies (from `pyproject.toml`): `pysnmp-pysmi >=2.0.0b2,<3.0.0`, `pycryptodomex >=3.11.0,<4.0.0`, `pysnmp-pyasn1 >=1.2.0b14,<2.0.0`
+   - Runtime dependencies (from `pyproject.toml`): `pysnmp-pysmi >=2.0.0b2,<3.0.0`, `pycryptodomex >=3.11.0,<4.0.0`, `pysnmp-pyasn1 >=1.2.0rc1,<2.0.0`
    - Dev dependencies (from `pyproject.toml` `[project.optional-dependencies]`): `sphinx >=7.0.0,<9.0.0`, `pytest >=9.0.3,<10.0.0`, `coverage[toml] >=7.2.0,<8.0.0`, `mypy >=1.15.0,<3.0.0`, `ruff >=0.4.0,<1.0.0`
    - Generate code compatible with these specific versions
    - The project depends on the **pysnmp-pyasn1** fork, not upstream pyasn1. Import from `pyasn1.type`, `pyasn1.codec.ber`, `pyasn1.error`, and `pyasn1.compat.octets` as seen throughout `pysnmp/proto/` and `pysnmp/smi/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 dependencies = [
     "pysnmp-pysmi >=2.0.0b2,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
-    "pysnmp-pyasn1 >=1.2.0b14,<2.0.0",
+    "pysnmp-pyasn1 >=1.2.0rc1,<2.0.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -837,11 +837,11 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pyasn1"
-version = "1.2.0b14"
+version = "1.2.0rc1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/a3/39d3024262c4a48bc7cb52b637da897cd9a3a03c34f1aa10e213a59945a3/pysnmp_pyasn1-1.2.0b14.tar.gz", hash = "sha256:dece37e12d30021027ca2c2683ba50339aae46a1c7be5a3c57efcd969e39009e", size = 285030, upload-time = "2026-09-02T16:16:28.877Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/33/c21d34e9ffcfa6fdecac2cf560082e47ba3b5517a8161666396656047d9e/pysnmp_pyasn1-1.2.0rc1.tar.gz", hash = "sha256:7ebf143a1c1da7014789484bfcaafddd133a44bdec5309d5313f215cae0ef46a", size = 285269, upload-time = "2026-09-03T01:03:39.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/1b/95f92221d33355997e3a95681728204846ae3c0f81363d2f6c5019c7a262/pysnmp_pyasn1-1.2.0b14-py3-none-any.whl", hash = "sha256:417df3132f30a58795ba33c16475b9a753e0e816863880bfe7577ed01f9abead", size = 102236, upload-time = "2026-09-02T16:16:27.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/8c/2ca5f0ce827f41e4cb83f0011d5a0683d073d843c26a13206859ebde48ed/pysnmp_pyasn1-1.2.0rc1-py3-none-any.whl", hash = "sha256:7fd1b5c45b876c64713e0a0506b379a09e63a5db00c15d071e3a56bb53bfb1ab", size = 102233, upload-time = "2026-09-03T01:03:38.74Z" },
 ]
 
 [[package]]
@@ -859,7 +859,7 @@ wheels = [
 
 [[package]]
 name = "pysnmplib"
-version = "6.0.0rc1"
+version = "6.0.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "pycryptodomex" },
@@ -882,7 +882,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.2.0,<8.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0,<3.0.0" },
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
-    { name = "pysnmp-pyasn1", specifier = ">=1.2.0b14,<2.0.0" },
+    { name = "pysnmp-pyasn1", specifier = ">=1.2.0rc1,<2.0.0" },
     { name = "pysnmp-pysmi", specifier = ">=2.0.0b2,<3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0,<1.0.0" },


### PR DESCRIPTION
Bumps `pysnmp-pyasn1` floor from `1.2.0b14` to `1.2.0rc1`.

- `pyproject.toml` specifier + copilot instructions doc
- `uv.lock` relocked (also picks up the pending `pysnmplib` 6.0.0rc1 -> 6.0.0rc2 root version)

Full suite green: 868 passed, 12 skipped, 2 xfailed, 5 xpassed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated runtime compatibility requirements to support the newer `1.2.0rc1` release.
  - Updated the corresponding project documentation to keep installation and compatibility information aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->