### PR TITLE
fix(ci): publish docs from a branch, not a detached HEAD

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -59,7 +59,11 @@ jobs:
         run: |
           git fetch origin gh-pages --depth=1 || true
           if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
-            git worktree add ../site origin/gh-pages
+            # -B puts the worktree on a local gh-pages branch reset to the
+            # remote one. Without it `git worktree add <path> origin/gh-pages`
+            # checks out a detached HEAD, the commit below lands on no branch,
+            # and `git push origin gh-pages` has no such local ref to push.
+            git worktree add -B gh-pages ../site origin/gh-pages
           else
             git worktree add --detach ../site
             git -C ../site checkout --orphan gh-pages


### PR DESCRIPTION
A latent defect in the docs publisher this repository took from pyasn1 in #176. Same fix in pysnmp/pyasn1#161, where it is not latent — it has failed all five runs there.

## Cause

```yaml
git worktree add ../site origin/gh-pages
```

checks out a **detached HEAD**, not a local branch. The commit then lands on no branch, and `git push origin gh-pages` finds no local ref of that name, because a CI checkout carries only `refs/remotes/origin/gh-pages`:

```
error: src refspec gh-pages does not match any
```

The `else` branch is fine — `checkout --orphan gh-pages` does leave the worktree on a branch.

## Why it has not bitten here yet

This repository has no `gh-pages` branch. Its first publish would take the orphan path and succeed; **every publish after that would fail**, once the branch it just created exists. pyasn1 has had `gh-pages` throughout, which is why it failed from the very first run and this was found there.

So it would have looked like the feature worked and then broke by itself one release later.

## Verified

Against a scratch remote carrying an existing `gh-pages`, cloned fresh each time as CI does:

| | HEAD | push |
| --- | --- | --- |
| as shipped | `DETACHED` | `error: src refspec gh-pages does not match any` |
| with `-B gh-pages` | `gh-pages` | `f60c1cb..bbec46e  gh-pages -> gh-pages` |

`-B gh-pages` puts the worktree on a local branch reset to the remote one, so both paths end on something pushable.

The workflow stays byte-identical to pyasn1's. Note this repository's docs publishing has not started yet in any case — the note on #176 about repointing www.pysnmp.com/pysnmp at the `gh-pages` branch still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation publishing reliability by ensuring updates are committed and pushed to the correct branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->