### PR TITLE
ci: release runtime dependency bumps, not just record them

### DIFF
--- a/.github/copilot/copilot-instructions.md
+++ b/.github/copilot/copilot-instructions.md
@@ -189,16 +189,22 @@ This is a pure-Python SNMP v1/v2c/v3 engine. The package layout mirrors the SNMP
 
 ### Commit message conventions
 
-Releases are cut by semantic-release with the Angular preset: only `feat`, `fix`, `perf` and `BREAKING CHANGE` produce a
-version. `chore`, `ci`, `docs`, `refactor`, `style` and `test` never do.
+Releases are cut by semantic-release with the `conventionalcommits` preset: only `feat`, `fix`, `perf` and a breaking
+change (`!` or a `BREAKING CHANGE:` footer) produce a version. `build`, `chore`, `ci`, `docs`, `refactor`, `style` and
+`test` never do. See [`.github/semantic-release.md`](../semantic-release.md) for the full mapping.
 
-- Runtime dependency changes are **`fix(deps):`**, not `chore(deps):`. Raising a floor in `[project].dependencies`
-  changes what users resolve and install, so it must ship as a release.
+For dependencies the **scope** decides, not the type — `.releaserc` carries explicit `releaseRules` for it:
+
+- Runtime dependency changes are **`fix(deps):`**. Raising a floor in `[project].dependencies` changes what users
+  resolve and install, so it must ship as a release.
   Example: `fix(deps): require pysnmp-pyasn1 >=1.2.0`
-- Development-only dependency changes (`[dependency-groups]`, pre-commit hooks, CI actions) stay `chore(deps):` or `ci:`
-  — they are invisible to installers.
-- A `chore(deps):` runtime bump merged to `next` or `main` will sit unreleased until an unrelated releasable commit
-  lands. Use the correct type up front rather than fixing it after the fact.
+- Development-only dependency changes (`[dependency-groups]`) are **`chore(deps-dev):`** — they are invisible to
+  installers and release nothing. Pre-commit hooks and workflow actions are `ci:` (dependabot writes `ci(actions):`).
+- The `deps` scope releases a patch whatever type it is written with, and the `deps-dev` scope releases nothing
+  whatever type it is written with. That is a backstop, not a licence: the release notes are grouped by type, and a
+  `chore` is not printed in them at all. Use the right type up front.
+- Do not write the scope into a dependabot `commit-message.prefix` — dependabot appends its own, and the message comes
+  out as `chore(deps)(deps): ...`.
 
 ## General Best Practices
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+
+# Dependabot reads this file from the default branch (main) but opens its pull
+# requests against target-branch. next is where work integrates and where the
+# rc is cut; main only ever receives a merge from next, so bumps have to land on
+# next or the two branches drift and every promotion conflicts.
+updates:
+  # Runtime dependencies ([project].dependencies) and development-only ones
+  # ([dependency-groups]) live in the same files but are not the same kind of
+  # change, and only the first kind is worth a version:
+  #
+  #   fix(deps): bump requests from 2.31.0 to 2.32.0      -> patch release
+  #   chore(deps-dev): bump ruff from 0.8.0 to 0.9.0      -> no release
+  #
+  # A runtime bump changes what an installer resolves, so it has to reach PyPI
+  # to mean anything; a dev bump is invisible outside this repository.
+  #
+  # prefix applies to runtime dependencies and prefix-development to the rest;
+  # include: scope appends the (deps) / (deps-dev) scope that .releaserc keys
+  # its release rules on. The scope must NOT be written into the prefix itself
+  # -- dependabot appends its own, and "chore(deps)" would come out as
+  # "chore(deps)(deps): ...", which no conventional-commits parser reads.
+  #
+  # Do not group these updates: one pull request carrying both a runtime and a
+  # dev bump can only have one commit message, so the distinction is lost.
+  - package-ecosystem: "uv"
+    directory: "/"
+    target-branch: "next"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"
+
+  # Actions are CI plumbing: nothing an installer ever resolves, so nothing to
+  # release. The scope is deliberately not "deps" -- .releaserc reads that scope
+  # as "a published dependency changed" and cuts a patch for it whatever the
+  # type is. No include: scope here, for the same reason.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "next"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "ci(actions)"

--- a/.github/semantic-release.md
+++ b/.github/semantic-release.md
@@ -1,0 +1,69 @@
+# Releases and commit conventions
+
+Versions are cut by [semantic-release](https://semantic-release.gitbook.io/) from
+the commit history. Nothing is versioned by hand: `.releaserc` writes the version
+into `pyproject.toml` and `__init__.py`, generates `CHANGELOG.md`, tags, and
+publishes. What decides the version is the type and scope of the commits since
+the last release, so the commit message is the release note and the release
+trigger at once.
+
+`next` is where work integrates and where the rc is cut; merging `next` into
+`main` cuts the GA. Both are cut by dispatching the CI workflow by hand — every
+other push is a dry run.
+
+## Types
+
+The `conventionalcommits` preset is in use, so `<type>(<scope>): <subject>`:
+
+| Type | Release | Appears in the notes |
+| --- | --- | --- |
+| `fix` | patch | Bug Fixes |
+| `feat` | minor | Features |
+| `perf` | patch | Performance Improvements |
+| any type with `!` or a `BREAKING CHANGE:` footer | major | Breaking Changes |
+| `build`, `chore`, `ci`, `docs`, `refactor`, `style`, `test` | none | no |
+
+A commit whose type releases nothing is not lost -- it ships with the next
+release that something else triggers. It just cannot cause one on its own.
+
+## Dependencies
+
+A dependency bump is the one case where the scope, not the type, decides:
+
+| Scope | Means | Release |
+| --- | --- | --- |
+| `deps` | a dependency in `[project].dependencies` moved | patch, whatever the type |
+| `deps-dev` | a dependency in `[dependency-groups]` moved | none, whatever the type |
+
+Write runtime bumps as **`fix(deps):`** and development-only bumps as
+**`chore(deps-dev):`**. Those are the messages
+[`.github/dependabot.yml`](dependabot.yml) is configured to produce, and the
+ones that read correctly in the release notes.
+
+The reason for the split is what a bump changes for someone who is not working
+in this repository. `[project].dependencies` is published metadata: raising a
+floor there changes what every installer resolves, and until a release carries
+it to PyPI the change may as well not exist. `[dependency-groups]` is not
+published at all -- it is how this repository tests itself, and no released
+artifact mentions it. CI plumbing (workflow actions, pre-commit hooks) is the
+same: `ci:`, and no `deps` scope.
+
+`.releaserc` enforces this with explicit `releaseRules` rather than trusting the
+type alone, so a runtime bump written as `chore(deps):` still cuts a patch
+instead of sitting unreleased until an unrelated commit lands, and a dev bump
+written as `fix(deps-dev):` still cuts nothing. Prefer the right type anyway:
+release rules control the version, but the notes are grouped by type, and a
+`chore` is not printed in them at all.
+
+Breaking changes and `feat(deps)` keep their normal meaning -- the rules restate
+them, because a custom rule that matches short-circuits the built-in ones.
+
+## Examples
+
+```
+fix(deps): require pysnmp-pyasn1 >=1.3.0          # patch, published
+chore(deps-dev): bump ruff from 0.8.0 to 0.9.0    # nothing
+ci(actions): bump actions/checkout from 7 to 8    # nothing
+feat(deps): support the pure-Python crypto backend # minor
+fix(deps)!: drop Python 3.9                       # major
+```

--- a/.releaserc
+++ b/.releaserc
@@ -11,7 +11,13 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits"
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "breaking": true, "release": "major" },
+          { "scope": "deps-dev", "release": false },
+          { "type": "feat", "scope": "deps", "release": "minor" },
+          { "scope": "deps", "release": "patch" }
+        ]
       }
     ],
     [


### PR DESCRIPTION
A dependency bump written as `chore(deps)` versions nothing and releases nothing, so a raised floor in `[project].dependencies` never reached PyPI — it would sit in the history until an unrelated `fix` or `feat` happened to land. That is backwards: published metadata is the one kind of dependency change an installer can actually see. It matters most here, where the runtime dependencies are `pysnmp-pysmi` and `pysnmp-pyasn1` and a floor bump is how a fix in a sibling repository actually reaches users.

This repository had no Dependabot configuration at all, so this adds one alongside the release rules that make it mean something.

## The split

The **scope** decides, not the type:

| message | release |
| --- | --- |
| `fix(deps): require pysnmp-pyasn1 >=1.3.0` | patch |
| `chore(deps-dev): bump ruff from 0.8.0 to 0.9.0` | none |
| `ci(actions): bump actions/checkout from 7 to 8` | none |

`[project].dependencies` is published metadata; `[dependency-groups]` and CI plumbing are invisible outside this repository.

## Changes

**`.github/dependabot.yml`** — new. `prefix: fix` / `prefix-development: chore` / `include: scope` on the `uv` ecosystem, which is Dependabot's own production-vs-development split. Actions get their own `ci(actions)` prefix and deliberately no `deps` scope, so CI plumbing can never borrow it and cut a release. The scope must come from `include` alone — Dependabot appends its own, so a prefix that already carries one comes out as `chore(deps)(deps): ...`, which parses as nothing.

Updates are left ungrouped on purpose: one pull request carrying both a runtime and a dev bump can only have one commit message, so the distinction would be lost.

**`.releaserc`** — explicit `releaseRules` back the convention up, so a runtime bump still cuts a patch when someone writes it as `chore(deps)` by hand, and a dev bump cuts nothing even written as `fix(deps-dev)`. Custom rules short-circuit the built-in ones, so breaking changes and `feat(deps)` are restated or they would be demoted to a patch.

**`.github/copilot/copilot-instructions.md`** — the existing "Commit message conventions" section already called for `fix(deps):`, which is what prompted this. Two things in it were wrong: it named the Angular preset where `.releaserc` uses `conventionalcommits`, and it told contributors to write development-only bumps as `chore(deps):` — the same scope that now cuts a release. Corrected to `chore(deps-dev):`, matching what Dependabot emits.

**`.github/semantic-release.md`** — new, documenting the full type/scope-to-release mapping.

## Target branch

Dependabot targets `next`, so bumps follow the same path as every other change — integrate on `next`, promote to `main`. Note that Dependabot reads this file only from the default branch, so it starts working once `next` promotes to `main`.

## Verification

Ran `@semantic-release/commit-analyzer@13` (what `semantic_version: 24` resolves to) against this repository's actual `.releaserc`, over fifteen representative messages spanning the deps scopes and the ordinary types. All resolved to the intended release type, including `fix(deps)!` → major, `chore(deps)` → patch, `fix(deps-dev)` → none, and `ci(actions)` → none.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx2w8JKAN1wxVFrb7cX3K1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hx2w8JKAN1wxVFrb7cX3K1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated daily runtime and development dependency update checks.
  - Added weekly GitHub Actions update checks.
  - Updates are categorized with consistent commit prefixes and labels.

- **Documentation**
  - Documented release versioning rules, commit types, dependency scopes, branch workflows, and changelog behavior.
  - Clarified how breaking changes and dependency updates affect release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->