### PR TITLE
fix(smi): accept numeric input for integer TCs carrying a DISPLAY-HINT

### DIFF
--- a/pysnmp/smi/mibs/SNMPv2-TC.py
+++ b/pysnmp/smi/mibs/SNMPv2-TC.py
@@ -219,10 +219,17 @@ class TextualConvention:
 
         if self.displayHint and (
             self.__integer.isSuperTypeOf(self, matchConstraints=False)
-            and self.namedValues
+            and not self.namedValues
             or self.__unsigned32.isSuperTypeOf(self, matchConstraints=False)
             or self.__timeticks.isSuperTypeOf(self, matchConstraints=False)
         ):
+            # A DISPLAY-HINT governs presentation; it does not narrow the set of
+            # values the type accepts. Numeric input is what BER decoding and
+            # clone() hand over, so it goes straight to the base type. Only text
+            # is parsed against the hint below.
+            if isinstance(value, (int, univ.Integer)):
+                return base.prettyIn(self, int(value))
+
             value = str(value)
 
             displayHintType, decimalPrecision = (tuple(self.displayHint.split("-")) + (0,))[:2]
@@ -246,16 +253,11 @@ class TextualConvention:
                     raise SmiError("octal evaluation error: %s" % e)
             elif displayHintType == "b" and (value.startswith("B") or value.startswith("-B")):
                 negative = value.startswith("-")
-                if negative:
-                    value = value[2:]
-                else:
-                    value = value[1:]
-                value = [x != "0" and 1 or 0 for x in value]
-                binValue = 0
-                while value:
-                    binValue <<= value[0]
-                    del value[0]
-                return base.prettyIn(self, binValue)
+                try:
+                    binValue = int(value[2:] if negative else value[1:], 2)
+                except Exception as e:
+                    raise SmiError("binary evaluation error: %s" % e)
+                return base.prettyIn(self, -binValue if negative else binValue)
             else:
                 raise SmiError(
                     f'Unsupported numeric type spec "{displayHintType}" at {self.__class__.__name__}'

--- a/tests/test_smi.py
+++ b/tests/test_smi.py
@@ -848,3 +848,75 @@ class TestSmiReference:
         assert node.getReference() == ""
         assert node.setReference("RFC 2580 section 3") is node
         assert node.getReference() == "RFC 2580 section 3"
+
+
+class TestTextualConventionPrettyIn:
+    """A DISPLAY-HINT governs presentation; it must not narrow accepted input.
+
+    Regression test for #150: an integer-valued TEXTUAL-CONVENTION carrying
+    DISPLAY-HINT "x", "o" or "b" rejected every numeric input, which broke BER
+    decoding of any object using such a TC.
+    """
+
+    @pytest.fixture
+    def subscriber_label(self, mib_builder):
+        """CISCO-SUBSCRIBER-IDENTITY-TC-MIB's SubscriberLabel, in miniature."""
+        (TextualConvention,) = mib_builder.importSymbols("SNMPv2-TC", "TextualConvention")
+        (Unsigned32,) = mib_builder.importSymbols("SNMPv2-SMI", "Unsigned32")
+
+        class SubscriberLabel(TextualConvention, Unsigned32):
+            displayHint = "x"
+            subtypeSpec = Unsigned32.subtypeSpec + ValueRangeConstraint(0, 4294967295)
+
+        return SubscriberLabel
+
+    @pytest.mark.parametrize("value", [0, 255, 4294967295])
+    def test_accepts_integers(self, subscriber_label, value):
+        assert int(subscriber_label(value)) == value
+
+    def test_accepts_pyasn1_integers(self, subscriber_label):
+        assert int(subscriber_label(Integer32(255))) == 255
+
+    def test_clone_accepts_integers(self, subscriber_label):
+        assert int(subscriber_label("0x5").clone(7)) == 7
+
+    def test_ber_round_trip(self, subscriber_label):
+        from pyasn1.codec.ber import decoder, encoder
+
+        decoded, _ = decoder.decode(
+            encoder.encode(subscriber_label(9)), asn1Spec=subscriber_label()
+        )
+        assert int(decoded) == 9
+
+    def test_hex_text_still_parses(self, subscriber_label):
+        assert int(subscriber_label("0xff")) == 255
+
+    def test_prettyOut_round_trips_through_prettyIn(self, subscriber_label):
+        rendered = subscriber_label(255).prettyPrint()
+        assert rendered == "0xff"
+        assert int(subscriber_label(rendered)) == 255
+
+    def test_binary_hint_accumulates_digits(self, mib_builder):
+        """The "b" branch shifted by each digit instead of by one, so it
+        always evaluated to zero, and dropped the sign it had computed."""
+        (TextualConvention,) = mib_builder.importSymbols("SNMPv2-TC", "TextualConvention")
+
+        class BinaryTC(TextualConvention, Integer32):
+            displayHint = "b"
+
+        assert int(BinaryTC("B1011")) == 11
+        assert int(BinaryTC("-B1011")) == -11
+        assert int(BinaryTC(11)) == 11
+
+    def test_enumerated_integer_ignores_display_hint(self, mib_builder):
+        """RFC 2579 forbids DISPLAY-HINT on an enumerated INTEGER. prettyOut
+        already ignored the hint for one; prettyIn did the opposite."""
+        (TextualConvention,) = mib_builder.importSymbols("SNMPv2-TC", "TextualConvention")
+
+        class EnumTC(TextualConvention, Integer32):
+            displayHint = "x"
+            namedValues = NamedValues(("up", 1), ("down", 2))
+            subtypeSpec = Integer32.subtypeSpec + SingleValueConstraint(1, 2)
+
+        assert int(EnumTC("up")) == 1
+        assert int(EnumTC(2)) == 2


### PR DESCRIPTION
Closes #150.

## The defect

`TextualConvention.prettyIn()` coerced its argument to `str` and then dispatched on a textual prefix:

```python
value = str(value)
if displayHintType == "x" and (value.startswith("0x") or value.startswith("-0x")):
    ...
else:
    raise SmiError(f'Unsupported numeric type spec "{displayHintType}" ...')
```

`str(255)` is `"255"`, which matches no prefix. So an integer-valued TC with `DISPLAY-HINT "x"`, `"o"` or `"b"` accepted only the string form it had itself rendered:

```
SubscriberLabel(255)    -> SmiError: Unsupported numeric type spec "x"
SubscriberLabel('0xff') -> ok
```

BER decoding constructs from an integer, so any object using such a TC could not be decoded off the wire. `clone()` failed the same way, which with pysmi 2.0.x makes `CISCO-SUBSCRIBER-SESSION-MIB` fail to import outright — it emits its `DEFVAL { 0 }` as `SubscriberLabel().clone(0)`.

## The fix

A DISPLAY-HINT governs presentation; it does not narrow the set of values the type accepts. Numeric input now goes straight to the base type, and only text is parsed against the hint.

## Two more defects in the same branch

Both are unambiguously wrong and sit inside the code being changed, so they are fixed here rather than filed:

**The `"b"` parser always evaluated to zero.** It accumulated with `binValue <<= value[0]` — shifting by the digit rather than by one, and never OR-ing the digit in. It also computed `negative` and never applied it, so `"-B1011"` came back positive. Replaced by `int(digits, 2)`, which is shorter and correct.

**`prettyIn` and `prettyOut` disagreed on enumerations.** `prettyIn` required `namedValues` to be present before parsing an integer hint; `prettyOut` requires them to be *absent*. RFC 2579 forbids a DISPLAY-HINT on an enumerated INTEGER, so `prettyOut` had it right. `prettyIn` now matches, which means an (non-conformant) enumerated TC carrying a hint resolves its names instead of raising.

## Not fixed here

`prettyOut` renders the `"b"` hint with a trailing marker (`"101B"`) while `prettyIn` expects a leading one (`"B101"`), so that hint does not round-trip as text. Nobody has reported it and changing either side is a visible behaviour change, so it is left alone.

## Tests

`TestTextualConventionPrettyIn` in `tests/test_smi.py`, built on a miniature of the real `CISCO-SUBSCRIBER-IDENTITY-TC-MIB` TC. Verified red before green: 9 of the 10 cases fail against the unpatched module (the tenth asserts the pre-existing `"0xff"` behaviour is preserved, and passes both ways).

Full suite: 910 passed, 12 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Integer-valued textual conventions now correctly handle integer and ASN.1 integer inputs without misinterpreting them as formatted display text.
  - Binary display hints now preserve negative values and provide consistent parsing errors.
  - Enumerated integer values continue to behave correctly regardless of display hints.

- **Tests**
  - Added coverage for hexadecimal and binary formatting, cloning, encoding round trips, signed values, and formatted input/output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->