### PR TITLE
fix(smi): let transport-address TCs use the TEXTUAL-CONVENTION machinery

### DIFF
--- a/pysnmp/smi/mibs/SNMPv2-TM.py
+++ b/pysnmp/smi/mibs/SNMPv2-TM.py
@@ -76,13 +76,16 @@ class SnmpUDPAddress(TextualConvention, OctetString):
 
     def prettyIn(self, value):
         if isinstance(value, tuple):
-            # Wild hack -- need to implement TextualConvention.prettyIn
+            # A Python socket address, the counterpart of __asSocketAddress
+            # below. Address-family specific, so it stays here; everything
+            # else, the DISPLAY-HINT text form included, belongs to
+            # TextualConvention.prettyIn.
             value = (
                 inet_pton(AF_INET, value[0])
                 + bytes(((value[1] >> 8) & 0xFF,))
                 + bytes((value[1] & 0xFF,))
             )
-        return OctetString.prettyIn(self, value)
+        return super().prettyIn(value)
 
     # Socket address syntax coercion
     def __asSocketAddress(self):

--- a/pysnmp/smi/mibs/TRANSPORT-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/TRANSPORT-ADDRESS-MIB.py
@@ -355,13 +355,16 @@ class TransportAddressIPv4(TextualConvention, OctetString):
 
     def prettyIn(self, value):
         if isinstance(value, tuple):
-            # Wild hack -- need to implement TextualConvention.prettyIn
+            # A Python socket address, the counterpart of __asSocketAddress
+            # below. Address-family specific, so it stays here; everything
+            # else, the DISPLAY-HINT text form included, belongs to
+            # TextualConvention.prettyIn.
             value = (
                 inet_pton(socket.AF_INET, value[0])
                 + bytes(((value[1] >> 8) & 0xFF,))
                 + bytes((value[1] & 0xFF,))
             )
-        return OctetString.prettyIn(self, value)
+        return super().prettyIn(value)
 
     # Socket address syntax coercion
     def __asSocketAddress(self):

--- a/tests/test_smi.py
+++ b/tests/test_smi.py
@@ -920,3 +920,36 @@ class TestTextualConventionPrettyIn:
 
         assert int(EnumTC("up")) == 1
         assert int(EnumTC(2)) == 2
+
+
+class TestTransportAddressPrettyIn:
+    """SnmpUDPAddress and TransportAddressIPv4 delegate to TextualConvention.
+
+    Both overrode prettyIn to coerce a Python socket-address tuple and then
+    called OctetString.prettyIn directly, shadowing the TEXTUAL-CONVENTION
+    machinery entirely — so the DISPLAY-HINT text form these types render was
+    not accepted back. See #155.
+    """
+
+    OCTETS = b"\x01\x02\x03\x04\x00\xa1"
+
+    @pytest.fixture(
+        params=[("SNMPv2-TM", "SnmpUDPAddress"), ("TRANSPORT-ADDRESS-MIB", "TransportAddressIPv4")]
+    )
+    def address_type(self, request, mib_builder):
+        (cls,) = mib_builder.importSymbols(*request.param)
+        return cls
+
+    def test_socket_tuple(self, address_type):
+        assert address_type(("1.2.3.4", 161)).asOctets() == self.OCTETS
+
+    def test_raw_octets(self, address_type):
+        assert address_type(self.OCTETS).asOctets() == self.OCTETS
+
+    def test_display_hint_text(self, address_type):
+        rendered = address_type(self.OCTETS).prettyPrint()
+        assert rendered.startswith("1.2.3.4")
+        assert address_type(rendered).asOctets() == self.OCTETS
+
+    def test_socket_address_coercion_survives(self, address_type):
+        assert tuple(address_type(("1.2.3.4", 161))) == ("1.2.3.4", 161)


### PR DESCRIPTION
Closes #155.

## What the "Wild hack" comment was hiding

Both sites named in the issue look like this:

```python
def prettyIn(self, value):
    if isinstance(value, tuple):
        # Wild hack -- need to implement TextualConvention.prettyIn
        value = inet_pton(AF_INET, value[0]) + ...
    return OctetString.prettyIn(self, value)
```

The last line is the actual defect. It calls the *base type* directly, so `TextualConvention.prettyIn` is never reached for any input — tuple or not. These types render themselves through the DISPLAY-HINT and then cannot read that back:

```
SnmpUDPAddress(b"\x01\x02\x03\x04\x00\xa1").prettyPrint()  ->  '1.2.3.4/161'
SnmpUDPAddress('1.2.3.4/161')                              ->  ValueConstraintError (11 octets)
```

## The issue's question, answered

The issue asks whether `TextualConvention.prettyIn` should grow the display-hint handling these sites need, or whether per-module conversion is right and the comments should just go.

Neither, quite. `TextualConvention.prettyIn` **already** parses `1d.1d.1d.1d/2d` and `1d.1d.1d.1d:2d` correctly — verified directly against both types. Nothing needed implementing; the overrides simply never called it.

What *is* genuinely local is the tuple coercion. A Python socket-address tuple is not a DISPLAY-HINT form, it is address-family-specific pysnmp convenience, and it is the counterpart of the `__asSocketAddress`/`__iter__`/`__getitem__` trio sitting directly below it in the same class. It stays.

So: keep the tuple branch, delegate everything else with `super().prettyIn()`, and replace the comment with what the branch is actually for.

## TransportAddressIPv6 is left alone

It carries the same tuple branch (without the comment). Its DISPLAY-HINT is `0a[2x:2x:2x:2x:2x:2x:2x:2x]0a:2d`, which the current parser cannot handle — it has no notion of the zero-length `a` anchor or the bracket literals, and raises `SmiError: Display format eval failure: b'['`. Delegating there would trade one failure for another. Filed separately as #167.

## Tests

`TestTransportAddressPrettyIn` in `tests/test_smi.py`, parametrised over both types, covering the socket tuple, raw octets, the DISPLAY-HINT text round trip, and that the socket-address coercion still works. The two `test_display_hint_text` cases fail against the unpatched modules; the other six pass both ways, which is the point — nothing else changed.

Full suite: 908 passed, 12 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved consistency when converting SNMP UDP and IPv4 transport addresses from socket tuples or raw octets.
  - Preserved existing address formatting and text round-trip behavior.

- **Tests**
  - Added coverage for socket-address tuple conversion, raw-octet construction, and display-hint formatting for transport addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->