### PR TITLE
docs(rfc1902): stop demonstrating str() on OctetString

### DIFF
--- a/.github/copilot/copilot-instructions.md
+++ b/.github/copilot/copilot-instructions.md
@@ -27,7 +27,7 @@ Before generating code, scan the codebase to identify:
    - Never suggest features not available in the detected framework versions
 
 3. **Library Versions**: Note the exact versions of key libraries and dependencies
-   - Runtime dependencies (from `pyproject.toml`): `pysnmp-pysmi >=2.0.1,<3.0.0`, `pycryptodomex >=3.11.0,<4.0.0`, `pysnmp-pyasn1 >=1.2.0,<2.0.0`
+   - Runtime dependencies (from `pyproject.toml`): `pysnmp-pysmi >=2.0.1,<3.0.0`, `pycryptodomex >=3.11.0,<4.0.0`, `pysnmp-pyasn1 >=1.3.0rc2,<2.0.0`
    - Dev dependencies (from `pyproject.toml` `[project.optional-dependencies]`): `sphinx >=7.0.0,<9.0.0`, `pytest >=9.0.3,<10.0.0`, `coverage[toml] >=7.2.0,<8.0.0`, `mypy >=1.15.0,<3.0.0`, `ruff >=0.4.0,<1.0.0`
    - Generate code compatible with these specific versions
    - The project depends on the **pysnmp-pyasn1** fork, not upstream pyasn1. Import from `pyasn1.type`, `pyasn1.codec.ber`, `pyasn1.error`, and `pyasn1.compat.octets` as seen throughout `pysnmp/proto/` and `pysnmp/smi/`

--- a/pysnmp/proto/rfc1902.py
+++ b/pysnmp/proto/rfc1902.py
@@ -179,7 +179,7 @@ class Integer(Integer32):
 
 
 class OctetString(univ.OctetString):
-    """Creates an instance of SNMP OCTET STRING class.
+    r"""Creates an instance of SNMP OCTET STRING class.
 
     The :py:class:`~pysnmp.proto.rfc1902.OctetString` type represents
     arbitrary binary or text data (:RFC:`1902#section-7.1.2`).
@@ -209,11 +209,15 @@ class OctetString(univ.OctetString):
         OctetString('some apples')
         >>> OctetString('some apples') + ' and oranges'
         OctetString('some apples and oranges')
-        >>> str(OctetString('some apples'))
+        >>> OctetString('some apples').asOctets()
+        b'some apples'
+        >>> OctetString('some apples').prettyPrint()
         'some apples'
         >>> SomeString = OctetString.withSize(3, 12)
-        >>> str(SomeString(hexValue='deadbeef'))
-        '\xde\xad\xbe\xef'
+        >>> SomeString(hexValue='deadbeef').asOctets()
+        b'\xde\xad\xbe\xef'
+        >>> SomeString(hexValue='deadbeef').prettyPrint()
+        '0xdeadbeef'
         >>>
 
     """
@@ -291,7 +295,7 @@ class ObjectIdentifier(univ.ObjectIdentifier):
 
 
 class IpAddress(OctetString):
-    """Creates an instance of SNMP IpAddress class.
+    r"""Creates an instance of SNMP IpAddress class.
 
     The :py:class:`~pysnmp.proto.rfc1902.IpAddress` class represents
     a 32-bit internet address as an OCTET STRING of length 4, in network
@@ -313,8 +317,10 @@ class IpAddress(OctetString):
         >>> from pysnmp.proto.rfc1902 import *
         >>> IpAddress('127.0.0.1')
         IpAddress(hexValue='7f000001')
-        >>> str(IpAddress(hexValue='7f000001'))
-        '\x7f\x00\x00\x01'
+        >>> IpAddress(hexValue='7f000001').prettyPrint()
+        '127.0.0.1'
+        >>> IpAddress(hexValue='7f000001').asOctets()
+        b'\x7f\x00\x00\x01'
         >>> IpAddress('\x7f\x00\x00\x01')
         IpAddress(hexValue='7f000001')
         >>>
@@ -496,7 +502,7 @@ class TimeTicks(univ.Integer):
 
 
 class Opaque(univ.OctetString):
-    """Creates an instance of SNMP Opaque class.
+    r"""Creates an instance of SNMP Opaque class.
 
     The :py:class:`~pysnmp.proto.rfc1902.Opaque` type supports the
     capability to pass arbitrary ASN.1 syntax.  A value is encoded
@@ -528,10 +534,14 @@ class Opaque(univ.OctetString):
         Opaque('some apples')
         >>> Opaque('some apples') + ' and oranges'
         Opaque('some apples and oranges')
-        >>> str(Opaque('some apples'))
+        >>> Opaque('some apples').asOctets()
+        b'some apples'
+        >>> Opaque('some apples').prettyPrint()
         'some apples'
-        >>> str(Opaque(hexValue='deadbeef'))
-        '\xde\xad\xbe\xef'
+        >>> Opaque(hexValue='deadbeef').asOctets()
+        b'\xde\xad\xbe\xef'
+        >>> Opaque(hexValue='deadbeef').prettyPrint()
+        '0xdeadbeef'
         >>>
 
     """


### PR DESCRIPTION
Closes #153.

pyasn1 1.2 deprecated `str()` on `OctetString` and `Any`. The class docstrings for `OctetString`, `IpAddress` and `Opaque` taught it as *the* way to read a value, so anyone copying an example inherits a `DeprecationWarning` — which this repo's `filterwarnings` promotes to an error.

Examples now show the two supported accessors:

```
>>> IpAddress(hexValue='7f000001').prettyPrint()
'127.0.0.1'
>>> IpAddress(hexValue='7f000001').asOctets()
b'\x7f\x00\x00\x01'
```

More useful than the old `str()` output, which was the four raw bytes.

`str(ObjectIdentifier(...))` and `str(ObjectType(...))` are left alone — neither is deprecated.

**Also:** those three docstrings were not raw, so they interpreted their own `\xde\xad\xbe\xef` examples — the built docs carried literal high bytes, and `IpAddress` embedded NUL characters. Verified: zero non-printable characters in all three docstrings now.

Refreshes the `pysnmp-pyasn1` version in the copilot notes, stale since #152.

Local: 868 passed, 12 skipped. Sphinx `-W` clean.

---

Separately — running the doctests to check this turned up **31 pre-existing failures** in this module alone, unrelated to the change. Every `repr()` example is stale (`Integer32(1234)` now renders as `<Integer32 value object, payload [1234]>`), and one example asserts `Integer32(1) > 2` is `True`. Doctests are not in CI, so they rotted. Filing separately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated runtime compatibility guidance to require `pysnmp-pyasn1` version 1.3.0rc2 or newer, while retaining the existing version limit.
  - Revised `OctetString`, `IpAddress`, and `Opaque` examples to use clearer byte and hexadecimal output methods.
  - Improved documentation formatting for these type examples to make expected output easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->