### PR TITLE
fix(deps): release the pysnmp-pyasn1 1.2.0 and pysnmp-pysmi 2.0.1 floors

### DIFF
--- a/.github/copilot/copilot-instructions.md
+++ b/.github/copilot/copilot-instructions.md
@@ -185,6 +185,19 @@ This is a pure-Python SNMP v1/v2c/v3 engine. The package layout mirrors the SNMP
 - Match existing patterns for documenting breaking changes in `CHANGELOG.md` (Revision-header sections with bulleted notes)
 - Follow the same approach for deprecation notices
 
+### Commit message conventions
+
+Releases are cut by semantic-release with the Angular preset: only `feat`, `fix`, `perf` and `BREAKING CHANGE` produce a
+version. `chore`, `ci`, `docs`, `refactor`, `style` and `test` never do.
+
+- Runtime dependency changes are **`fix(deps):`**, not `chore(deps):`. Raising a floor in `[project].dependencies`
+  changes what users resolve and install, so it must ship as a release.
+  Example: `fix(deps): require pysnmp-pyasn1 >=1.2.0`
+- Development-only dependency changes (`[dependency-groups]`, pre-commit hooks, CI actions) stay `chore(deps):` or `ci:`
+  — they are invisible to installers.
+- A `chore(deps):` runtime bump merged to `next` or `main` will sit unreleased until an unrelated releasable commit
+  lands. Use the correct type up front rather than fixing it after the fact.
+
 ## General Best Practices
 
 - Follow naming conventions exactly as they appear in existing code:


### PR DESCRIPTION
## Problem

The runtime dependency floors raised on `next` were committed as `chore(deps)`. The Angular preset used by
semantic-release releases only `feat`, `fix`, `perf` and breaking changes, so all three bumps sat unreleased — the
manual CI dispatch on `next` correctly reported *"Analysis of 12 commits complete: no release"*.

Nothing was wrong with the workflow or `.releaserc`; pysnmp-pyasn1 uses the same bare `commit-analyzer` config and
releases only because its commits are typed `fix:` / `feat:`.

## Changes

- **`fix(deps)` commit** carrying the already-applied floors into a release:
  - `pysnmp-pyasn1 >=1.2.0b14` → `>=1.2.0,<2.0.0`
  - `pysnmp-pysmi >=2.0.0b2` → `>=2.0.1,<3.0.0`
- **Commit convention documented** in `.github/copilot/copilot-instructions.md`: runtime dependency bumps are
  `fix(deps):`, dev-only bumps stay `chore(deps):` / `ci:`.

No code or dependency-specifier changes — the specifiers are already correct on `next`, they just never shipped.

## Result

Merging cuts `v6.0.0-rc.3` and sweeps in the five other unreleased `chore` / `ci` commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for commit message conventions.
  * Documented release eligibility and rules for runtime versus development dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->