### PR TITLE
docs(proto): correct the rfc1902 doctests and gate them in CI

### DIFF
--- a/pysnmp/proto/rfc1902.py
+++ b/pysnmp/proto/rfc1902.py
@@ -44,7 +44,7 @@ class Null(univ.Null):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> Null('')
-        Null('')
+        <Null value object, payload []>
         >>>
     """
 
@@ -75,19 +75,19 @@ class Integer32(univ.Integer):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> Integer32(1234)
-        Integer32(1234)
+        <Integer32 value object, payload [1234]>
         >>> Integer32(1) > 2
-        True
+        False
         >>> Integer32(1) + 1
-        Integer32(2)
+        <Integer32 value object, payload [2]>
         >>> int(Integer32(321))
         321
         >>> SmallInteger = Integer32.withRange(1,3)
         >>> SmallInteger(1)
-        Integer32(1)
+        <Integer32 value object, payload [1]>
         >>> DiscreetInteger = Integer32.withValues(4, 8, 1)
         >>> DiscreetInteger(4)
-        Integer32(4)
+        <Integer32 value object, payload [4]>
         >>>
 
     """
@@ -145,16 +145,16 @@ class Integer(Integer32):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> Integer(1234)
-        Integer(1234)
+        <Integer value object, payload [1234]>
         >>> Integer(1) > 2
-        True
+        False
         >>> Integer(1) + 1
-        Integer(2)
+        <Integer value object, payload [2]>
         >>> int(Integer(321))
         321
         >>> SomeState = Integer.withNamedValues(enable=1, disable=0)
         >>> SomeState(1)
-        Integer('enable')
+        <Integer value object, payload [enable]>
         >>> int(SomeState('disable'))
         0
         >>>
@@ -206,9 +206,9 @@ class OctetString(univ.OctetString):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> OctetString('some apples')
-        OctetString('some apples')
+        <OctetString value object, payload [some apples]>
         >>> OctetString('some apples') + ' and oranges'
-        OctetString('some apples and oranges')
+        <OctetString value object, payload [some apples and oranges]>
         >>> OctetString('some apples').asOctets()
         b'some apples'
         >>> OctetString('some apples').prettyPrint()
@@ -282,9 +282,9 @@ class ObjectIdentifier(univ.ObjectIdentifier):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> ObjectIdentifier((1, 3, 6))
-        ObjectIdentifier('1.3.6')
+        <ObjectIdentifier value object, payload [1.3.6]>
         >>> ObjectIdentifier('1.3.6')
-        ObjectIdentifier('1.3.6')
+        <ObjectIdentifier value object, payload [1.3.6]>
         >>> tuple(ObjectIdentifier('1.3.6'))
         (1, 3, 6)
         >>> str(ObjectIdentifier('1.3.6'))
@@ -316,13 +316,13 @@ class IpAddress(OctetString):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> IpAddress('127.0.0.1')
-        IpAddress(hexValue='7f000001')
+        <IpAddress value object, payload [127.0.0.1]>
         >>> IpAddress(hexValue='7f000001').prettyPrint()
         '127.0.0.1'
         >>> IpAddress(hexValue='7f000001').asOctets()
         b'\x7f\x00\x00\x01'
         >>> IpAddress('\x7f\x00\x00\x01')
-        IpAddress(hexValue='7f000001')
+        <IpAddress value object, payload [127.0.0.1]>
         >>>
 
     """
@@ -374,9 +374,9 @@ class Counter32(univ.Integer):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> Counter32(1234)
-        Counter32(1234)
+        <Counter32 value object, payload [1234]>
         >>> Counter32(1) + 1
-        Counter32(2)
+        <Counter32 value object, payload [2]>
         >>> int(Counter32(321))
         321
         >>>
@@ -412,9 +412,9 @@ class Gauge32(univ.Integer):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> Gauge32(1234)
-        Gauge32(1234)
+        <Gauge32 value object, payload [1234]>
         >>> Gauge32(1) + 1
-        Gauge32(2)
+        <Gauge32 value object, payload [2]>
         >>> int(Gauge32(321))
         321
         >>>
@@ -449,9 +449,9 @@ class Unsigned32(univ.Integer):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> Unsigned32(1234)
-        Unsigned32(1234)
+        <Unsigned32 value object, payload [1234]>
         >>> Unsigned32(1) + 1
-        Unsigned32(2)
+        <Unsigned32 value object, payload [2]>
         >>> int(Unsigned32(321))
         321
         >>>
@@ -486,9 +486,9 @@ class TimeTicks(univ.Integer):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> TimeTicks(1234)
-        TimeTicks(1234)
+        <TimeTicks value object, payload [1234]>
         >>> TimeTicks(1) + 1
-        TimeTicks(2)
+        <TimeTicks value object, payload [2]>
         >>> int(TimeTicks(321))
         321
         >>>
@@ -531,9 +531,9 @@ class Opaque(univ.OctetString):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> Opaque('some apples')
-        Opaque('some apples')
+        <Opaque value object, payload [some apples]>
         >>> Opaque('some apples') + ' and oranges'
-        Opaque('some apples and oranges')
+        <Opaque value object, payload [some apples and oranges]>
         >>> Opaque('some apples').asOctets()
         b'some apples'
         >>> Opaque('some apples').prettyPrint()
@@ -574,9 +574,9 @@ class Counter64(univ.Integer):
     --------
         >>> from pysnmp.proto.rfc1902 import *
         >>> Counter64(1234)
-        Counter64(1234)
+        <Counter64 value object, payload [1234]>
         >>> Counter64(1) + 1
-        Counter64(2)
+        <Counter64 value object, payload [2]>
         >>> int(Counter64(321))
         321
         >>>
@@ -630,11 +630,11 @@ class Bits(OctetString):
         >>> SomeBits(('apple', 'orange')).prettyPrint()
         'apple, orange'
         >>> SomeBits(('apple', 'orange'))
-        Bits(hexValue='c0')
+        <Bits value object, payload [apple, orange]>
         >>> SomeBits('\x80')
-        Bits(hexValue='80')
+        <Bits value object, payload [apple]>
         >>> SomeBits(hexValue='80')
-        Bits(hexValue='80')
+        <Bits value object, payload [apple]>
         >>> SomeBits(hexValue='80').prettyPrint()
         'apple'
         >>>

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,28 @@
+"""Runs the doctests in modules whose examples are known to be correct.
+
+Nothing ran these, so they rotted: 31 of the 71 examples in
+``pysnmp.proto.rfc1902`` were failing when this file was added, most of them
+against a pyasn1 repr that changed years ago. See #161.
+
+Modules are added to ``DOCTESTED_MODULES`` as their examples are corrected.
+The remaining modules carrying stale examples are tracked in #168.
+"""
+
+import doctest
+import importlib
+
+import pytest
+
+DOCTESTED_MODULES = [
+    "pysnmp.proto.rfc1902",
+]
+
+
+@pytest.mark.parametrize("module_name", DOCTESTED_MODULES)
+def test_module_doctests(module_name):
+    module = importlib.import_module(module_name)
+    results = doctest.testmod(module, verbose=False, report=True)
+    assert results.attempted, f"{module_name} has no doctests to run"
+    assert results.failed == 0, (
+        f"{results.failed} of {results.attempted} doctests failed in {module_name}"
+    )


### PR DESCRIPTION
Closes #161.

## The two problems, as filed

**29 stale reprs.** pyasn1 stopped rendering value objects in the eval-able form:

```
Expected: Integer32(1234)
Got:      <Integer32 value object, payload [1234]>
```

Corrected mechanically to what the code actually produces, across `Null`, `Integer32`, `Integer`, `ObjectIdentifier`, `OctetString`, `IpAddress`, `Counter32`, `Gauge32`, `Unsigned32`, `TimeTicks`, `Opaque`, `Counter64` and `Bits`.

**2 wrong factual claims.** `Integer32` and `Integer` both documented `Integer32(1) > 2` as `True`. It is `False`. The expression is kept and the answer corrected, so the example still demonstrates that comparison works rather than being deleted.

## The decision the issue asked for

The issue asks whether these should be corrected and wired into CI, or marked `#doctest: +SKIP` as illustrative-only.

Corrected and wired in. They are runnable, they were wrong, and `+SKIP` on a runnable example that reveals a real error is how they got here.

The gate is `tests/test_doctests.py` — `doctest.testmod` over an explicit module list, rather than `--doctest-modules` in the pytest invocation. That keeps the gate in the suite where every matrix entry already runs it, needs no CI change, and makes the set of vetted modules an explicit list that grows by one line.

Verified red before green: against the unpatched module the gate reports `***Test Failed*** 31 failures.`

## What the audit turned up

The issue notes that other modules were not audited. They are now — a package-wide sweep (excluding generated `smi/mibs/*`) finds **38 more failures across 8 modules**:

| Module | Failing / total |
|---|---|
| `pysnmp.smi.rfc1902` | 19 / 42 |
| `pysnmp.hlapi.asyncio.transport` | 6 / 8 |
| `pysnmp.hlapi.asyncio.cmdgen` | 5 / 17 |
| `pysnmp.hlapi.auth` | 4 / 6 |
| `pysnmp.smi.view` | 4 / 4 |
| `pysnmp.hlapi.context` | 2 / 4 |
| `pysnmp.hlapi.asyncio.ntforg` | 1 / 4 |
| `pysnmp.entity.engine` | 1 / 1 |

These are not the same kind of problem. `rfc1902`'s failures were one find-and-replace; these set up an engine, a MIB view controller or a transport, and some may not be runnable in-process at all. Each needs reading. They are **not** added to the gate and **not** suppressed — they were never gated, and they are tracked in #168 with the reproduction command and the rule that a runnable example revealing a real defect does not get skipped.

Full suite: 901 passed, 12 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated protocol examples to display current representations for scalar, string, OID, IP address, counter, gauge, time tick, opaque, and BITS values.
  * Corrected integer comparison and named-bit output examples.

* **Tests**
  * Added automated doctest coverage to verify that documented examples execute successfully and continue producing the expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->