### PR TITLE
fix(deps): track pysmi and pyasn1 release candidates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,28 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 readme = "README.md"
+# The two sibling floors name a release candidate on purpose, and naming one is
+# the only way to say this: dependabot offers a prerelease when the current
+# version is already one OR when a requirement string names one, and there is no
+# configuration key for it (dependabot/dependabot-core#1926, closed as not
+# planned). PEP 440 admits prereleases per specifier, so this puts pysmi and
+# pyasn1 -- and only them, pycryptodomex keeps its stable floor -- on the rc
+# stream, and this repository integrates against the siblings it is released
+# alongside instead of against their last GA.
+#
+# Each floor names the last rc of the line its GA is on, so it sits one hair
+# below the GA rather than above it. Resolution takes the newest allowed
+# version regardless, so today these still resolve to pysmi 2.1.0 and pyasn1
+# 2.0.0; the rc floors only start to matter once a sibling publishes an rc
+# ahead of its next GA.
+#
+# This belongs to the 6.0.0 rc cycle, not to the package forever. Put both
+# floors back on a GA before cutting the 6.0.0 GA, or a released pysnmplib
+# lets an installer resolve sibling release candidates.
 dependencies = [
-    "pysnmp-pysmi >=2.1.0,<3.0.0",
+    "pysnmp-pysmi >=2.1.0rc3,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
-    "pysnmp-pyasn1 >=2.0.0,<3.0.0",
+    "pysnmp-pyasn1 >=2.0.0rc2,<3.0.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -932,8 +932,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
-    { name = "pysnmp-pyasn1", specifier = ">=2.0.0,<3.0.0" },
-    { name = "pysnmp-pysmi", specifier = ">=2.1.0,<3.0.0" },
+    { name = "pysnmp-pyasn1", specifier = ">=2.0.0rc2,<3.0.0" },
+    { name = "pysnmp-pysmi", specifier = ">=2.1.0rc3,<3.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
pysnmp is cut as 6.0.0-rc.N against two siblings that are themselves on an rc stream, but its floors named their GAs — so it only ever integrated against their last stable release. A sibling rc could not be exercised here until it shipped, which is the wrong way round: the rc is the thing that needs exercising.

## Why the specifier, and not configuration

There is no Dependabot option for this. Dependabot offers a prerelease when the dependency's current version is already one, **or** when a requirement string names one, and nothing else — the feature request ([dependabot-core#1926](https://github.com/dependabot/dependabot-core/issues/1926)) was closed as not planned. From `wants_prerelease?` in `common/lib/dependabot/package/package_latest_version_finder.rb`:

```ruby
def wants_prerelease?
  return true if dependency.numeric_version&.prerelease?
  dependency.requirements.any? do |req|
    # ... true if any requirement string names a prerelease
  end
end
```

The locked version being a final does not block it, so naming an rc in the specifier is the whole mechanism. And because PEP 440 decides prerelease admission per specifier, it applies to exactly these two: `pycryptodomex` keeps its stable floor and still refuses rcs.

## What changes

```diff
-    "pysnmp-pysmi >=2.1.0,<3.0.0",
+    "pysnmp-pysmi >=2.1.0rc3,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
-    "pysnmp-pyasn1 >=2.0.0,<3.0.0",
+    "pysnmp-pyasn1 >=2.0.0rc2,<3.0.0",
```

Each floor names the last rc of the line its GA is on, so it sits a hair below the GA rather than above it, and resolution still takes the newest allowed version. **`uv.lock` is unchanged in what it pins** — pysmi 2.1.0 and pyasn1 2.0.0, exactly as before; only the recorded `requires-dist` strings move. The floors start to bite once a sibling publishes an rc ahead of its next GA.

## Verification

`SpecifierSet.filter` is the policy a resolver applies, so it is what decides this:

| specifier | candidates | picks |
| --- | --- | --- |
| `>=2.1.0rc3,<3.0.0` (new) | 2.1.0, 2.2.0rc1 | **2.2.0rc1** |
| `>=2.1.0,<3.0.0` (old) | 2.1.0, 2.2.0rc1 | 2.1.0 |
| `>=2.0.0rc2,<3.0.0` (new) | 2.0.0, 2.1.0rc1 | **2.1.0rc1** |
| `>=2.0.0,<3.0.0` (old) | 2.0.0, 2.1.0rc1 | 2.0.0 |
| `>=3.11.0,<4.0.0` (unchanged) | 3.23.0, 3.24.0rc1 | 3.23.0 |

Suite: 935 passed, 12 skipped. `uv lock --check` passes.

## Temporary by design

This belongs to the 6.0.0 rc cycle, not to the package forever. The comment on the dependency block says so explicitly: put both floors back on a GA before the 6.0.0 GA is cut, or a released `pysnmplib` lets an installer resolve sibling release candidates.

The commit is `fix(deps)`, which under the rules merged in #184 cuts a patch — correct here, because the published floors genuinely changed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx2w8JKAN1wxVFrb7cX3K1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hx2w8JKAN1wxVFrb7cX3K1)_