### PR TITLE
fix(deps): bump pysnmp-pyasn1 to 1.3.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 dependencies = [
     "pysnmp-pysmi >=2.0.1,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
-    "pysnmp-pyasn1 >=1.2.0,<2.0.0",
+    "pysnmp-pyasn1 >=1.3.0rc2,<2.0.0",
 ]
 
 [project.urls]

--- a/pysnmp/proto/api/verdec.py
+++ b/pysnmp/proto/api/verdec.py
@@ -30,8 +30,9 @@ def decodeMessageVersion(wholeMsg):
     except PyAsn1Error:
         raise ProtocolError("Invalid BER at SNMP version component")
     except (TypeError, ValueError) as exc:
-        # Malformed substrate can drive the BER decoder into paths that raise
-        # plain Python exceptions rather than PyAsn1Error. This is the first
-        # thing an untrusted datagram touches, so nothing but ProtocolError may
-        # escape here.
+        # Retained as defence in depth, not because a known input reaches it.
+        # pyasn1 used to let plain Python exceptions escape this substrateFun
+        # path (pyasn1 #140, #142, both fixed in 1.3.0rc2), and this is the
+        # first thing an untrusted datagram touches, so nothing but
+        # ProtocolError may escape here.
         raise ProtocolError(f"Malformed BER at SNMP version component: {exc}")

--- a/uv.lock
+++ b/uv.lock
@@ -837,11 +837,11 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pyasn1"
-version = "1.2.0"
+version = "1.3.0rc2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/71/b095c62daf8d11bdc37cbc8896aa2efa2ddd877f83979e2b0f5c3c3e1145/pysnmp_pyasn1-1.2.0.tar.gz", hash = "sha256:3748dc9d72572c268a442a1a27609fbb1f788997082c4343e756de56ff87ccc6", size = 285280, upload-time = "2026-09-03T02:12:44.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/b9/307ea66da7c8706d2617a39ab84c17b3c4e0c96c2a7efa8b3f7cfc592e02/pysnmp_pyasn1-1.3.0rc2.tar.gz", hash = "sha256:8f6126f0424bac68ff3ce2e99fab7de5b0385fd31a688ff50e983b72250004fb", size = 313842, upload-time = "2026-09-05T15:10:35.703Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/9d/08c0889a189a67ba523960ac645381d4794c5ee8146f6952c33ff4930365/pysnmp_pyasn1-1.2.0-py3-none-any.whl", hash = "sha256:7f96290ce7f2c21615c1ffab76aea0b008aacdff6842193fc157681302bb53db", size = 102199, upload-time = "2026-09-03T02:12:42.678Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/17/24505c02677936ee3a8f8ea09b26e0358dfbe7b90a3a75ec94bc05915564/pysnmp_pyasn1-1.3.0rc2-py3-none-any.whl", hash = "sha256:d38cbb4ac2d3a1c13d3330245ffc59dc0f4fa120e7617684ddb3438dae034c65", size = 108664, upload-time = "2026-09-05T15:10:34.374Z" },
 ]
 
 [[package]]
@@ -859,7 +859,7 @@ wheels = [
 
 [[package]]
 name = "pysnmplib"
-version = "6.0.0rc2"
+version = "6.0.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "pycryptodomex" },
@@ -882,7 +882,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.2.0,<8.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0,<3.0.0" },
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
-    { name = "pysnmp-pyasn1", specifier = ">=1.2.0,<2.0.0" },
+    { name = "pysnmp-pyasn1", specifier = ">=1.3.0rc2,<2.0.0" },
     { name = "pysnmp-pysmi", specifier = ">=2.0.1,<3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0,<1.0.0" },


### PR DESCRIPTION
Bumps the runtime constraint to `pysnmp-pyasn1 >=1.3.0rc1,<2.0.0`.

The explicit prerelease in the specifier is what lets pip pick up `1.3.0rc1`; verified with a plain `pip install -e ".[dev]"` in a clean venv (resolves to `1.3.0-rc.1`).

## Local CI run (out of CI credits, everything below run on this machine)

| Job | Result |
| --- | --- |
| Unit Tests 3.10 / 3.11 / 3.12 / 3.13 / 3.14 | 868 passed, 12 skipped, 2 xfailed, 5 xpassed on each |
| Coverage (3.12) | 67% total, gate is `fail_under = 63` |
| pre-commit (ruff-check, ruff-format) | passed |
| Docs Build (`sphinx -W`) | build succeeded |
| Net-SNMP Integration: v1, v2c, v3-noauth, v3-sha, v3-des, v3-aes | all 6 profiles passed |
| Semgrep | run locally with `p/default` + `p/python`; only pre-existing findings in `pysnmp/smi/builder.py` and `tools/iana_pen_to_mib.py`, both untouched by this change |

CodeQL was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the supported `pysnmp-pyasn1` dependency range to require version 1.3.0rc2 or later while retaining compatibility with versions below 2.0.0.
  * Refined defensive handling documentation for message version decoding; runtime behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->