### PR TITLE
chore(deps)!: bump pysnmp-pyasn1 to 2.0.0 and pysnmp-pysmi to 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 ]
 readme = "README.md"
 dependencies = [
-    "pysnmp-pysmi >=2.0.1,<3.0.0",
+    "pysnmp-pysmi >=2.1.0,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
-    "pysnmp-pyasn1 >=1.3.0,<2.0.0",
+    "pysnmp-pyasn1 >=2.0.0,<3.0.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -888,24 +888,24 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pyasn1"
-version = "1.3.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/a8/eb7460392fb7f3eac1cbe6a35685db8a5e7ce0d4c2ba8006d962fb9cc3e2/pysnmp_pyasn1-1.3.0.tar.gz", hash = "sha256:e6d82f53e1b1f45cfdf50d0a83e535747615b920c0dd7ae4b4fd098e1725f882", size = 316276, upload-time = "2026-09-05T17:18:06.437Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/1c/30fea6d456af4d0e374f4c4d9003592c7cd79b37b4e2be59c12a2b914a1f/pysnmp_pyasn1-2.0.0.tar.gz", hash = "sha256:d9b4d016f3112eb1941c6ddbac2e0b1ebd337a7936b462a32625f0e4eabca9f7", size = 321076, upload-time = "2026-09-05T17:48:31.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/24/82bd59c919a4dbca9a484745eda46c413a550470c3b4c25583085d4fbabc/pysnmp_pyasn1-1.3.0-py3-none-any.whl", hash = "sha256:c7fcdc8ce38c39decd11319dfc53b8cb8a826ea2eb17fb197ff380c9b9623a6b", size = 108628, upload-time = "2026-09-05T17:18:04.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/c7/011f98976f650edf36bd20525fbe32f0ce2d28fb21a5b959212051f3415b/pysnmp_pyasn1-2.0.0-py3-none-any.whl", hash = "sha256:897861419e8d33d7912772364a52d079a32d979d5f4784d0da98772c769efddb", size = 108627, upload-time = "2026-09-05T17:48:29.641Z" },
 ]
 
 [[package]]
 name = "pysnmp-pysmi"
-version = "2.0.1"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/24/fd287d29784081079bad18b6e61fd42cf719776709707f2489f3b000fdea/pysnmp_pysmi-2.0.1.tar.gz", hash = "sha256:95862000ea63b373fe5e960d3f8e3604e0694184f5f0d59e9de6c5b57462b6ca", size = 388136, upload-time = "2026-09-03T21:42:41.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/99/248d447747728ffb86997aec2fe6c2b4cfc8283a603930f63464a384727d/pysnmp_pysmi-2.1.0.tar.gz", hash = "sha256:a12ce0f8cd4023951054d5f018cdb3fc47def35a98aa45153b7407655ef63eb1", size = 497322, upload-time = "2026-09-06T01:48:57.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/66/c37d323185e30d96d7d27e365a7049aad030eae7f597d753ab5ff7fc9c9c/pysnmp_pysmi-2.0.1-py3-none-any.whl", hash = "sha256:360886465b9e93970de597d33a4d656eeec7bf77fb1872120792ff02e8dba305", size = 171913, upload-time = "2026-09-03T21:42:40.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e4/cc811b7239f893387b2908d85486d8f4742779c8cc300ad0cc92b7af99a0/pysnmp_pysmi-2.1.0-py3-none-any.whl", hash = "sha256:52f76c530bc54e3afb5e1ea425eea34631c9546e94641e3d17ba5af8ab64aa89", size = 367524, upload-time = "2026-09-06T01:48:55.853Z" },
 ]
 
 [[package]]
@@ -932,8 +932,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
-    { name = "pysnmp-pyasn1", specifier = ">=1.3.0,<2.0.0" },
-    { name = "pysnmp-pysmi", specifier = ">=2.0.1,<3.0.0" },
+    { name = "pysnmp-pyasn1", specifier = ">=2.0.0,<3.0.0" },
+    { name = "pysnmp-pysmi", specifier = ">=2.1.0,<3.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1057,7 +1057,7 @@ name = "roman-numerals-py"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "roman-numerals" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
 wheels = [
@@ -1106,23 +1106,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -1139,23 +1139,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals-py" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.11'" },
+    { name = "babel", marker = "python_full_version >= '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "imagesize", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [


### PR DESCRIPTION
Moves both first-party dependency floors to their GA releases.

| Package | Before | After |
| --- | --- | --- |
| `pysnmp-pyasn1` | `>=1.3.0,<2.0.0` | `>=2.0.0,<3.0.0` |
| `pysnmp-pysmi` | `>=2.0.1,<3.0.0` | `>=2.1.0,<3.0.0` |

The prerelease specifier that was temporarily needed to reach `pysmi 2.1.0-rc.2` is dropped now that 2.1.0 is on PyPI.

## On the pyasn1 major bump

`pysnmp-pyasn1` 2.0.0 is byte-identical to 1.3.0 in library code — an AST comparison across every changed file shows
`__init__.py`'s version string as the only executable difference; the rest are Sphinx docstring cross-reference repairs.
The major came from pyasn1 adopting the `conventionalcommits` preset, which parsed a `!` marker on a CI commit.

The commit is still marked breaking here, because pysnmp's declared requirement floor genuinely moves to 2.x and
downstream resolvers will see that.

## Verification

- `uv lock` + `uv sync` resolve cleanly to `pysnmp-pyasn1 2.0.0` and `pysnmp-pysmi 2.1.0`
- 924 passed, 12 skipped, 0 failed
- MIB load smoke test (SNMPv2-MIB, IF-MIB, SNMP-COMMUNITY-MIB) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated runtime dependency version requirements to support newer compatible releases.
  - Retained upper-version bounds for the affected dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->