### PR TITLE
ci: move the release toolchain off Node 20

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -31,7 +31,17 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.10"
-      - uses: pre-commit/action@v3.0.1
+      # pre-commit/action is archived at v3.0.1 and pins actions/cache@v4
+      # inside itself, which runs on the deprecated Node 20 runtime. Its steps
+      # are short enough to keep here instead, on a cache action that is not.
+      - uses: actions/cache@v6
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        run: |
+          python -m pip install pre-commit
+          pre-commit run --show-diff-on-failure --color=always --all-files
 
   lint:
     name: lint
@@ -216,18 +226,30 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          # semantic-release 25 needs ^22.14, and @semantic-release/changelog
+          # and /git need ^22.22.2 || >=24.15. Pin the major here rather than
+          # inherit whatever node the runner image happens to ship.
+          node-version: "24"
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v6
         id: semantic   # Need an `id` for output variables
         with:
-          semantic_version: 24
+          semantic_version: 25
           dry_run: ${{ env.DRY }}
+          # Pinned to majors: the action npm-installs these fresh on every
+          # run, so an unpinned name is whatever was published that morning.
+          # The preset stays on 9 deliberately -- 10 renders through
+          # conventional-changelog-writer@9, and semantic-release 25 still
+          # carries writer 8, which fails at note-generation time.
           extra_plugins: |
-            @semantic-release/changelog
-            @semantic-release/exec
-            @semantic-release/git
-            @google/semantic-release-replace-plugin
-            conventional-changelog-conventionalcommits@8.0.0
+            @semantic-release/changelog@7
+            @semantic-release/exec@7
+            @semantic-release/git@11
+            @google/semantic-release-replace-plugin@1
+            conventional-changelog-conventionalcommits@9
         env:
           GITHUB_TOKEN: ${{ secrets.SEMREL_TOKEN }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/commit-conventions.yml
+++ b/.github/workflows/commit-conventions.yml
@@ -32,9 +32,9 @@ jobs:
           # The default checkout is a single commit and the range below spans
           # the whole pull request, so its history has to be present.
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
       # commitlint.config.mjs sits at the repository root, and the preset it
       # extends is resolved from there -- hence an install into the workspace
       # rather than a bare npx, which would resolve from a cache directory and


### PR DESCRIPTION
GitHub is retiring the Node 20 action runtime. Three actions here still ran on it:

| | before | after |
|---|---|---|
| `actions/setup-node` | v4 (node20) | v6 (node24) |
| `github/codeql-action/*` | v3 (node20) | v4 (node24) |
| `pre-commit/action` | v3.0.1 → `actions/cache@v4` (node20) | inlined onto `actions/cache@v6` |

`pre-commit/action` is archived at v3.0.1, so the `actions/cache@v4` it pins cannot be bumped from the outside. Its two steps are short enough to keep in the workflow directly, on a current cache action.

semantic-release goes 24 → 25, which rules Node 20 out on its own (`^22.14 || >=24.10`), as do `@semantic-release/changelog@7` and `@semantic-release/git@11` (`^22.22.2 || >=24.15`). The release job took whatever node the runner image happened to ship; it now asks for 24. The plugins the action installs are pinned to majors — unpinned, they resolve to whatever was published that morning, which is how a release pipeline breaks on a day nobody touched it.

The `conventionalcommits` preset is pinned to 9 rather than latest on purpose: preset 10 renders through `conventional-changelog-writer@9`, semantic-release 25 still carries writer 8, and the pair fails at note-generation time with `Missing helper: "conventional-changelog-conventionalcommits requires conventional-changelog-writer@9 or newer"`. 9 is the newest that works.

### Verification

- semantic-release 25 with these plugin majors was run against this repo's real `.releaserc` and history: every plugin loads, and `--dry-run` analyses commits and reaches its verdict.
- preset 10 was tried and reproduces the failure above; 8 and 9 both produce identical notes.
- `actionlint` passes on every workflow.
- `pre-commit run --show-diff-on-failure --color=always --all-files` — the exact command the workflow now runs — passes.

Companion PRs do the same in pyasn1 and pysmi, so all three carry an identical action set and release toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7JTvMctLrgGvb3M1uAswm

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7JTvMctLrgGvb3M1uAswm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, release, and commit-validation workflows to use Node.js 24.
  * Improved pre-commit setup and caching for more reliable checks.
  * Updated release tooling and compatible plugin versions.
  * Upgraded CodeQL analysis actions to v4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->