### PR TITLE
refactor(proto): drop dead TypeCoercionHackMixIn

### DIFF
--- a/pysnmp/proto/rfc1155.py
+++ b/pysnmp/proto/rfc1155.py
@@ -122,20 +122,7 @@ class ObjectName(univ.ObjectIdentifier):
     pass
 
 
-class TypeCoercionHackMixIn:  # XXX keep this old-style class till pyasn1 types becomes new-style
-    # Reduce ASN1 type check to simple tag check as SMIv2 objects may
-    # not be constraints-compatible with those used in SNMP PDU.
-    def _verifyComponent(self, idx, value, **kwargs):
-        componentType = self._componentType
-        if componentType:
-            if idx >= len(componentType):
-                raise PyAsn1Error("Component type error out of range")
-            t = componentType[idx].getType()
-            if not t.tagSet.isSuperTagSetOf(value.tagSet):
-                raise PyAsn1Error(f"Component type error {t!r} vs {value!r}")
-
-
-class SimpleSyntax(TypeCoercionHackMixIn, univ.Choice):
+class SimpleSyntax(univ.Choice):
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("number", univ.Integer()),
         namedtype.NamedType("string", univ.OctetString()),
@@ -144,7 +131,7 @@ class SimpleSyntax(TypeCoercionHackMixIn, univ.Choice):
     )
 
 
-class ApplicationSyntax(TypeCoercionHackMixIn, univ.Choice):
+class ApplicationSyntax(univ.Choice):
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("address", NetworkAddress()),
         namedtype.NamedType("counter", Counter()),

--- a/pysnmp/proto/rfc1902.py
+++ b/pysnmp/proto/rfc1902.py
@@ -5,7 +5,7 @@
 #
 from pyasn1.type import constraint, namedtype, namedval, tag, univ
 
-from pysnmp.proto import error, rfc1155
+from pysnmp.proto import error
 
 __all__ = [
     "Opaque",
@@ -689,7 +689,7 @@ class ObjectName(univ.ObjectIdentifier):
     pass
 
 
-class SimpleSyntax(rfc1155.TypeCoercionHackMixIn, univ.Choice):
+class SimpleSyntax(univ.Choice):
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("integer-value", Integer()),
         namedtype.NamedType("string-value", OctetString()),
@@ -697,7 +697,7 @@ class SimpleSyntax(rfc1155.TypeCoercionHackMixIn, univ.Choice):
     )
 
 
-class ApplicationSyntax(rfc1155.TypeCoercionHackMixIn, univ.Choice):
+class ApplicationSyntax(univ.Choice):
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("ipAddress-value", IpAddress()),
         namedtype.NamedType("counter-value", Counter32()),

--- a/pysnmp/proto/secmod/rfc3414/service.py
+++ b/pysnmp/proto/secmod/rfc3414/service.py
@@ -13,7 +13,7 @@ from pyasn1.type import constraint, namedtype, univ
 
 from pysnmp import debug
 from pysnmp.entity.observer import execution_context
-from pysnmp.proto import api, errind, error, rfc1155, rfc3411
+from pysnmp.proto import api, errind, error, rfc3411
 from pysnmp.proto.secmod.base import AbstractSecurityModel
 from pysnmp.proto.secmod.rfc3414.auth import hmacmd5, hmacsha, noauth
 from pysnmp.proto.secmod.rfc3414.priv import des, nopriv
@@ -55,7 +55,7 @@ def _run_or_raise_serialization_error(operation: Callable[[], _T], logLabel: str
 # USM security params
 
 
-class UsmSecurityParameters(rfc1155.TypeCoercionHackMixIn, univ.Sequence):
+class UsmSecurityParameters(univ.Sequence):
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("msgAuthoritativeEngineId", univ.OctetString()),
         namedtype.NamedType(


### PR DESCRIPTION
`TypeCoercionHackMixIn` overrides `_verifyComponent`, a pyasn1 hook deleted in pyasn1 commit `26d4988` (2017). The override has not been called in nine years.

Verified dead before removing: no caller anywhere in pyasn1 or pysnmp, and a runtime probe patching the method to raise recorded zero invocations across the full suite.

Removes the class and drops it from the five base-class lists that inherited it:
- `rfc1155.SimpleSyntax`, `rfc1155.ApplicationSyntax`
- `rfc1902.SimpleSyntax`, `rfc1902.ApplicationSyntax`
- `secmod/rfc3414/service.py`

The stale `XXX keep this old-style class till pyasn1 types becomes new-style` comment goes with it.

Unit matrix 3.10–3.14 unchanged: 868 passed, 12 skipped, 2 xfailed, 5 xpassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated SNMP protocol and security parameter types to use standard ASN.1 choice and sequence handling.
  - Removed custom type-coercion and component-verification behavior from these protocol structures.
  - Existing choice definitions and security parameter fields remain unchanged, while validation and value handling now follow the underlying ASN.1 library’s standard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->