### PR TITLE
test(carrier): assert the broadcast test's actual subject

### DIFF
--- a/tests/test_entity_carrier.py
+++ b/tests/test_entity_carrier.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import socket
 import tempfile
 
 import pytest
@@ -400,7 +401,8 @@ class TestUdpTransport:
         transport = udp.UdpAsyncioTransport(loop=loop).enableBroadcast()
         transport.openClientMode()
         loop.run_until_complete(asyncio.sleep(0))
-        assert transport.getLocalAddress() is not None
+        sock = transport.transport.get_extra_info("socket")
+        assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST)
         transport.closeTransport()
         loop.run_until_complete(asyncio.sleep(0))
         loop.close()


### PR DESCRIPTION
The first Windows result from the matrix added in #163. One failure out of 917, on both 3.10 and 3.14, and it is the test's assertion rather than the code.

`test_broadcast_option_is_applied_after_connection` asserted:

```python
transport.openClientMode()
loop.run_until_complete(asyncio.sleep(0))
assert transport.getLocalAddress() is not None
```

That is neither what the test is named for nor portable. `getLocalAddress()` returns `get_extra_info("sockname")`, and for a datagram socket that was never bound:

| Platform | result |
|---|---|
| Linux, macOS | `('0.0.0.0', 0)` |
| Windows | `None` |

So on Linux and macOS it passed as an incidental proxy for "the endpoint got created", and on Windows it reads as failure while the endpoint is fine — `openClientMode()` returned without raising and `self.transport` is set.

The test now asserts `SO_BROADCAST` is actually set on the socket. That is what the name claims, it is a stronger assertion than the one it replaces, and it holds everywhere. Verified on macOS: `getsockopt(SOL_SOCKET, SO_BROADCAST)` is 32 after `enableBroadcast()`.

Whether `getLocalAddress()` returning `None` on Windows matters in its own right — `normalizeAddress()` feeds it straight into `setLocalAddress()` — is filed as #173. I have no Windows machine to settle it on, so it is a question there rather than a guess here.

Windows stays `continue-on-error` until it has a track record, as designed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated UDP broadcast coverage to verify that socket broadcast support is enabled directly, improving test accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->