### PR TITLE
refactor(error): derive PySnmpError cause from exception chaining

### DIFF
--- a/.github/copilot/copilot-instructions.md
+++ b/.github/copilot/copilot-instructions.md
@@ -165,7 +165,7 @@ This is a pure-Python SNMP v1/v2c/v3 engine. The package layout mirrors the SNMP
 
 ## Error Handling Patterns
 
-- The base exception is `pysnmp.error.PySnmpError` (`pysnmp/error.py`); it captures `sys.exc_info()` as `.cause` and appends `caused by ...` to the message. Let this base class carry cause context rather than reimplementing it.
+- The base exception is `pysnmp.error.PySnmpError` (`pysnmp/error.py`); it exposes the chained exception as `.cause` (a `sys.exc_info()`-shaped triple, derived from `__cause__`/`__context__`) and appends `caused by ...` to `str()`. Let this base class carry cause context rather than reimplementing it, and use plain `raise ... from exc` or a bare `raise` inside an `except` block to set it.
 - SNMP v3 protocol errors derive from `ProtocolError(PySnmpError, PyAsn1Error)` in `proto/error.py`; SMI errors derive from `SmiError(PySnmpError, PyAsn1Error)` in `smi/error.py`; transport errors derive from `CarrierError(PySnmpError)` in `carrier/error.py`.
 - `ErrorIndication` (`proto/errind.py`) is a separate `Exception` hierarchy for SNMP error-indication values; instances are compared by string value and carry a `.prettyPrint()`-style description.
 - Abstract base classes raise `error.ProtocolError('method not implemented')` for unimplemented methods (see `proto/mpmod/base.py`, `proto/secmod/base.py`). Follow this when adding new abstract methods.

--- a/pysnmp/error.py
+++ b/pysnmp/error.py
@@ -4,8 +4,6 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
-import sys
-
 
 class PySnmpCryptoWarning(UserWarning):
     """Base class for warnings about SNMPv3 cryptographic protocol selection.
@@ -26,15 +24,33 @@ class PySnmpNonStandardCryptoWarning(PySnmpCryptoWarning):
 
 
 class PySnmpError(Exception):
-    def __init__(self, *args):
-        msg = args and str(args[0]) or ""
+    """Base class for pysnmp exceptions.
 
-        self.cause = sys.exc_info()
+    Carries the exception it was raised from, if any, into its own string
+    form, so a caller that only logs `str(exc)` still sees the underlying
+    failure.
+    """
 
-        if self.cause[0]:
-            msg += f"caused by {self.cause[0]}: {self.cause[1]}"
+    @property
+    def _chained(self) -> BaseException | None:
+        return self.__cause__ or self.__context__
 
-        if msg:
-            args = (msg,) + args[1:]
+    @property
+    def cause(self) -> tuple:
+        """The chained exception as a `sys.exc_info()`-shaped triple.
 
-        super().__init__(*args)
+        Empty triple when this exception was not raised while another was
+        being handled.
+        """
+        cause = self._chained
+        if cause is None:
+            return (None, None, None)
+        return (type(cause), cause, cause.__traceback__)
+
+    def __str__(self) -> str:
+        msg = super().__str__()
+        cause = self._chained
+        if cause is None:
+            return msg
+        suffix = f"caused by {type(cause).__name__}: {cause}"
+        return f"{msg}, {suffix}" if msg else suffix

--- a/tests/test_char_comparison_contract.py
+++ b/tests/test_char_comparison_contract.py
@@ -148,11 +148,6 @@ class TestObjectIdentityComparison:
     def test_lt(self, resolved_oid, resolved_oid2):
         assert resolved_oid < resolved_oid2
 
-    @pytest.mark.xfail(
-        reason="BUG: ObjectIdentity.__le__ delegates to < instead of <=. "
-        "For equal OIDs, < returns False but <= should return True. "
-        "Fixed by total_ordering in Phase 5."
-    )
     def test_le_equal(self, resolved_oid):
         oid2 = ObjectIdentity("1.3.6.1.2.1.1.1.0")
         mibBuilder = builder.MibBuilder()
@@ -169,25 +164,10 @@ class TestObjectIdentityComparison:
     def test_ge_greater(self, resolved_oid, resolved_oid2):
         assert resolved_oid2 >= resolved_oid
 
-    @pytest.mark.xfail(
-        reason="BUG: ObjectIdentity.__ge__ delegates to > instead of >=. "
-        "For equal OIDs, > returns False but >= should return True. "
-        "Fixed by total_ordering in Phase 5."
-    )
     def test_ge_equal(self, resolved_oid):
-        """__ge__ should use >=, not >. With equal OIDs, >= is True but > is False.
-
-        This is the KNOWN BUG: ObjectIdentity.__ge__ currently delegates to
-        > instead of >=. This test documents the bug and will pass AFTER
-        total_ordering is applied (which synthesizes correct __ge__).
-        """
+        """__ge__ must use >=, not >: for equal OIDs it is True where > is False."""
         oid2 = ObjectIdentity("1.3.6.1.2.1.1.1.0")
         mibBuilder = builder.MibBuilder()
         mibView = view.MibViewController(mibBuilder)
         oid2.resolveWithMib(mibView)
-        result = resolved_oid >= oid2
-        assert result, (
-            "ObjectIdentity.__ge__ returns False for equal OIDs. "
-            "This is the known bug — __ge__ delegates to > instead of >=. "
-            "total_ordering will fix this."
-        )
+        assert resolved_oid >= oid2

--- a/tests/test_error_cause.py
+++ b/tests/test_error_cause.py
@@ -1,0 +1,115 @@
+"""Regression tests for PySnmpError cause attribution.
+
+PySnmpError used to snapshot sys.exc_info() in __init__, which reports the
+exception being handled anywhere up the stack at construction time — not the
+one this error was raised from. Constructing an error inside an unrelated
+except block therefore glued a stranger's exception onto the message.
+
+Cause now derives from __cause__/__context__, which Python sets at raise time.
+"""
+
+import pytest
+
+from pysnmp.error import PySnmpError
+
+
+class TestUnchainedError:
+    """An error with no chained exception reports none."""
+
+    def test_str_is_just_the_message(self):
+        assert str(PySnmpError("bad config")) == "bad config"
+
+    def test_cause_is_empty_triple(self):
+        assert PySnmpError("bad config").cause == (None, None, None)
+
+    def test_no_args(self):
+        assert str(PySnmpError()) == ""
+
+    def test_constructed_inside_unrelated_except_block(self):
+        """Construction is not a raise; a handled exception is not our cause."""
+        try:
+            raise ValueError("unrelated parsing failure")
+        except ValueError:
+            exc = PySnmpError("bad config")
+        assert str(exc) == "bad config"
+        assert exc.cause == (None, None, None)
+
+    def test_caller_further_up_is_handling_an_exception(self):
+        try:
+            raise OSError("socket closed")
+        except OSError:
+            exc = PySnmpError("bad config")
+        assert str(exc) == "bad config"
+
+
+class TestChainedError:
+    """An error raised while handling another reports that one."""
+
+    def test_implicit_context(self):
+        with pytest.raises(PySnmpError) as info:
+            try:
+                raise ValueError("bad BER")
+            except ValueError:
+                raise PySnmpError("decode failed")
+        assert str(info.value) == "decode failed, caused by ValueError: bad BER"
+        assert info.value.cause[0] is ValueError
+
+    def test_explicit_from(self):
+        with pytest.raises(PySnmpError) as info:
+            try:
+                raise KeyError("nope")
+            except KeyError as exc:
+                raise PySnmpError("lookup failed") from exc
+        assert info.value.cause[0] is KeyError
+
+    def test_explicit_from_outranks_context(self):
+        chosen = TypeError("the real cause")
+        with pytest.raises(PySnmpError) as info:
+            try:
+                raise ValueError("incidental")
+            except ValueError:
+                raise PySnmpError("failed") from chosen
+        assert info.value.cause[1] is chosen
+
+    def test_cause_triple_carries_traceback(self):
+        with pytest.raises(PySnmpError) as info:
+            try:
+                raise ValueError("bad BER")
+            except ValueError:
+                raise PySnmpError("decode failed")
+        kind, value, traceback = info.value.cause
+        assert kind is ValueError
+        assert isinstance(value, ValueError)
+        assert traceback is value.__traceback__
+
+    def test_message_omitted_when_error_has_no_args(self):
+        with pytest.raises(PySnmpError) as info:
+            try:
+                raise ValueError("bad BER")
+            except ValueError:
+                raise PySnmpError
+        assert str(info.value) == "caused by ValueError: bad BER"
+
+
+class TestSubclasses:
+    """Cause handling reaches the subclasses that inherit it."""
+
+    def test_smi_error(self):
+        from pysnmp.smi.error import SmiError
+
+        with pytest.raises(SmiError) as info:
+            try:
+                raise ValueError("no such module")
+            except ValueError:
+                raise SmiError("MIB load failed")
+        assert info.value.cause[0] is ValueError
+
+    def test_protocol_error(self):
+        from pysnmp.proto.error import ProtocolError
+
+        with pytest.raises(ProtocolError) as info:
+            try:
+                raise ValueError("truncated")
+            except ValueError:
+                raise ProtocolError("bad PDU")
+        assert "caused by ValueError: truncated" in str(info.value)


### PR DESCRIPTION
`PySnmpError.__init__` snapshotted `sys.exc_info()` at construction time. That returns whichever exception is being handled *anywhere up the stack*, not the one this error was raised from — so constructing an error inside an unrelated except block attached a stranger to the message:

```python
try:
    raise ValueError('unrelated parsing failure')
except ValueError:
    exc = PySnmpError('bad config')

str(exc)  # "bad configcaused by <class 'ValueError'>: unrelated parsing failure"
```

Same result whenever any caller further up the stack was mid-`except`. pyasn1 fixed this identical pattern in `ObjectIdentifier.prettyIn` (part of the 1.3.0 delta).

**Change:** `.cause` becomes a property over `__cause__`/`__context__` — set by Python at *raise* time — and keeps its `sys.exc_info()`-shaped triple, so existing readers are unaffected. Genuine chaining still reaches `str()`, now with the missing separator and without the class repr:

| | before | after |
|---|---|---|
| unchained | `'bad config'` | `'bad config'` |
| built in unrelated `except` | `"bad configcaused by <class 'ValueError'>: ..."` | `'bad config'` |
| raised from `ValueError` | `"decode failedcaused by <class 'ValueError'>: bad BER"` | `'decode failed, caused by ValueError: bad BER'` |

The old `args and str(args[0]) or ""` idiom goes with the removed `__init__`.

Also removes the two stale `xfail` markers on `ObjectIdentity.__le__`/`__ge__` (fixed by `total_ordering`, both XPASS), and corrects the copilot instruction that documented the `sys.exc_info()` behaviour.

Adds `tests/test_error_cause.py` — 12 tests over unchained, implicit-context, `raise ... from`, traceback identity, and the `SmiError`/`ProtocolError` subclasses.

Local: 882 passed, 12 skipped on 3.10/3.13/3.14. Remaining 2 xfail / 3 xpass in `test_char_clone_falsy.py` are #158's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting by preserving the original cause of chained exceptions.
  - Error messages now include relevant underlying exception details when available.
  - Prevented unrelated previously handled exceptions from being reported as causes.
  - Preserved traceback information across common error types.

- **Tests**
  - Added coverage for implicit and explicit exception chaining, empty messages, traceback preservation, and propagated causes.
  - Activated comparison checks for equal object identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->