### PR TITLE
ci: check commit messages against the conventions

### DIFF
--- a/.github/semantic-release.md
+++ b/.github/semantic-release.md
@@ -67,3 +67,56 @@ ci(actions): bump actions/checkout from 7 to 8    # nothing
 feat(deps): support the pure-Python crypto backend # minor
 fix(deps)!: drop Python 3.9                       # major
 ```
+
+## Enforcement
+
+None of the above works if the message is not conventional in the first place,
+so the format is checked rather than assumed. Both checks read the same
+[`commitlint.config.mjs`](../commitlint.config.mjs) at the repository root:
+
+| Where | What it checks |
+| --- | --- |
+| the `commit-msg` hook, from [`.pre-commit-config.yaml`](../.pre-commit-config.yaml) | the message being written, before the commit exists |
+| the `Commit conventions` workflow, on every pull request | every commit in the pull request |
+
+Install the hook once per checkout:
+
+```console
+$ pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+pre-commit installed at .git/hooks/commit-msg
+```
+
+`default_install_hook_types` is what adds the second line. A checkout that ran
+`pre-commit install` before that setting existed has to run it again, or the
+`commit-msg` hook is configured and never runs. The hook does not run under
+`pre-commit run --all-files`, so the `pre-commit` CI job does not duplicate the
+workflow.
+
+The rules are `@commitlint/config-conventional` with three deliberate changes:
+
+- the type list is restated in the config, so it cannot drift if the shared
+  preset widens it;
+- body and footer line lengths are unlimited -- the `chore(release):` commit
+  carries the entire release notes, and a dependabot body carries compare
+  links, neither of which wraps to a column;
+- subject case is not checked. `fix: Windows path handling` is prose, not a
+  style error. The *type* is still lower case, because `Fix:` is not what the
+  release rules match on and would release nothing.
+
+Merge commits, `fixup!` commits and git's own `Revert "..."` subjects are
+ignored, as they are by every conventional-commits parser. The pull request
+title is not checked: pull requests here are merged, not squashed, so the title
+never enters the history. Turning squash merging on would make the title the
+commit subject, and would need a check of its own.
+
+To lint a range by hand, the way the workflow does:
+
+```console
+$ npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+$ npx commitlint --verbose --from origin/next --to HEAD
+```
+
+The workflow is the gate only if the branch requires it: add **Commit
+conventions / commitlint** to the required status checks for `main` and `next`
+in the repository's branch protection, or a red check can still be merged past.

--- a/.github/workflows/commit-conventions.yml
+++ b/.github/workflows/commit-conventions.yml
@@ -8,8 +8,12 @@ name: Commit conventions
 # Only pull requests are checked. Both long-lived branches move by merge, so
 # every commit that reaches them passes through here first.
 on:
+  # `edited` as well as the defaults: retargeting a pull request changes the
+  # base, and so changes the range of commits this lints. Without it a check
+  # that ran against the old base stays on the pull request as its verdict.
   pull_request:
     branches: [main, next]
+    types: [opened, synchronize, reopened, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,7 +34,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       # commitlint.config.mjs sits at the repository root, and the preset it
       # extends is resolved from there -- hence an install into the workspace
       # rather than a bare npx, which would resolve from a cache directory and

--- a/.github/workflows/commit-conventions.yml
+++ b/.github/workflows/commit-conventions.yml
@@ -1,0 +1,48 @@
+name: Commit conventions
+
+# The version and the release notes are computed from the commit messages, so a
+# message semantic-release cannot read is a defect that only surfaces at release
+# time -- as a release that does not happen, or as notes with a hole in them.
+# This is where it is caught instead, while the message can still be reworded.
+#
+# Only pull requests are checked. Both long-lived branches move by merge, so
+# every commit that reaches them passes through here first.
+on:
+  pull_request:
+    branches: [main, next]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    name: commitlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The default checkout is a single commit and the range below spans
+          # the whole pull request, so its history has to be present.
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      # commitlint.config.mjs sits at the repository root, and the preset it
+      # extends is resolved from there -- hence an install into the workspace
+      # rather than a bare npx, which would resolve from a cache directory and
+      # fail to find the preset.
+      - name: Install commitlint
+        run: npm install --no-save --no-fund --no-audit @commitlint/cli@21 @commitlint/config-conventional@21
+      # The range is the pull request's own commits: base..head. --verbose
+      # prints each message it accepted, so the log shows what was checked and
+      # not merely that nothing failed. Merge commits, and git's own "Revert
+      # ..." subjects, are ignored by commitlint itself.
+      - name: Check commit messages
+        run: >
+          npx commitlint --verbose
+          --from ${{ github.event.pull_request.base.sha }}
+          --to ${{ github.event.pull_request.head.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ sonar_plan.md
 .coverage.*
 coverage.xml
 htmlcov/
+
+# Written by the commitlint install in .github/workflows/commit-conventions.yml,
+# and by anyone running that check locally.
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+# pre-commit installs only the pre-commit hook type by default, which would
+# leave the commit-msg hook below configured but never run. Naming both here
+# makes a plain `pre-commit install` install both.
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.5
@@ -11,3 +16,16 @@ repos:
       - id: mypy
         args: [--ignore-missing-imports]
         files: ^pysnmp/
+
+  # The same check .github/workflows/commit-conventions.yml runs, against the
+  # same commitlint.config.mjs, at the point where the message is written --
+  # rewording a message before it exists is a retype, after it exists it is a
+  # rebase. `pre-commit install` picks the commit-msg hook type up from
+  # default_install_hook_types above; an existing checkout has to run it once
+  # more for the hook to be installed at all.
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.26.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional@21"]

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,48 @@
+// Commit messages are the input to the release, not decoration: semantic-release
+// reads the type and scope of every commit since the last tag to decide the
+// version and to write the notes. A message it cannot parse does not fail
+// anywhere -- it just releases nothing and appears in no note -- so the format
+// is checked rather than trusted.
+//
+// One file, two places. The commit-msg hook in .pre-commit-config.yaml checks a
+// message as it is written; .github/workflows/commit-conventions.yml checks
+// every commit in a pull request. Both read this config, so a message that
+// passes locally passes in CI.
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    // The types .github/semantic-release.md documents, restated here so the
+    // set stays put if the shared preset ever widens it. Anything outside the
+    // list is a typo -- a "feature:" or "bugfix:" commit parses as no type at
+    // all and drops out of the release.
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+      ],
+    ],
+
+    // Bodies are written by tools as often as by hand: the "chore(release):"
+    // commit carries the entire release notes, and a dependabot body carries
+    // compare links. Neither wraps to a column, and neither is worth failing.
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0],
+
+    // The subject is prose and starts with whatever word it starts with --
+    // "fix: Windows path handling" is not a style error. The type stays lower
+    // case (type-case, from the shared preset), because that is what
+    // semantic-release matches its release rules on.
+    "subject-case": [0],
+  },
+};

--- a/docs/source/ci-and-releases.rst
+++ b/docs/source/ci-and-releases.rst
@@ -78,6 +78,22 @@ produces a minor release rather than a major one. All three projects set
 Reference an issue in the body (``Closes #123``) rather than in the
 subject, so the generated notes link it.
 
+The format is checked rather than assumed. `commitlint
+<https://commitlint.js.org/>`_ reads ``commitlint.config.mjs`` at the
+repository root from two places: the ``commit-msg`` hook installed by
+``pre-commit install`` checks a message as it is written, and the
+``Commit conventions`` workflow checks every commit in a pull request.
+Run ``pre-commit install`` once per checkout — a checkout made before
+the hook was added has to run it again, because installing the
+``commit-msg`` hook type is what makes the check run at all.
+
+Merge commits, ``fixup!`` commits and the subjects git writes for a
+revert are ignored. The pull request title is not checked: pull requests
+here are merged rather than squashed, so the title never enters the
+history. What the config changes relative to
+``@commitlint/config-conventional``, and how to lint a range by hand, is
+in ``.github/semantic-release.md``.
+
 What runs on a pull request
 ---------------------------
 
@@ -115,6 +131,11 @@ Two workflows run alongside it and do not gate a release:
 ``net-snmp-integration.yml``, which exercises every SNMP version and USM
 security profile against a real Net-SNMP agent in a container, and
 ``codeql-analysis.yml``.
+
+A third, ``commit-conventions.yml``, lints the commit messages of a pull
+request against the conventions above. It runs on pull requests only, so
+it is not part of the release path, but it does gate a merge wherever
+branch protection names it as a required check.
 
 The test matrix
 ---------------


### PR DESCRIPTION
Retargeted from `main` to `next`. The `main` base made this read as the whole `next` promotion (254 commits, 349 files); against `next` it is the single commit below.

## Summary

Releases are cut from the commit history, so a message semantic-release cannot parse does not fail anywhere — it releases nothing and appears in no note, and the omission only surfaces at release time. This checks the format instead of trusting it, in the two places a message can be caught.

| Where | What it checks |
| --- | --- |
| the `commit-msg` hook, from `.pre-commit-config.yaml` | the message being written, before the commit exists |
| the `Commit conventions` workflow, on every pull request | every commit in the pull request |

Both read the same `commitlint.config.mjs`, so a message that passes locally passes in CI.

## Changes

- **`commitlint.config.mjs`** — `@commitlint/config-conventional` with three deliberate changes: the type list is restated so it cannot drift with the preset; body and footer line lengths are unlimited (the `chore(release):` commit carries the whole release notes, and dependabot bodies carry compare links); `subject-case` is off, since `fix: Windows path handling` is prose rather than a style error. The *type* stays lower case, because that is what the release rules match on.
- **`.github/workflows/commit-conventions.yml`** — a `commitlint` job on pull requests to `main` and `next`, linting `base.sha..head.sha` with `--verbose`.
- **`.pre-commit-config.yaml`** — the commit-msg hook, plus `default_install_hook_types` so a plain `pre-commit install` installs it. The hook has no pre-commit stage, so `pre-commit run --all-files` in CI does not duplicate the workflow.
- **`.github/semantic-release.md`**, **`docs/source/ci-and-releases.rst`** — what is enforced, how to install the hook, and how to lint a range by hand.
- **`.gitignore`** — `node_modules/`, which the commitlint install writes.

Merge commits, `fixup!` commits and git's own `Revert "..."` subjects are ignored. The pull request title is not checked: pull requests here are merged rather than squashed, so the title never enters the history.

## Verification

- The hook rejects a non-conventional message and accepts the commit in this PR — the commit went through it.
- The workflow's exact command exits 0 on this range and 1 on a range containing `bad message no type`.
- The last 120 commits of `main` were linted against this config to look for false positives; only pre-convention history from before the tooling fails, which the pull-request range never sees.
- `sphinx-build -n -W --keep-going` builds clean.

## Follow-up, not in this PR

The workflow gates a merge only once **Commit conventions / commitlint** is a required status check in branch protection for `main` and `next`. That is a repository setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9PfC4KUEhdsYEx8h3c4mY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for commit messages in pull requests.
  * Added local commit-message checks using pre-commit hooks.
  * Standardized supported commit types and validation rules.

* **Documentation**
  * Documented commit-message requirements, pull-request checks, manual validation, and required status checks.
  * Added guidance for installing and using local validation hooks.

* **Chores**
  * Updated project configuration to exclude installed Node.js dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->