### PR TITLE
build: ship the generated changelog in the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,12 +71,19 @@ build-backend = "hatchling.build"
 packages = ["pysnmp"]
 
 [tool.hatch.build.targets.sdist]
+# An explicit include is an allowlist: anything not named here is left out,
+# whatever else is in the tree. semantic-release generates CHANGELOG.md during
+# prepare, before this builds, so the release being cut is described by the
+# changelog shipped beside it -- which is where a downstream packager looks.
+# CHANGES.md is the narrative history through 5.x that CHANGELOG.md refers to.
 include = [
     "pysnmp",
     "docs",
     "tests",
     "examples",
     "tools",
+    "CHANGELOG.md",
+    "CHANGES.md",
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #163 — this is the residue of item 9, not the whole issue. **Most of #163 is already on `next`**, landed by 4330f64 twelve minutes after the issue was filed. Audit below.

## The gap

`[tool.hatch.build.targets.sdist]` uses an explicit `include`, which is an allowlist — anything not named is left out, whatever else is in the tree. The list named `pysnmp`, `docs`, `tests`, `examples`, `tools`, so the sdist root held only what hatchling adds by default:

```
pysnmplib-6.0.0rc7/.gitignore
pysnmplib-6.0.0rc7/LICENSE.rst
pysnmplib-6.0.0rc7/PKG-INFO
pysnmplib-6.0.0rc7/README.md
pysnmplib-6.0.0rc7/pyproject.toml
```

Item 9 asks for a changelog "in the repository or the sdist". The repository half is done — `.releaserc` runs `@semantic-release/changelog` and `CHANGELOG.md` is committed. The sdist half was not: a downstream packager reading the sdist had no record of what changed.

The ordering works out. `@semantic-release/changelog` writes the file during prepare, before `@semantic-release/exec` runs `sr-prepare.sh` to build, so the changelog shipped beside a release describes that release rather than the previous one.

`CHANGES.md` goes with it — it is the narrative history through 5.x that `CHANGELOG.md`'s own generated header sends the reader to.

After:

```
pysnmplib-6.0.0rc7/CHANGELOG.md
pysnmplib-6.0.0rc7/CHANGES.md
pysnmplib-6.0.0rc7/LICENSE.rst
...
```

## Audit of #163 against `next` as it stands

| # | Item | State |
| --- | --- | --- |
| 1 | Tests gate releases | done — `publish` needs `run-unit-tests`; the separate `unit-tests.yml` and `coverage.yml` are gone |
| 2 | `main` is a different project from `next` | **outstanding** — see below |
| 3 | Angular preset ignores `!` | done — `conventionalcommits` on both analyzer and notes generator |
| 4 | Releases happen on push | done — `DRY: ${{ github.event_name != 'workflow_dispatch' }}`; no `release_type` input, no `.releaserc` `sed` |
| 5 | Test workflow | done — `setup-matrix`, `uv run --locked`, macOS + Windows on the edge versions, JUnit artifact, Codecov upload |
| 6 | No build or docs gate | done — `build` and `docs` jobs, both in `publish`'s `needs`; `-W --keep-going` |
| 7 | `develop` still a release channel | done — `.releaserc` branches are the maintenance glob, `main`, `next` |
| 8 | Pinned to old plugin majors | done — `semantic_version: 24`, `@google/…-replace-plugin`, `conventional-changelog-conventionalcommits@8.0.0` |
| 9 | No generated changelog | repository half done; **sdist half is this PR** |
| 10 | Action versions | done — checkout/setup-python/setup-uv/upload-artifact at v7, semantic-release-action v6, codecov v7 |
| 11 | Document it | done — `docs/source/ci-and-releases.rst`, in the `contents.rst` toctree |

**Item 2 cannot be done in a PR to `next`.** It is the `next` → `main` promotion — `main` is still poetry-built `pysnmplib` 5.0.24 with no tests in tree, and the 6.0 line has never been promoted. That is a release decision and a PR into `main`, not a change to `next`.

## Verification

- built the sdist and listed its root: both files present
- wheel unchanged
- `uv lock --check` current
- `pytest`: **935 passed, 12 skipped**
- pre-commit (ruff, ruff format) clean
- docs build clean under `-W --keep-going`

## Noted, not changed

- **`-n` on the docs build.** pysmi runs `-n -W --keep-going`; pysnmp omits `-n`. Turning it on here produces 96 unresolved cross-references, the same situation the pyasn1 report set aside as needing its own pass. #163 item 6 only asked for `--keep-going`, which is present.
- **CodeQL never scans `next`.** `codeql-analysis.yml` triggers on `main` only, so the branch all development happens on is unscanned. Outside #163's list, so I have left it alone — say the word and it is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Source distributions now include the project’s changelog files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->