### PR TITLE
fix(carrier): report the family wildcard for an unbound datagram socket

### DIFF
--- a/pysnmp/carrier/asyncio/dgram/base.py
+++ b/pysnmp/carrier/asyncio/dgram/base.py
@@ -46,6 +46,14 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
     #: without IPv6 -- in which case the transport cannot be opened at all.
     sockFamily: "socket.AddressFamily | None" = None
 
+    #: Local address to report for a socket the platform declines to name.
+    #: An endpoint opened with no local address is left unbound, and there the
+    #: platforms disagree: POSIX answers getsockname() with the family's
+    #: wildcard, Windows fails it and asyncio turns that into a None sockname.
+    #: Concrete transports name their wildcard here so getLocalAddress() gives
+    #: the same answer everywhere; None where the family has no wildcard.
+    unboundLocalAddress: "tuple | str | None" = None
+
     def __init__(self, sock=None, sockMap=None, loop=None):
         self._writeQ = []
         self._lport = None
@@ -156,7 +164,10 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
     def getLocalAddress(self):
         if self.transport is None:
             return None
-        return self.transport.get_extra_info("sockname")
+        localAddress = self.transport.get_extra_info("sockname")
+        if localAddress is None:
+            return self.unboundLocalAddress
+        return localAddress
 
     def normalizeAddress(self, transportAddress):
         if not isinstance(transportAddress, self.addressType):

--- a/pysnmp/carrier/asyncio/dgram/udp.py
+++ b/pysnmp/carrier/asyncio/dgram/udp.py
@@ -44,6 +44,9 @@ class UdpTransportAddress(tuple, AbstractTransportAddress):
 class UdpAsyncioTransport(DgramAsyncioProtocol):
     sockFamily = socket.AF_INET
     addressType = UdpTransportAddress
+    # Not a bind: this is the address getsockname() reports for a socket that
+    # was never bound, so S104 does not apply.
+    unboundLocalAddress = ("0.0.0.0", 0)  # noqa: S104
 
 
 UdpTransport = UdpAsyncioTransport

--- a/pysnmp/carrier/asyncio/dgram/udp6.py
+++ b/pysnmp/carrier/asyncio/dgram/udp6.py
@@ -18,19 +18,25 @@ class Udp6TransportAddress(tuple, AbstractTransportAddress):
 class Udp6AsyncioTransport(DgramAsyncioProtocol):
     sockFamily = socket.has_ipv6 and socket.AF_INET6 or None
     addressType = Udp6TransportAddress
+    unboundLocalAddress = ("::", 0, 0, 0)
 
     def normalizeAddress(self, transportAddress):
-        if "%" in transportAddress[0]:  # strip zone ID
-            return self.addressType(
-                (
-                    transportAddress[0].split("%")[0],
-                    transportAddress[1],
-                    0,
-                    0,
-                )  # flowinfo
-            )  # scopeid
-        else:
-            return self.addressType((transportAddress[0], transportAddress[1], 0, 0))
+        localAddress = None
+        if isinstance(transportAddress, AbstractTransportAddress):
+            localAddress = transportAddress.getLocalAddress()
+
+        normalizedAddress = self.addressType(
+            (
+                transportAddress[0].split("%")[0],  # strip zone ID
+                transportAddress[1],
+                0,  # flowinfo
+                0,  # scopeid
+            )
+        )
+        if localAddress:
+            normalizedAddress.setLocalAddress(localAddress)
+
+        return DgramAsyncioProtocol.normalizeAddress(self, normalizedAddress)
 
 
 Udp6Transport = Udp6AsyncioTransport

--- a/tests/test_entity_carrier.py
+++ b/tests/test_entity_carrier.py
@@ -7,7 +7,7 @@ import tempfile
 
 import pytest
 
-from pysnmp.carrier.asyncio.dgram import udp
+from pysnmp.carrier.asyncio.dgram import udp, udp6
 from pysnmp.carrier.asyncio.dispatch import AsyncioDispatcher
 from pysnmp.carrier.base import (
     AbstractTransport,
@@ -414,6 +414,112 @@ class TestUdpTransport:
         transport = udp.UdpAsyncioTransport()
         with pytest.raises(CarrierError, match="Packet-information"):
             transport.enablePktInfo()
+
+
+def _ipv6IsUsable():
+    """Whether this host can actually open an AF_INET6 socket.
+
+    socket.has_ipv6 only reports what Python was built with; a container with
+    IPv6 disabled still fails at socket() time.
+    """
+    if not socket.has_ipv6:
+        return False
+    try:
+        socket.socket(socket.AF_INET6, socket.SOCK_DGRAM).close()
+    except OSError:
+        return False
+    return True
+
+
+class _UnnamedSocketTransport:
+    """asyncio transport whose socket the platform declines to name.
+
+    Windows fails getsockname() on an unbound datagram socket, and asyncio
+    reports that as a None sockname; POSIX answers with the family wildcard.
+    """
+
+    def get_extra_info(self, name, default=None):
+        return None
+
+
+class TestUnboundLocalAddress:
+    """getLocalAddress() on an endpoint opened with no local address.
+
+    openClientMode() with no iface leaves the socket unbound, which the two
+    platform families report differently. See issue #173.
+    """
+
+    def test_udp_reports_the_wildcard_for_an_unnamed_socket(self):
+        transport = udp.UdpAsyncioTransport()
+        transport.transport = _UnnamedSocketTransport()
+        assert transport.getLocalAddress() == ("0.0.0.0", 0)
+
+    def test_udp6_reports_the_wildcard_for_an_unnamed_socket(self):
+        transport = udp6.Udp6AsyncioTransport()
+        transport.transport = _UnnamedSocketTransport()
+        assert transport.getLocalAddress() == ("::", 0, 0, 0)
+
+    def test_closed_transport_still_reports_no_local_address(self):
+        transport = udp.UdpAsyncioTransport()
+        assert transport.getLocalAddress() is None
+
+    def test_udp_normalize_address_stores_the_wildcard(self):
+        transport = udp.UdpAsyncioTransport()
+        transport.transport = _UnnamedSocketTransport()
+        address = transport.normalizeAddress(("127.0.0.1", 161))
+        assert address.getLocalAddress() == ("0.0.0.0", 0)
+
+    def test_udp6_normalize_address_strips_zone_and_stores_the_wildcard(self):
+        transport = udp6.Udp6AsyncioTransport()
+        transport.transport = _UnnamedSocketTransport()
+        address = transport.normalizeAddress(("fe80::1%eth0", 161, 0, 0))
+        assert address == ("fe80::1", 161, 0, 0)
+        assert address.getLocalAddress() == ("::", 0, 0, 0)
+
+    def test_udp6_normalize_address_keeps_an_explicit_local_address(self):
+        transport = udp6.Udp6AsyncioTransport()
+        transport.transport = _UnnamedSocketTransport()
+        address = udp6.Udp6TransportAddress(("fe80::1%eth0", 161, 0, 0))
+        address.setLocalAddress(("::1", 12345, 0, 0))
+        normalized = transport.normalizeAddress(address)
+        assert normalized == ("fe80::1", 161, 0, 0)
+        assert normalized.getLocalAddress() == ("::1", 12345, 0, 0)
+
+    def test_udp_client_mode_reports_the_wildcard(self):
+        loop = asyncio.new_event_loop()
+        transport = udp.UdpAsyncioTransport(loop=loop).openClientMode()
+        try:
+            loop.run_until_complete(asyncio.sleep(0))
+            assert transport.getLocalAddress() == ("0.0.0.0", 0)
+        finally:
+            transport.closeTransport()
+            loop.run_until_complete(asyncio.sleep(0))
+            loop.close()
+
+    @pytest.mark.skipif(not _ipv6IsUsable(), reason="IPv6 is unavailable")
+    def test_udp6_client_mode_reports_the_wildcard(self):
+        loop = asyncio.new_event_loop()
+        transport = udp6.Udp6AsyncioTransport(loop=loop).openClientMode()
+        try:
+            loop.run_until_complete(asyncio.sleep(0))
+            assert transport.getLocalAddress() == ("::", 0, 0, 0)
+        finally:
+            transport.closeTransport()
+            loop.run_until_complete(asyncio.sleep(0))
+            loop.close()
+
+    def test_udp_server_mode_reports_the_bound_address(self):
+        loop = asyncio.new_event_loop()
+        transport = udp.UdpAsyncioTransport(loop=loop).openServerMode(("127.0.0.1", 0))
+        try:
+            loop.run_until_complete(asyncio.sleep(0))
+            host, port = transport.getLocalAddress()
+            assert host == "127.0.0.1"
+            assert port != 0
+        finally:
+            transport.closeTransport()
+            loop.run_until_complete(asyncio.sleep(0))
+            loop.close()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Closes #173. Targets `next` — the earlier attempt, #189, was cut from `main`, where the carrier still has the asyncore transports and `normalizeAddress()` does not yet feed `setLocalAddress()`, so it does not apply here.

## The divergence

`getLocalAddress()` returned `self.transport.get_extra_info("sockname")` unchanged. For an endpoint opened by `openClientMode()` with no `iface` the socket is never bound, and the platforms disagree about what that means: POSIX answers `getsockname()` with the family wildcard, Windows fails the call and asyncio records the failure as a `None` sockname. `normalizeAddress()` then stored that `None` on the address.

## Answers to the three points in the issue

**Do callers assume a `(host, port)` tuple?** Yes. `AbstractTransportAddress.clone()` passes the local address straight through to the clone, and `sockmsg.getSendTo()` subscripts it — `ipaddress.ip_address(_to.getLocalAddress()[0])` — which is a `TypeError` on `None`. That path is not reachable from the asyncio transports today (`enablePktInfo()` raises there), but it is the shape the rest of the carrier is written against.

**Does `openServerMode(iface)` diverge too?** No. That socket is bound, so `getsockname()` succeeds on both families and the sockname is a real address. `test_udp_server_mode_reports_the_bound_address` holds that.

**Wildcard or `None`?** The wildcard. `('0.0.0.0', 0)` is the answer POSIX already gives, so normalizing on it leaves the majority platform's behaviour untouched and asks nothing new of callers, where `None` would mean auditing every consumer of a local address for a case only Windows produces.

## The change

- `DgramAsyncioProtocol.unboundLocalAddress` — each transport names its own wildcard (`("0.0.0.0", 0)` for UDP, `("::", 0, 0, 0)` for UDP6), and `getLocalAddress()` falls back to it when the platform declines to name the socket. Unix domain has no wildcard and keeps `None`; its client mode binds a temp path anyway.
- A closed transport (`self.transport is None`) still reports `None`. That means "no socket", which is a different thing from "unbound", and nothing about it is platform-specific.
- `Udp6AsyncioTransport.normalizeAddress()` built a fresh address and returned it without ever reaching the base method, so an IPv6 address came back carrying no local address at all — neither the one it was handed nor the transport's. It now carries an incoming local address across the zone-ID strip and defers to the base method for the default. The two branches were identical apart from the `split("%")`, which is a no-op on an address with no zone ID, so they collapse into one.

## Tests

Eight tests in `tests/test_entity_carrier.py::TestUnboundLocalAddress`. Five stand in a transport whose `get_extra_info("sockname")` is `None`, so the Windows behaviour is exercised on every platform rather than only where CI happens to run Windows; those five fail on `next` without this change. Three more go over real sockets: client mode on UDP and UDP6 asserting the wildcard, and server mode asserting the bound address.

The UDP6 real-socket test skips by trying to open an `AF_INET6` socket rather than reading `socket.has_ipv6` — the flag reports what Python was built with, and a container with IPv6 turned off still fails at `socket()`.

Full suite: 958 passed, 13 skipped. `ruff check`, `ruff format --check` and `mypy` clean; `ty` unchanged at its 76-diagnostic baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L63SjfxkTZUUyy6EdG5hRR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L63SjfxkTZUUyy6EdG5hRR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UDP transport behavior when sockets do not report a local address, including reliable wildcard-address fallbacks for IPv4 and IPv6.
  - Improved IPv6 address normalization, including preservation of local-address details and consistent handling of zone, flow, and scope information.
  - Improved local-address reporting across client, server, unnamed-socket, and closed-transport scenarios.
- **Tests**
  - Added coverage for IPv4 and IPv6 address handling, with automatic skipping when IPv6 is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->