### PR TITLE
feat(smi): add setReference/getReference to conformance macro classes

### DIFF
--- a/pysnmp/smi/mibs/SNMPv2-CONF.py
+++ b/pysnmp/smi/mibs/SNMPv2-CONF.py
@@ -16,6 +16,7 @@ class ObjectGroup(MibNode):
     status = "current"
     objects = ()
     description = ""
+    reference = ""
 
     def getStatus(self):
         return self.status
@@ -39,6 +40,13 @@ class ObjectGroup(MibNode):
 
     def setDescription(self, v):
         self.description = v
+        return self
+
+    def getReference(self):
+        return self.reference
+
+    def setReference(self, v):
+        self.reference = v
         return self
 
     def asn1Print(self):
@@ -53,6 +61,7 @@ class NotificationGroup(MibNode):
     status = "current"
     objects = ()
     description = ""
+    reference = ""
 
     def getStatus(self):
         return self.status
@@ -76,6 +85,13 @@ class NotificationGroup(MibNode):
 
     def setDescription(self, v):
         self.description = v
+        return self
+
+    def getReference(self):
+        return self.reference
+
+    def setReference(self, v):
+        self.reference = v
         return self
 
     def asn1Print(self):
@@ -90,6 +106,7 @@ class ModuleCompliance(MibNode):
     status = "current"
     objects = ()
     description = ""
+    reference = ""
 
     def getStatus(self):
         return self.status
@@ -113,6 +130,13 @@ class ModuleCompliance(MibNode):
 
     def setDescription(self, v):
         self.description = v
+        return self
+
+    def getReference(self):
+        return self.reference
+
+    def setReference(self, v):
+        self.reference = v
         return self
 
     def asn1Print(self):

--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -122,6 +122,7 @@ class ModuleIdentity(MibNode):
     organization = ""
     contactInfo = ""
     description = ""
+    reference = ""
     revisions = ()
     revisionsDescriptions = ()
 
@@ -172,6 +173,13 @@ class ModuleIdentity(MibNode):
 
     def setRevisionsDescriptions(self, args):
         self.revisionsDescriptions = args
+        return self
+
+    def getReference(self):
+        return self.reference
+
+    def setReference(self, v):
+        self.reference = v
         return self
 
     def asn1Print(self):

--- a/tests/test_smi.py
+++ b/tests/test_smi.py
@@ -820,3 +820,31 @@ class TestCloneSubtypeSemantics:
         assert int(value) == 1
         assert value.namedValues[1] == "up"
         assert value.namedValues[2] == "down"
+
+
+class TestSmiReference:
+    """Every SMI/CONF macro class that RFC 2578/2580 allows a REFERENCE clause on."""
+
+    @pytest.mark.parametrize(
+        ("module", "symbol"),
+        [
+            ("SNMPv2-SMI", "ModuleIdentity"),
+            ("SNMPv2-SMI", "ObjectIdentity"),
+            ("SNMPv2-SMI", "NotificationType"),
+            ("SNMPv2-SMI", "MibScalar"),
+            ("SNMPv2-SMI", "MibTableColumn"),
+            ("SNMPv2-SMI", "MibTableRow"),
+            ("SNMPv2-CONF", "ObjectGroup"),
+            ("SNMPv2-CONF", "NotificationGroup"),
+            ("SNMPv2-CONF", "ModuleCompliance"),
+            ("SNMPv2-CONF", "AgentCapabilities"),
+        ],
+    )
+    def test_set_and_get_reference(self, mib_builder, module, symbol):
+        (cls,) = mib_builder.importSymbols(module, symbol)
+        oid = (1, 3, 6, 1, 4, 1, 99)
+        node = cls(oid, None) if symbol == "MibTableColumn" else cls(oid)
+
+        assert node.getReference() == ""
+        assert node.setReference("RFC 2580 section 3") is node
+        assert node.getReference() == "RFC 2580 section 3"


### PR DESCRIPTION
Closes #133

`ObjectGroup`, `NotificationGroup`, `ModuleCompliance` and `ModuleIdentity` had no `setReference()`/`getReference()`, so a MIB compiled with `--generate-mib-texts` raised `AttributeError: 'ObjectGroup' object has no attribute 'setReference'` at load time.

RFC 2580 defines `ReferPart` on OBJECT-GROUP (§3), NOTIFICATION-GROUP (§4) and MODULE-COMPLIANCE (§5). `ModuleIdentity` is included for symmetry even though RFC 2578 §5 gives MODULE-IDENTITY no REFERENCE clause.

Copies the existing accessor already present on `ObjectIdentity`, `NotificationType`, `ObjectType` and `AgentCapabilities`. `asn1Print()` is unchanged — the conformance renderers already omit STATUS, so REFERENCE was left out too.

Test: `TestSmiReference` in `tests/test_smi.py` parametrizes all ten macro classes that may carry REFERENCE.

Full suite (excluding the snmpsim/net-snmp integration modules): 851 passed, 1 skipped, 2 xfailed, 5 xpassed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for storing and retrieving reference information on module identities, object groups, notification groups, and module compliance definitions.
  - References default to an empty value and can be updated through the public API.

- **Tests**
  - Added coverage verifying default reference values, updates, and fluent setter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->