### PR TITLE
build(mypy): exempt the generated MIB modules, so the real errors are visible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,15 @@ warn_redundant_casts = true
 no_implicit_optional = true
 files = ["pysnmp"]
 
+# Generated MIB modules bind mibBuilder and every symbol they use via
+# mibBuilder.importSymbols() at import time, so static analysis cannot see any
+# of it: 1279 of the 1339 errors mypy reported came from here, all of them
+# "Name is not defined". Ruff exempts the same files from F821 for the same
+# reason. These are generated artifacts, not hand-written code.
+[[tool.mypy.overrides]]
+module = ["pysnmp.smi.mibs.*", "pysnmp.smi.mibs.instances.*"]
+ignore_errors = true
+
 [[tool.mypy.overrides]]
 module = "pysnmp.hlapi.*"
 check_untyped_defs = true

--- a/pysnmp/debug.py
+++ b/pysnmp/debug.py
@@ -109,8 +109,10 @@ class Debug:
 
 
 # This will yield false from bitwise and with a flag, and save
-# on unnecessary calls
-logger = 0
+# on unnecessary calls. setLogger() replaces it with a Debug instance, so the
+# annotation has to admit both: without it every `debug.logger(...)` call in
+# the package reads as an attempt to call an int.
+logger: "Debug | int" = 0
 
 
 def setLogger(newLogger):


### PR DESCRIPTION
Refs #178 — **does not close it**. This is the step that makes the rest of that issue possible to work on; the analysis is on the issue.

## What this does

mypy reported **1339 errors across 68 files**, which is why nothing has ever run it. **1279 of them — 95% — come from `pysnmp/smi/mibs/`**, and every one is `Name … is not defined`:

```
pysnmp/smi/mibs/SNMPv2-MIB.py:12: error: Name "mibBuilder" is not defined  [name-defined]
```

Those modules bind `mibBuilder` and every symbol they use through `mibBuilder.importSymbols()` at import time, so no static analysis can see any of it. Ruff already exempts the same files from `F821` for exactly this reason, with the same comment — this applies the same treatment to mypy.

**Result: 1339 → 116**, all in hand-written code. Nobody could have found those 116 in the previous output.

`debug.logger` is annotated while here. It is assigned `0` and replaced by a `Debug` instance in `setLogger()`, so mypy inferred `int` and read all 243 call sites as calling an integer. The annotation states what it actually holds. It deliberately does **not** silence those errors — mypy still rejects calling the `int` arm — because they are a design question, not noise.

## Why #178 stays open

The remaining 116 are spread across every subpackage, so the staged `files:` narrowing that issue proposes buys almost nothing:

| subtree | files | with errors |
| --- | --- | --- |
| `pysnmp/*.py` | 5 | 0 |
| `pysnmp/carrier` | 13 | 5 |
| `pysnmp/entity` | 15 | 5 |
| `pysnmp/hlapi` | 17 | 4 |
| `pysnmp/proto` | 54 | 18 |
| `pysnmp/smi` | 9 | 3 |

And they are substantive rather than mechanical — Liskov violations on `_resolveAddr`, `Optional` handling, a shadowed name. **33 of them are one root cause**: the `debug.logger & debug.flagBld and debug.logger(...)` idiom, used 243 times. Making that type-clean means a null-object with `__bool__`, `__and__` and `__call__`, because `Debug()` logs and builds a `Printer` in its constructor and so cannot be the default. That is a real refactor of the debug path, and not something to slip into a "turn the hook on" change.

The ruff half is larger still: the pysmi/pyasn1 rule set reports **3424 violations** here, and **1438** even excluding the generated MIBs and the docstring families.

Both are worth doing. Neither is a pass.

## Verification

No runtime change — the diff is `pyproject.toml` and one annotation. 935 tests pass, 12 skipped; ruff check and format clean; docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved static type-checking compatibility for dynamically generated management information modules.
  - Clarified supported logger configuration types, improving type-checking for applications that configure debugging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->