### PR TITLE
docs: resolve every cross-reference, and build nitpicky

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -48,7 +48,7 @@ jobs:
       # --keep-going lists every warning instead of stopping at the first, so
       # one push fixes them all.
       - name: Build docs
-        run: uv run --locked --group dev sphinx-build -W --keep-going -b html docs/source docs/build
+        run: uv run --locked --group dev sphinx-build -n -W --keep-going -b html docs/source docs/build
       - uses: actions/upload-artifact@v7
         with:
           name: docs-html

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -52,7 +52,7 @@ jobs:
         # outside the output tree so the build cache is not published.
         run: >
           uv run --locked --group dev
-          sphinx-build -W --keep-going -b html
+          sphinx-build -n -W --keep-going -b html
           -d "${RUNNER_TEMP}/doctrees" docs/source docs/build
 
       - name: Check out gh-pages

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -55,6 +55,7 @@ Documentation
 
    /docs/tutorial
    /docs/api-reference
+   /docs/api-internals
    /docs/breaking-changes
    /docs/security-considerations
    /docs/smi-table-api

--- a/docs/source/docs/api-internals.rst
+++ b/docs/source/docs/api-internals.rst
@@ -1,0 +1,76 @@
+Errors and supporting types
+===========================
+
+The objects on this page are referenced throughout the library reference and
+the docstrings — as the exceptions an operation raises, the type a call hands
+back, or the MIB services the high-level API is built on. They are collected
+here so that every one of those references resolves.
+
+Exceptions
+----------
+
+.. autoexception:: pysnmp.error.PySnmpError
+   :members:
+
+.. autoexception:: pysnmp.smi.error.SmiError
+   :members:
+
+   Raised by the SMI layer. It derives from both
+   :exc:`~pysnmp.error.PySnmpError` and :class:`~pyasn1.error.PyAsn1Error`, so
+   either is enough to catch it.
+
+Warnings
+--------
+
+.. autoexception:: pysnmp.error.PySnmpCryptoWarning
+
+.. autoexception:: pysnmp.error.PySnmpWeakCryptoWarning
+
+.. autoexception:: pysnmp.error.PySnmpNonStandardCryptoWarning
+
+Return types
+------------
+
+.. module:: pysnmp.hlapi
+
+.. autoclass:: pysnmp.hlapi.types.SnmpResponse
+
+.. autodata:: pysnmp.proto.rfc1905.endOfMibView
+   :annotation:
+
+   The value a response carries in place of a variable binding when a walk has
+   run past the end of the MIB view.
+
+.. autoclass:: pysnmp.proto.rfc1902.ObjectName
+
+Transport
+---------
+
+.. autoclass:: pysnmp.hlapi.transport.AbstractTransportTarget
+   :members:
+
+MIB services
+------------
+
+.. module:: pysnmp.smi.rfc1902
+
+.. autoclass:: pysnmp.smi.builder.MibBuilder
+   :members: addMibSources, getMibSources, loadModules, importSymbols
+
+.. autoclass:: pysnmp.smi.view.MibViewController
+   :members:
+
+Synchronous command generators
+------------------------------
+
+These are the blocking counterparts of the coroutines in
+:doc:`hlapi/asyncio/manager/cmdgen/getcmd` and its siblings. They take the same
+arguments and return the same tuple, having driven the event loop themselves.
+
+.. autofunction:: pysnmp.hlapi.getCmd
+
+.. autofunction:: pysnmp.hlapi.setCmd
+
+.. autofunction:: pysnmp.hlapi.nextCmd
+
+.. autofunction:: pysnmp.hlapi.bulkCmd

--- a/docs/source/docs/pysnmp-hlapi-tutorial.rst
+++ b/docs/source/docs/pysnmp-hlapi-tutorial.rst
@@ -103,8 +103,8 @@ In this example we will query
 `public SNMP Simulator <https://pypi.org/project/snmpsim/>`__
 available over IPv4 on the Internet at *localhost*. Transport
 configuration is passed to SNMP LCD in form of properly initialized
-:py:class:`~pysnmp.hlapi.UdpTransportTarget` or
-:py:class:`~pysnmp.hlapi.Udp6TransportTarget` objects
+:py:class:`~pysnmp.hlapi.asyncio.UdpTransportTarget` or
+:py:class:`~pysnmp.hlapi.asyncio.Udp6TransportTarget` objects
 respectively.
 
 .. code-block:: python

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -102,7 +102,7 @@ async def getCmd(
 
     Raises
     ------
-    PySnmpError
+    pysnmp.error.PySnmpError
         Or its derivative indicating that an error occurred while
         performing SNMP operation.
 
@@ -199,7 +199,7 @@ async def setCmd(
 
     Raises
     ------
-    PySnmpError
+    pysnmp.error.PySnmpError
         Or its derivative indicating that an error occurred while
         performing SNMP operation.
 
@@ -299,7 +299,7 @@ async def nextCmd(
 
     Raises
     ------
-    PySnmpError
+    pysnmp.error.PySnmpError
         Or its derivative indicating that an error occurred while
         performing SNMP operation.
 
@@ -429,7 +429,7 @@ async def bulkCmd(
 
     Raises
     ------
-    PySnmpError
+    pysnmp.error.PySnmpError
         Or its derivative indicating that an error occurred while
         performing SNMP operation.
 

--- a/pysnmp/hlapi/asyncio/ntforg.py
+++ b/pysnmp/hlapi/asyncio/ntforg.py
@@ -82,7 +82,7 @@ async def sendNotification(
 
     Raises
     ------
-    PySnmpError
+    pysnmp.error.PySnmpError
         Or its derivative indicating that an error occurred while
         performing SNMP operation.
 

--- a/pysnmp/hlapi/asyncio/transport.py
+++ b/pysnmp/hlapi/asyncio/transport.py
@@ -72,9 +72,9 @@ class Udp6TransportTarget(AbstractTransportTarget):
     """Creates UDP/IPv6 configuration entry and initialize socket API if needed.
 
     This object can be used by
-    :py:class:`~pysnmp.hlapi.asyncio.AsyncCommandGenerator` or
-    :py:class:`~pysnmp.hlapi.asyncio.AsyncNotificationOriginator`
-    and their derevatives for adding new entries to Local Configuration
+    :py:func:`~pysnmp.hlapi.asyncio.getCmd` and the other command-generator
+    coroutines, or by :py:func:`~pysnmp.hlapi.asyncio.sendNotification`,
+    for adding new entries to Local Configuration
     Datastore (LCD) managed by :py:class:`~pysnmp.hlapi.SnmpEngine`
     class instance.
 

--- a/pysnmp/hlapi/auth.py
+++ b/pysnmp/hlapi/auth.py
@@ -34,9 +34,9 @@ class CommunityData:
     """Creates SNMP v1/v2c configuration entry.
 
     This object can be used by
-    :py:class:`~pysnmp.hlapi.asyncio.AsyncCommandGenerator` or
-    :py:class:`~pysnmp.hlapi.asyncio.AsyncNotificationOriginator`
-    and their derivatives for adding new entries to Local Configuration
+    :py:func:`~pysnmp.hlapi.asyncio.getCmd` and the other command-generator
+    coroutines, or by :py:func:`~pysnmp.hlapi.asyncio.sendNotification`,
+    for adding new entries to Local Configuration
     Datastore (LCD) managed by :py:class:`~pysnmp.hlapi.SnmpEngine`
     class instance.
 
@@ -88,7 +88,7 @@ class CommunityData:
         refer to :RFC:`3413#section-4.1.1` and :RFC:`2576#section-5.3`
         (e.g. the *snmpCommunityTransportTag* object).
 
-        See also: :py:class:`~pysnmp.hlapi.UdpTransportTarget`
+        See also: :py:class:`~pysnmp.hlapi.asyncio.UdpTransportTarget`
 
     Warnings
     --------
@@ -247,9 +247,9 @@ class UsmUserData:
     """Creates SNMP v3 User Security Model (USM) configuration entry.
 
     This object can be used by
-    :py:class:`~pysnmp.hlapi.asyncio.AsyncCommandGenerator` or
-    :py:class:`~pysnmp.hlapi.asyncio.AsyncNotificationOriginator`
-    and their derivatives for adding new entries to Local Configuration
+    :py:func:`~pysnmp.hlapi.asyncio.getCmd` and the other command-generator
+    coroutines, or by :py:func:`~pysnmp.hlapi.asyncio.sendNotification`,
+    for adding new entries to Local Configuration
     Datastore (LCD) managed by :py:class:`~pysnmp.hlapi.SnmpEngine`
     class instance.
 

--- a/pysnmp/hlapi/context.py
+++ b/pysnmp/hlapi/context.py
@@ -15,8 +15,8 @@ class ContextData:
     """Creates UDP/IPv6 configuration entry and initialize socket API if needed.
 
     This object can be used by
-    :py:class:`~pysnmp.hlapi.asyncio.AsyncCommandGenerator` or
-    :py:class:`~pysnmp.hlapi.asyncio.AsyncNotificationOriginator`
+    :py:func:`~pysnmp.hlapi.asyncio.getCmd` and the other command-generator
+    coroutines, or by :py:func:`~pysnmp.hlapi.asyncio.sendNotification`,
     and their derevatives for forming SNMP PDU and also adding new entries to
     Local Configuration Datastore (LCD) in order to support SNMPv1/v2c with
     SNMPv3 interoperability.

--- a/pysnmp/proto/rfc1902.py
+++ b/pysnmp/proto/rfc1902.py
@@ -37,7 +37,7 @@ class Null(univ.Null):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -68,7 +68,7 @@ class Integer32(univ.Integer):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -140,7 +140,7 @@ class Integer(Integer32):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -203,7 +203,7 @@ class OctetString(univ.OctetString):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -285,7 +285,7 @@ class ObjectIdentifier(univ.ObjectIdentifier):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -319,7 +319,7 @@ class IpAddress(OctetString):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -377,7 +377,7 @@ class Counter32(univ.Integer):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -417,7 +417,7 @@ class Gauge32(univ.Integer):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -456,7 +456,7 @@ class Unsigned32(univ.Integer):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -495,7 +495,7 @@ class TimeTicks(univ.Integer):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -542,7 +542,7 @@ class Opaque(univ.OctetString):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -585,7 +585,7 @@ class Counter64(univ.Integer):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples
@@ -638,7 +638,7 @@ class Bits(OctetString):
 
     Raises
     ------
-        PyAsn1Error :
+        pyasn1.error.PyAsn1Error
             On constraint violation or bad initializer.
 
     Examples

--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -28,7 +28,7 @@ class ObjectIdentity:
     to by its MIB name. The *ObjectIdentity* class supports various forms
     of MIB variable identification, providing automatic conversion from
     one to others. At the same time *ObjectIdentity* objects behave like
-    :py:obj:`tuples` of py:obj:`int` sub-OIDs.
+    :py:obj:`tuple` of :py:obj:`int` sub-OIDs.
 
     See :RFC:`1902#section-2` for more information on OBJECT-IDENTITY
     SMI definitions.
@@ -109,7 +109,7 @@ class ObjectIdentity:
 
         Raises
         ------
-        SmiError
+        pysnmp.smi.error.SmiError
             If MIB variable conversion has not been performed.
 
         Examples
@@ -141,7 +141,7 @@ class ObjectIdentity:
 
         Raises
         ------
-        SmiError
+        pysnmp.smi.error.SmiError
            If MIB variable conversion has not been performed.
 
         Examples
@@ -175,7 +175,7 @@ class ObjectIdentity:
 
         Raises
         ------
-        SmiError
+        pysnmp.smi.error.SmiError
            If MIB variable conversion has not been performed.
 
         Notes
@@ -233,7 +233,7 @@ class ObjectIdentity:
         -----
         Please refer to :py:class:`~pysmi.reader.localfile.FileReader`,
         :py:class:`~pysmi.reader.httpclient.HttpReader` and
-        :py:class:`~pysmi.reader.ftpclient.FtpReader` classes for
+        :py:class:`~pysmi.reader.zipreader.ZipReader` classes for
         in-depth information on ASN.1 MIB lookup.
 
         Examples
@@ -333,7 +333,7 @@ class ObjectIdentity:
 
         Raises
         ------
-        SmiError
+        pysnmp.smi.error.SmiError
            In case of fatal MIB hanling errora
 
         Notes
@@ -791,7 +791,7 @@ class ObjectType:
         -----
         Please refer to :py:class:`~pysmi.reader.localfile.FileReader`,
         :py:class:`~pysmi.reader.httpclient.HttpReader` and
-        :py:class:`~pysmi.reader.ftpclient.FtpReader` classes for
+        :py:class:`~pysmi.reader.zipreader.ZipReader` classes for
         in-depth information on ASN.1 MIB lookup.
 
         Examples
@@ -881,7 +881,7 @@ class ObjectType:
 
         Raises
         ------
-        SmiError
+        pysnmp.smi.error.SmiError
            In case of fatal MIB hanling errora
 
         Notes
@@ -985,7 +985,7 @@ class ObjectType:
 
         Raises
         ------
-        SmiError
+        pysnmp.smi.error.SmiError
            If MIB variable conversion has not been performed.
         """
         if self.__state & self.stClean:
@@ -1007,7 +1007,7 @@ class NotificationType:
     containers incorporating :py:class:`~pysnmp.smi.rfc1902.ObjectIdentity`
     class instance (identifying particular notification) and a collection
     of MIB variables IDs that
-    :py:class:`~pysnmp.entity.rfc3413.oneliner.cmdgen.NotificationOriginator`
+    :py:func:`~pysnmp.hlapi.asyncio.sendNotification`
     should gather and put into notification message.
 
     Typical notification is defined like this (from *IF-MIB.txt*):
@@ -1147,7 +1147,7 @@ class NotificationType:
         -----
         Please refer to :py:class:`~pysmi.reader.localfile.FileReader`,
         :py:class:`~pysmi.reader.httpclient.HttpReader` and
-        :py:class:`~pysmi.reader.ftpclient.FtpReader` classes for
+        :py:class:`~pysmi.reader.zipreader.ZipReader` classes for
         in-depth information on ASN.1 MIB lookup.
 
         Examples
@@ -1240,7 +1240,7 @@ class NotificationType:
 
         Raises
         ------
-        SmiError
+        pysnmp.smi.error.SmiError
            In case of fatal MIB hanling errora
 
         Notes

--- a/pysnmp/smi/view.py
+++ b/pysnmp/smi/view.py
@@ -378,7 +378,7 @@ class MibViewController:
         :return: list of ``(colId, colName, colNode)`` tuples — one per
             column in the row.  ``colId`` is the column number (last
             sub-OID), ``colName`` is the full OID tuple, and ``colNode``
-            is the :class:`MibTableColumn` instance.
+            is the ``MibTableColumn`` instance.
         :raises SmiError: if the module or symbol is not found.
 
         Examples


### PR DESCRIPTION
Closes #177. **79 nitpicky warnings → 0**, and both docs jobs now run `-n`, so all three repositories build documentation identically.

Nothing is suppressed to get there: no `nitpick_ignore`.

## Stale references — wrong today, flag or no flag

| what | why |
| --- | --- |
| `AsyncCommandGenerator`, `AsyncNotificationOriginator` ×12 | **do not exist.** The 6.0 high-level API is coroutines; the docstrings now name `getCmd` and `sendNotification`. The same sentences also said "derevatives" |
| `pysmi.reader.ftpclient.FtpReader` ×3 | removed from pysmi; `ZipReader` is what it offers instead |
| `pysnmp.entity.rfc3413.oneliner.cmdgen.NotificationOriginator` | names a module removed in 6.0 |
| `:py:obj:`tuples`` | not a type |
| `MibTableColumn` ×2 | defined in `pysnmp/smi/mibs/SNMPv2-SMI.py`, whose name is not an importable path, so there is nothing to point at — reads as a literal now |

## The Raises sections

Every exception was named unqualified, so none resolved. Qualifying them was **not enough on its own**: in `proto/rfc1902.py` each entry was written

```
Raises
------
    PyAsn1Error :
        On constraint violation or bad initializer.
```

numpydoc's `Raises` section takes the name alone — the trailing ` :` is Parameters syntax — so Sphinx was looking up a target literally named `PyAsn1Error :`. That is why the count did not move when I first qualified them. With the stray colon removed, all 13 resolve through the pyasn1 intersphinx mapping repaired in #176.

## Objects nothing documented

`docs/api-internals.rst` gives them a home: `PySnmpError`, `SmiError` and the three crypto warnings; `SnmpResponse`, `endOfMibView` and `ObjectName`; `AbstractTransportTarget`; `MibBuilder` and `MibViewController`; and the synchronous `getCmd`/`setCmd`/`nextCmd`/`bulkCmd`.

Those last four are worth noting: they are **distinct functions** from the asyncio coroutines, not aliases — `pysnmp.hlapi.getCmd` comes from `hlapi.asyncio.sync.cmdgen` — so documenting them is not a duplicate.

`UdpTransportTarget` needed the opposite treatment. `pysnmp.hlapi` and `pysnmp.hlapi.asyncio` expose **one class under two names**, so documenting both collides on its canonical path — which is what the pre-existing `:no-index:` was for, and why `pysnmp.hlapi.UdpTransportTarget` had no target at all. The asyncio spelling stays the definition, since it is referenced 11 times across docstrings against 2 for the other, and the tutorial now points at it.

## Verification

- `sphinx-build -n -W --keep-going` — **build succeeded**, run as the CI job now runs it
- 935 tests pass, 12 skipped
- ruff check and ruff format clean

## Where this leaves the three

| | docs command |
| --- | --- |
| pyasn1 | `sphinx-build -n -W --keep-going -b html` |
| pysmi | `sphinx-build -n -W --keep-going -b html` |
| pysnmp | `sphinx-build -n -W --keep-going -b html` |

That was the last difference between them outside #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new API internals reference covering exceptions, warnings, return types, transport targets, MIB services, and command generators.
  * Updated tutorials and API documentation with corrected asyncio references, exception links, notification APIs, and MIB reader details.
  * Improved documentation formatting and cross-references throughout the project.
* **Chores**
  * Documentation builds now check unresolved references more strictly, helping identify incomplete or invalid links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->