### PR TITLE
docs(proto): record what the constraint-verification bypasses actually do

### DIFF
--- a/pysnmp/proto/mpmod/rfc3412.py
+++ b/pysnmp/proto/mpmod/rfc3412.py
@@ -154,7 +154,14 @@ class SnmpV3MessageProcessingModel(AbstractMessageProcessingModel):
         )
 
         # 7.1.7c
-        # XXX need to coerce MIB value as it has incompatible constraints set
+        # The three flags are load-bearing, not an optimisation. The MIB scalar
+        # is an Integer32 carrying its own base range intersected with (484,
+        # 2147483647); msgMaxSize is a plain Integer constrained to the same
+        # (484, 2147483647). pyasn1 compares ConstraintsIntersection objects
+        # structurally rather than by range, so isSuperTypeOf() is False for
+        # this pair despite the bounds agreeing, and a strict set raises
+        # "Component value is tag-incompatible" on every outgoing message.
+        # See #154. Remove these only once pyasn1 compares ranges semantically.
         headerData.setComponentByPosition(
             1,
             snmpEngineMaxMessageSize.syntax,

--- a/pysnmp/proto/secmod/rfc3414/service.py
+++ b/pysnmp/proto/secmod/rfc3414/service.py
@@ -633,6 +633,11 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
         securityParameters.setComponentByPosition(
             0, securityEngineID, verifyConstraints=False, matchTags=False, matchConstraints=False
         )
+        # As in rfc3412, the flags on the next two are load-bearing rather than
+        # an optimisation: when these come from the LCD they are an Integer32
+        # and a SnmpEngineTime, whose ConstraintsIntersection differs
+        # structurally from the plain Integer these slots declare even though
+        # the ranges agree, so a strict set is rejected outright. See #154.
         securityParameters.setComponentByPosition(
             1, snmpEngineBoots, verifyConstraints=False, matchTags=False, matchConstraints=False
         )

--- a/tests/test_constraint_bypass.py
+++ b/tests/test_constraint_bypass.py
@@ -1,0 +1,82 @@
+"""Pins what the verifyConstraints/matchTags/matchConstraints flags actually do.
+
+pysnmp passes these three flags to pyasn1 setters in roughly forty places. The
+audit in #154 established two things about them that are not obvious from the
+call sites, and that decide whether any given one is removable:
+
+- for a raw Python value the flags change nothing, because pyasn1 clones the
+  value into the slot's own type and that clone verifies unconditionally;
+- for an already-constructed pyasn1 object they skip the compatibility check
+  entirely, and pyasn1 compares constraint objects structurally rather than by
+  range.
+
+The second is why three of the sites are load-bearing: a MIB-sourced Integer32
+carries a ConstraintsIntersection that differs structurally from the plain
+Integer the protocol slot declares, even when the numeric bounds agree. Remove
+the flags there and every outgoing message raises.
+
+These tests fail if pyasn1 changes either behaviour, which is exactly when the
+bypasses should be revisited.
+"""
+
+import pytest
+from pyasn1.error import PyAsn1Error, ValueConstraintError
+from pyasn1.type import constraint, namedtype, univ
+
+from pysnmp.entity.engine import SnmpEngine
+from pysnmp.proto.mpmod.rfc3412 import HeaderData
+from pysnmp.proto.secmod.rfc3414.service import UsmSecurityParameters
+
+FLAGS = {"verifyConstraints": False, "matchTags": False, "matchConstraints": False}
+
+
+class Constrained(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType(
+            "value",
+            univ.Integer().subtype(subtypeSpec=constraint.ValueRangeConstraint(0, 100)),
+        )
+    )
+
+
+class TestFlagSemantics:
+    def test_raw_value_is_verified_despite_the_flags(self):
+        """A raw int is cloned into the slot's type, and the clone verifies."""
+        with pytest.raises(ValueConstraintError):
+            Constrained().setComponentByPosition(0, 999999, **FLAGS)
+
+    def test_constructed_object_is_not_verified(self):
+        """An already-built object skips the check and reaches the encoder."""
+        from pyasn1.codec.ber import encoder
+
+        seq = Constrained()
+        seq.setComponentByPosition(0, univ.Integer(999999), **FLAGS)
+        assert int(seq.getComponentByPosition(0)) == 999999
+        assert encoder.encode(seq)
+
+
+class TestLoadBearingBypasses:
+    """The three sites where removing the flags breaks message generation."""
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def mib_builder():
+        return SnmpEngine().msgAndPduDsp.mibInstrumController.mibBuilder
+
+    @pytest.mark.parametrize(
+        ("spec", "position", "symbol"),
+        [
+            (HeaderData, 1, "snmpEngineMaxMessageSize"),
+            (UsmSecurityParameters, 1, "snmpEngineBoots"),
+            (UsmSecurityParameters, 2, "snmpEngineTime"),
+        ],
+    )
+    def test_mib_scalar_is_rejected_by_a_strict_set(self, mib_builder, spec, position, symbol):
+        (scalar,) = mib_builder.importSymbols("__SNMP-FRAMEWORK-MIB", symbol)
+        message = spec()
+
+        with pytest.raises(PyAsn1Error, match="tag-incompatible"):
+            message.setComponentByPosition(position, scalar.syntax)
+
+        message.setComponentByPosition(position, scalar.syntax, **FLAGS)
+        assert int(message.getComponentByPosition(position)) == int(scalar.syntax)


### PR DESCRIPTION
Closes #154.

> **Note on the issue itself:** the body of #154 is truncated on GitHub — it ends mid-sentence at `matchConstraints=Fa` followed by a context-elision placeholder that was pasted in when it was filed. The original text is not recoverable. This audit works from the title and the surviving first sentence.

## What is actually there

78 grep hits reduce to **52 call sites**: 42 setter/constructor calls and 10 `isSuperTypeOf(..., matchConstraints=False)` type tests. The extra 26 lines are formatter-split calls counted three times. The `isSuperTypeOf` ones are type-family identity tests in `SNMPv2-TC.prettyIn`/`prettyOut` and `smi/rfc1902` — not value bypasses, and `matchConstraints=False` is correct there by design.

Of the 42 setters: 30 INTERNAL, 8 CALLER, 4 WIRE, 0 unclear. 27 target a slot with no constraint at all.

## The two facts that matter

Both verified directly against `pysnmp-pyasn1` 1.3.0, not inferred.

**For a raw Python value the flags do nothing.** `setComponentByPosition` routes a non-pyasn1 value through `subComponentType.clone(value=...)` regardless of the flags, and that clone runs `subtypeSpec` unconditionally:

```python
Constrained().setComponentByPosition(0, 999999, verifyConstraints=False,
                                     matchTags=False, matchConstraints=False)
# ValueConstraintError -- still rejected
```

**For an already-built pyasn1 object they skip the check entirely**, and the object reaches the encoder:

```python
seq.setComponentByPosition(0, univ.Integer(999999), **FLAGS)   # accepted
encoder.encode(seq)                                            # non-conformant bytes
```

So the question at each site is not "is verification off" — it is "is the value already an object, and could its type differ from the slot's".

## Three sites are load-bearing, not an optimisation

`pysnmp/proto/mpmod/rfc3412.py:158` (`msgMaxSize`) and `pysnmp/proto/secmod/rfc3414/service.py:637,640` (`msgAuthoritativeEngineBoots`, `...EngineTime`).

Each assigns a MIB scalar into a protocol slot whose numeric bounds agree. pyasn1 compares `ConstraintsIntersection` objects structurally, not by range, so it still says no:

```
snmpEngineBoots | mib : Integer32  ConstraintsIntersection(Range(-2147483648, 2147483647), Range(1, 2147483647))
                | slot: Integer    ConstraintsIntersection(Range(0, 2147483647))
                | isSuperTypeOf: False
                | strict set: PyAsn1Error, component value is tag-incompatible
```

Remove the flags at any of the three and **every outgoing message raises**. Only `rfc3412` carried a note about this, and a terse one (`# XXX need to coerce MIB value as it has incompatible constraints set`); the two USM sites carried none, which is how an audit like this ends up being needed.

## What this PR changes

Nothing behavioural. It adds:

- comments at all three load-bearing sites naming the mechanism and the condition under which they can be removed (pyasn1 comparing ranges semantically);
- `tests/test_constraint_bypass.py`, five tests pinning both behaviours above. They fail if pyasn1 changes either — which is precisely when these bypasses want revisiting. Today they document why the code is shaped this way; tomorrow they are the tripwire.

## Reported, not changed

`pysnmp/proto/api/v1.py:42` (`VarBindAPI.setOIDVal`) and `:301` (`MessageAPI.setPDU`) select a CHOICE arm from a caller-supplied value with no cross-check. Every in-tree path reaches them with a value already validated by `rfc1902.ObjectType.resolveWithMib`, so there is no live defect — but a caller using the low-level v1 API directly gets an object accepted into the wrong slot silently. Adding verification there changes the behaviour of a public API on the per-packet hot path to guard against a misuse nobody has reported, so it is recorded here rather than fixed on my own judgement.

The ~27 inert sites (raw values, where the flags provably do nothing) could be deleted as noise. That is 27 call sites of churn on the hot path for readability alone, so it is also left alone; the tests above are what let a future reader tell inert from load-bearing without repeating this audit.

Full suite: 915 passed, 12 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when generating SNMPv3 messages involving engine boot, engine time, and maximum message size values.
  - Prevented constraint incompatibilities from blocking valid message creation.

- **Tests**
  - Added regression coverage for SNMPv3 message generation and value-assignment behavior.

- **Documentation**
  - Expanded technical explanations for compatibility handling in SNMPv3 message and security processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->