### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ venv*
 .env
 openspec/
 sonar_plan.md
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Adds a macOS `.DS_Store` entry to `.gitignore`. Finder recreates these files in the repo root and package dirs, leaving the working tree perpetually dirty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added macOS-specific ignore rules to prevent `.DS_Store` files from being included in the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->