### PR TITLE
chore(smi): drop dead pysmi <2.0 compat shims from MIB compiler setup

### DIFF
--- a/pysnmp/smi/compiler.py
+++ b/pysnmp/smi/compiler.py
@@ -19,19 +19,9 @@ try:
     from pysmi.borrower.pyfile import PyFileBorrower
     from pysmi.codegen.pysnmp import PySnmpCodeGen, baseMibs
     from pysmi.compiler import MibCompiler
-
-    try:
-        from pysmi.parser.dialect import smi_v1_relaxed
-    except ImportError:  # pysmi < 2.0
-        from pysmi.parser.dialect import smiV1Relaxed as smi_v1_relaxed
-    try:
-        from pysmi.parser.smi import parser_factory
-    except ImportError:  # pysmi < 2.0
-        from pysmi.parser.smi import parserFactory as parser_factory
-    try:
-        from pysmi.reader.url import get_readers_from_urls
-    except ImportError:  # pysmi < 2.0
-        from pysmi.reader.url import getReadersFromUrls as get_readers_from_urls
+    from pysmi.parser.dialect import smiV1Relaxed
+    from pysmi.parser.smi import parserFactory
+    from pysmi.reader.url import getReadersFromUrls
     from pysmi.searcher.pypackage import PyPackageSearcher
     from pysmi.searcher.stub import StubSearcher
     from pysmi.writer.pyfile import PyFileWriter
@@ -55,23 +45,21 @@ else:
             return
 
         compiler = MibCompiler(
-            parser_factory(**smi_v1_relaxed)(),
+            parserFactory(**smiV1Relaxed)(),
             PySnmpCodeGen(),
             PyFileWriter(kwargs.get("destination") or defaultDest),
         )
 
-        add_sources = getattr(compiler, "add_sources", None) or compiler.addSources
-        add_searchers = getattr(compiler, "add_searchers", None) or compiler.addSearchers
-        add_borrowers = getattr(compiler, "add_borrowers", None) or compiler.addBorrowers
+        compiler.add_sources(*getReadersFromUrls(*kwargs.get("sources") or defaultSources))
 
-        add_sources(*get_readers_from_urls(*kwargs.get("sources") or defaultSources))
-
-        add_searchers(StubSearcher(*baseMibs))
-        add_searchers(*[PyPackageSearcher(x.fullPath()) for x in mibBuilder.getMibSources()])
-        add_borrowers(
+        compiler.add_searchers(StubSearcher(*baseMibs))
+        compiler.add_searchers(
+            *[PyPackageSearcher(x.fullPath()) for x in mibBuilder.getMibSources()]
+        )
+        compiler.add_borrowers(
             *[
                 PyFileBorrower(x, genTexts=mibBuilder.loadTexts)
-                for x in get_readers_from_urls(
+                for x in getReadersFromUrls(
                     *kwargs.get("borrowers") or defaultBorrowers, **dict(lowcaseMatching=False)
                 )
             ]


### PR DESCRIPTION
## What

Removes unreachable pysmi-version compatibility code from `pysnmp/smi/compiler.py`. No behaviour change.

## Why

**The `try/except ImportError` import blocks were inverted.** pysmi 2.0 renamed its public API to snake_case, but
`_aliases.py` walks *classes* — module-level functions and constants kept their camelCase spelling. Verified against
installed pysmi 2.0.1:

| import attempted | exists in 2.0.1 |
|---|---|
| `pysmi.parser.dialect.smi_v1_relaxed` | ✗ |
| `pysmi.parser.smi.parser_factory` | ✗ |
| `pysmi.reader.url.get_readers_from_urls` | ✗ |

So all three blocks always fell through to the branch commented `# pysmi < 2.0`, raising and swallowing an `ImportError`
each time. The comments asserted the opposite of what was happening.

**The `getattr` method fallbacks are dead code.** `add_sources` / `add_searchers` / `add_borrowers` *are* real methods on
`MibCompiler` in 2.x, and the `pysnmp-pysmi` floor is now `>=2.0.1` (#135), so the
`or compiler.addSources` arms can no longer be reached.

## Verification

- `addMibCompiler()` builds a working `MibCompiler` under `-W error::DeprecationWarning` — no deprecation warnings
- Full suite: 868 passed, 12 skipped, 2 xfailed, 5 xpassed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MIB compilation to work with the current `pysmi` interfaces.
  * Improved consistency when registering source, search, and borrowing providers.
  * Removed support for older `pysmi` compatibility paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->