### PR TITLE
ci: gate on mypy against the real dependency set, as pyasn1 does

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -33,6 +33,37 @@ jobs:
           python-version: "3.10"
       - uses: pre-commit/action@v3.0.1
 
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - name: Install UV
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked
+      # The pre-commit job runs ruff and mypy too, but mypy there sees none of
+      # this package's dependencies -- so anything that turns on a pyasn1 or
+      # pysmi type only fails here. Matches pyasn1's lint job.
+      - name: Run Ruff
+        run: uv run ruff check .
+      - name: Check formatting
+        run: uv run ruff format --check .
+      - name: Run mypy
+        run: uv run mypy
+
+      # Advisory only. ty is pre-1.0 and has no disallow_untyped_defs
+      # equivalent, so mypy above remains the blocking gate. ty catches
+      # things mypy misses, notably Liskov override violations.
+      - name: Run ty (advisory)
+        run: uv run ty check pysnmp
+        continue-on-error: true
+
   docs:
     name: docs
     runs-on: ubuntu-latest
@@ -173,6 +204,7 @@ jobs:
       DRY: ${{ github.event_name != 'workflow_dispatch' }}
     needs:
       - pre-commit
+      - lint
       - docs
       - build
       - run-unit-tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "coverage[toml] >=7.2.0,<8.0.0",
     "mypy >=1.15.0,<3.0.0",
     "ruff >=0.4.0,<1.0.0",
+    "ty>=0.0.77",
 ]
 
 [tool.pytest.ini_options]
@@ -235,3 +236,10 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = "pysnmp.hlapi.*"
 check_untyped_defs = true
+
+# ty has no per-module equivalent of mypy's ignore_errors, so the generated MIB
+# modules are excluded from its source set for the same reason: they bind every
+# name they use through mibBuilder.importSymbols() at import time, and ty
+# reports 1053 unresolved references across them.
+[tool.ty.src]
+exclude = ["pysnmp/smi/mibs"]

--- a/uv.lock
+++ b/uv.lock
@@ -888,11 +888,11 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pyasn1"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/1c/30fea6d456af4d0e374f4c4d9003592c7cd79b37b4e2be59c12a2b914a1f/pysnmp_pyasn1-2.0.0.tar.gz", hash = "sha256:d9b4d016f3112eb1941c6ddbac2e0b1ebd337a7936b462a32625f0e4eabca9f7", size = 321076, upload-time = "2026-09-05T17:48:31.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/f8/9d17dff241c023116ab48bfa1e7180a9e9a3dbc8a63f3721d3b97ddb2d7e/pysnmp_pyasn1-2.0.1.tar.gz", hash = "sha256:776e624e83b6d8bdb30a0d03379b346bcfebbb752f6f02ad05287888c876483f", size = 229839, upload-time = "2026-09-06T02:48:23.616Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/c7/011f98976f650edf36bd20525fbe32f0ce2d28fb21a5b959212051f3415b/pysnmp_pyasn1-2.0.0-py3-none-any.whl", hash = "sha256:897861419e8d33d7912772364a52d079a32d979d5f4784d0da98772c769efddb", size = 108627, upload-time = "2026-09-05T17:48:29.641Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/5b/56bf01541234545eff651c273f4ef7909e6be45a6b51ba1b2be0dec13631/pysnmp_pyasn1-2.0.1-py3-none-any.whl", hash = "sha256:9cf4b0db4ac03b7394f46f389cfb7d8947c9a0757e881d6a45e7eb2cbd6cd600", size = 108633, upload-time = "2026-09-06T02:48:22.162Z" },
 ]
 
 [[package]]
@@ -927,6 +927,7 @@ dev = [
     { name = "ruff" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -944,6 +945,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "ruff", specifier = ">=0.4.0,<1.0.0" },
     { name = "sphinx", specifier = ">=7.0.0,<9.0.0" },
+    { name = "ty", specifier = ">=0.0.77" },
 ]
 
 [[package]]
@@ -1268,6 +1270,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.78"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/c7/2ba0861384c5b5097ac354383abb98188112cb330208c21d5197e98a29e5/ty-0.0.78.tar.gz", hash = "sha256:770b45854f85fa11595208f08c0f28df80943164d10a2832d86be6ac29f135b2", size = 7050609, upload-time = "2026-09-02T22:41:33.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/ed/f34cfc06a9ba72979df219e48dae1a0b6a6c74a340763ccd30a547edf913/ty-0.0.78-py3-none-linux_armv6l.whl", hash = "sha256:122700b98f9d45785c1ce91a9418154562e7f64f4bf34679f6f7b38c5b97453f", size = 13304624, upload-time = "2026-09-02T22:40:56.649Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/28/5576e2a08b57676d9b2a736d528f077a6c6e32c3d1de2d75dbbe28346966/ty-0.0.78-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cbe7e3709ccf29ef3d9f58f5914cc30ec36fb647008a5a4ff8483abe401bfe8d", size = 12928383, upload-time = "2026-09-02T22:40:59.162Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/027d49c3da5235e634da3d3fc52c4874ec89f50830388c9c259f8fb71e0e/ty-0.0.78-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c3528897b3ab9d3589561bc2b5e61a4d5d686de527a4400bb09a439b922a6c70", size = 12730058, upload-time = "2026-09-02T22:41:01.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/bc/6bf8ffefd8063730a70ae889cf85def72bc155fd1453135ebf8a09c2f1c2/ty-0.0.78-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8bfba4c44a06484093f527b8ef43a317abcf91395b49396170266629eedf74aa", size = 12813321, upload-time = "2026-09-02T22:41:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/c0/b3cdf26f82108908d92fdb7ddb741019c446ceb666cf204d4dbf611bde33/ty-0.0.78-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f903c06fdee17baf8373173039ab28f1bce28e66b1c734929a5f50b37eb54d9", size = 13072219, upload-time = "2026-09-02T22:41:05.225Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/36/16bfb0abdd178dae11dbc4b57b9a86c2b62642a18c1103fd2c2930aa5879/ty-0.0.78-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd83e5fe3f07291d1bd4e591f8d2607c204f3eab53bcb1b8060c40e876e1aa61", size = 13903958, upload-time = "2026-09-02T22:41:07.333Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/0c/74d3b1f0344b13156c719dd68a7edf7e48c2051718c9f326ba3cbf45ea53/ty-0.0.78-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:325285377319cf7168a2b8b771ae5027f411530e3c7eab1faf4583cdd72fd7c9", size = 14355581, upload-time = "2026-09-02T22:41:09.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d7/7ca0359e1e61b15b8b02328c8d120db3c507876b9b7c6bd9f26935353e0e/ty-0.0.78-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b7846a404da6492697b524a769755ee9bee157d67674063ecd9c5f69dc52ff", size = 14044749, upload-time = "2026-09-02T22:41:11.678Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6a/731f16ff42c5fc96e742c2f4e0a6915356bae114ae02ae4af6f33502175f/ty-0.0.78-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:169d3b9d134c0b48fe1af8a844142d374655552054a9d6c15a4b6e51bb0382ea", size = 13391647, upload-time = "2026-09-02T22:41:13.928Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/af/250cc29daf310e837188509ea4d78460c495d8a74c4fb84b4152d9ef2d4f/ty-0.0.78-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6108cb3b2d28dac5981d4e25008a0a5547d8c877a67f6da9e8c38e7e946be44f", size = 13945020, upload-time = "2026-09-02T22:41:15.968Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f9/96aab1dee4535e66554e8dc7657c69f6c61c181d8e70b9c3527908e93ef4/ty-0.0.78-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:589ad03608d9d2975ef4b23c41c4f847e325bcc7686f51d4c66066b8dbc18a2a", size = 12851149, upload-time = "2026-09-02T22:41:18.06Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b0/53d8fe9a847534ef5fe2165c7d5292cb853b29dfd7011cbfb1cdb90a8012/ty-0.0.78-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b3fa0786edc1af06030f872d83499c0cea7c261dbbb651e0aee8306bf2c8a869", size = 13091464, upload-time = "2026-09-02T22:41:20.227Z" },
+    { url = "https://files.pythonhosted.org/packages/21/65/94a4e5a02de559f6c6c0ee7a14b88660b4eee058ec6fec5c0ff6ecfbf5cc/ty-0.0.78-py3-none-musllinux_1_2_i686.whl", hash = "sha256:92c5639befc577578c8abd4e5a7fccf98d828db98b09e8d4dd81605dc0e54aef", size = 13389389, upload-time = "2026-09-02T22:41:22.27Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/d0c7fe6be64ca5a15100c4b1f0e39c19660d53bc544f609fa117b346e661/ty-0.0.78-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0dce70bc51652b2775debd1d1e422fb0179f5207c73deb4d5d0aca37e5f61695", size = 13691928, upload-time = "2026-09-02T22:41:24.292Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5d/36081205611ba3fa802efc4ad63e4b1e949bda2f7bb37b34ac9bb6c00db0/ty-0.0.78-py3-none-win32.whl", hash = "sha256:1c80976ca9185d7a9d1baab1fb57240331b8dac58d3b11e46200284086a6de8d", size = 12647346, upload-time = "2026-09-02T22:41:26.699Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/89/b925fe1ea1bc56fc7f11d2496e29072fdd2ceb7b389884fc7b2d07cf0c41/ty-0.0.78-py3-none-win_amd64.whl", hash = "sha256:32e82b704471eab34f67b51c151660ca8a00815977b28278905d76fba54f7415", size = 13241810, upload-time = "2026-09-02T22:41:28.857Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f1/090ef7b52355bcedfbfbff6ce70fa81ba5bd5f6ed3f8d99ae05e6f2fe75b/ty-0.0.78-py3-none-win_arm64.whl", hash = "sha256:3a14d641a3c04fa9a80f2a46be1531d915f60d4fb79d4b894627bbe46bb35d64", size = 13077433, upload-time = "2026-09-02T22:41:31.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to #187, now that pysnmp/pyasn1#165 is merged and released as pysnmp-pyasn1 2.0.1.

## Why

The `pre-commit` job runs mypy, but `mirrors-mypy` installs no project dependencies, so it sees pyasn1 and pysmi as `Any`. That is exactly why the two `univ.SequenceOf.componentType` errors #187 could not fix never showed up there — the hook cannot see the type it would have to contradict. A type gate that cannot see the package's own dependencies is not a type gate.

pyasn1 has had a `lint` job doing this properly for a while; pysnmp only had `pre-commit`. This closes that gap.

## What

- New `lint` job, byte-for-byte the shape of pyasn1's: `uv sync --locked`, then `ruff check`, `ruff format --check`, `uv run mypy`.
- Added to the release gate's `needs`, alongside `pre-commit`, `docs`, `build` and `run-unit-tests`.
- `pysnmp-pyasn1` moved 2.0.0 → 2.0.1 in `uv.lock`, which is what makes the gate green: with it, `mypy` reports **no issues found in 148 source files**.
- The advisory `ty` step comes with it, again matching pyasn1. `ty` is pre-1.0 and has no `disallow_untyped_defs` equivalent, so mypy stays the blocking gate; `ty` catches things mypy misses — notably the Liskov override violations `AbstractTransportTarget` had before #187.

```toml
# ty has no per-module equivalent of mypy's ignore_errors, so the generated MIB
# modules are excluded from its source set for the same reason: they bind every
# name they use through mibBuilder.importSymbols() at import time, and ty
# reports 1053 unresolved references across them.
[tool.ty.src]
exclude = ["pysnmp/smi/mibs"]
```

Without that exclusion `ty` prints 1151 diagnostics, 1053 of them the generated-MIB noise mypy already exempts. With it, 76 — a readable advisory signal rather than a wall.

## Verification

- `uv run mypy`: no issues found in 148 source files
- `ruff check` / `ruff format --check`: clean
- `pytest`: 950 passed, 12 skipped
- `pre-commit run --all-files`: passes
- `ty check pysnmp`: 76 diagnostics (advisory, `continue-on-error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQnZaCAsGNod89Kjz4R4Eu)_