### PR TITLE
Add branch protection rulesets and CI gate jobs

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -47,6 +47,17 @@ The pull request rule is set for a single maintainer:
 - **`require_last_push_approval: false`.** With one maintainer this would be
   the same deadlock as requiring an approval.
 
+## Repository settings
+
+`repo-settings.json` carries the two repository settings that go with a
+pull-request-only workflow, applied by the same script:
+
+- **`allow_auto_merge`.** With merging gated on checks rather than on a review,
+  auto-merge is what makes that bearable alone: open the pull request, arm it,
+  and it lands when CI goes green instead of being watched.
+- **`delete_branch_on_merge`.** Branches cannot be deleted while a ruleset
+  protects them, so the ones that are not protected should not accumulate.
+
 ## Required checks
 
 | Check | Workflow | Covers |

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,116 @@
+# Branch rulesets
+
+The protection on `main` and `next` for this repository, kept here as JSON so
+that all four pysnmp repositories can be given the same policy and so that a
+change to it is reviewable like any other change.
+
+Apply it with [`apply.sh`](apply.sh), which needs a token carrying
+`administration:write`:
+
+```console
+$ ./.github/rulesets/apply.sh --dry-run
+$ ./.github/rulesets/apply.sh
+```
+
+Every ruleset that matches a branch applies, so a leftover one still binds
+even after this one is in place -- a stray "require 1 approval" rule blocks a
+lone maintainer whatever is written here. `apply.sh` lists anything on the
+repository it does not define; `--prune` deletes those, once you have read the
+list.
+
+Nothing applies these automatically. A workflow cannot: the token GitHub gives
+a workflow run has no administration scope, and handing one that does to CI
+would let any workflow change the rules that gate it.
+
+## What `protected-branches.json` does
+
+It targets `refs/heads/main` and `refs/heads/next`.
+
+| Rule | Effect |
+| --- | --- |
+| `deletion` | The branch cannot be deleted. |
+| `non_fast_forward` | No force pushes; history cannot be rewritten. |
+| `pull_request` | Every change arrives through a pull request. |
+| `required_status_checks` | The checks below must pass before merging. |
+
+The pull request rule is set for a single maintainer:
+
+- **`required_approving_review_count: 0`.** GitHub does not let anyone approve
+  their own pull request, so any number above zero would make it impossible to
+  merge anything alone. Zero still forces the change through a pull request,
+  which is where the checks run and where the diff is on the record.
+- **`dismiss_stale_reviews_on_push: true`** and
+  **`required_review_thread_resolution: true`.** These are what make a review
+  worth something when one does happen -- from a human, from Copilot, or from a
+  review bot. A new push drops the old approval, and every thread has to be
+  answered rather than merged past.
+- **`require_last_push_approval: false`.** With one maintainer this would be
+  the same deadlock as requiring an approval.
+
+## Required checks
+
+| Check | Workflow | Covers |
+| --- | --- | --- |
+| `ci-gate` | `build-test-release.yml` | pre-commit, ruff, mypy, docs, build and the unit-test matrix |
+| `net-snmp-gate` | `net-snmp-integration.yml` | the integration suite against a real Net-SNMP agent, over every SNMP version and security profile |
+| `commitlint` | `commit-conventions.yml` | conventional-commit subjects, which is what semantic-release reads to work out a version |
+| `Analyze (python)` | `codeql-analysis.yml` | CodeQL |
+
+`ci-gate` is one job in `build-test-release.yml` that depends on every gating
+job in it. It exists so that this file does not have to name the test matrix
+entry by entry: those names carry the Python version and the runner
+(`test-unit (py3.14 ubuntu-latest)`), the set of them changes with the labels
+on a pull request, and dropping a Python version would otherwise leave a
+required check that can never report again -- which is indistinguishable, to a
+pull request, from a check that is failing. `ci-gate` fails if anything it
+depends on failed *or was skipped*, so a matrix that never ran cannot pass as
+green. `net-snmp-gate` does the same for the Net-SNMP integration matrix in
+`net-snmp-integration.yml`.
+
+Each check is pinned to `integration_id` 15368, GitHub Actions, so that only
+Actions can satisfy it. Without the pin any app or token with `checks:write`
+on the repository could post a passing check under the same name.
+
+### When CI job names change
+
+Renaming a job, or removing it, breaks the ruleset: the old name stays
+required and never reports again, and pull requests to `main` and `next` stop
+being mergeable. Change `protected-branches.json` in the same pull request as
+the workflow, and re-run `apply.sh` once it has merged.
+
+## Bypass
+
+Organization owners and repository admins bypass all of it (`bypass_mode:
+always`). That is not decoration -- releases depend on it.
+`@semantic-release/git` pushes the `chore(release):` commit that carries the
+changelog and the version bump straight to `main` or `next`, using
+`SEMREL_TOKEN`. Without a bypass for whoever owns that token, every release
+would fail on the pull request rule.
+
+It doubles as the escape hatch for the maintainer. Bypassing is a deliberate
+act -- pushing to the branch, or choosing to merge past the rules in the web
+UI -- so the rules still apply to ordinary work, and the bypass is recorded in
+the repository's rule insights.
+
+If `SEMREL_TOKEN` is ever moved to a GitHub App rather than a personal token,
+replace the two `bypass_actors` entries with the app:
+
+```json
+{"actor_id": <the app's id>, "actor_type": "Integration", "bypass_mode": "always"}
+```
+
+## What is deliberately not here
+
+- **Tag protection.** Blocking tag deletion and non-fast-forward updates on
+  `refs/tags/v*` would be worth having, but the semver alias tags are *moved*
+  on purpose after each release, and a `non_fast_forward` rule on tags would
+  stop that.
+- **`required_linear_history`.** `next` is promoted into `main` as a merge
+  commit.
+- **`required_signatures`.** `@semantic-release/git` pushes over plain git and
+  does not sign; requiring signatures would break every release.
+- **`strict_required_status_checks_policy`** (the "branches must be up to
+  date" setting) is off. Every release lands a commit on `main`, which would
+  put every open pull request out of date and demand a rebase for a commit that
+  only touches the changelog and the version. The checks re-run on the push to
+  `main` regardless, so a semantic conflict still surfaces immediately.

--- a/.github/rulesets/apply.sh
+++ b/.github/rulesets/apply.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Apply every ruleset in this directory to the repository on GitHub.
+# Apply every ruleset in this directory to the repository on GitHub, and the
+# repository settings in repo-settings.json alongside them.
 #
 # Rulesets are matched to what is already on the repository by name: a ruleset
 # whose name is not there yet is created, one that is gets overwritten. Running
@@ -94,6 +95,9 @@ existing="$(api GET "repos/$REPO/rulesets?per_page=100")"
 managed=()
 for file in "$DIR"/*.json; do
   [ -e "$file" ] || continue
+  # Everything here is a ruleset except the repository settings, applied below
+  # against a different endpoint.
+  [ "$(basename "$file")" = repo-settings.json ] && continue
   name="$(jq -r '.name' "$file")"
   managed+=("$name")
   id="$(jq -r --arg n "$name" 'map(select(.name == $n)) | first | .id // empty' <<<"$existing")"
@@ -113,6 +117,16 @@ for file in "$DIR"/*.json; do
     api POST "repos/$REPO/rulesets" "$file" | jq -r '"created  \(.name) (id \(.id), \(.enforcement))"'
   fi
 done
+
+settings="$DIR/repo-settings.json"
+if [ -f "$settings" ]; then
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "would set repository settings $(jq -c . "$settings")"
+  else
+    api PATCH "repos/$REPO" "$settings" |
+      jq -r '"settings delete_branch_on_merge=\(.delete_branch_on_merge) allow_auto_merge=\(.allow_auto_merge)"'
+  fi
+fi
 
 # Anything else on the repository was made by hand and is not tracked here.
 # Left alone rather than deleted -- say so, and let a human decide.

--- a/.github/rulesets/apply.sh
+++ b/.github/rulesets/apply.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Apply every ruleset in this directory to the repository on GitHub.
+#
+# Rulesets are matched to what is already on the repository by name: a ruleset
+# whose name is not there yet is created, one that is gets overwritten. Running
+# this twice in a row is a no-op, so it is safe to re-run after every edit.
+#
+# Needs a token with administration:write on the repository -- either the one
+# `gh auth login` holds, or GH_TOKEN/GITHUB_TOKEN in the environment. The
+# token that GitHub Actions hands a workflow cannot do this; the rulesets are
+# what stops a workflow from rewriting the branches it is gated by.
+#
+# Rulesets on the repository that this directory does not define are left
+# alone and listed at the end. GitHub applies every ruleset that matches a
+# branch, so a leftover one still binds: a stray "require 1 approval" rule
+# blocks a lone maintainer no matter what is written here. --prune deletes
+# them once you have read the list.
+#
+#   ./.github/rulesets/apply.sh              # this repository, from `origin`
+#   ./.github/rulesets/apply.sh --dry-run    # print what would be sent
+#   ./.github/rulesets/apply.sh --prune      # also delete the ones listed
+#   ./.github/rulesets/apply.sh owner/repo   # somewhere else
+#
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRY_RUN=0
+PRUNE=0
+REPO=""
+
+usage() { sed -n '2,/^[^#]/p' "${BASH_SOURCE[0]}" | sed '$d; s/^# \{0,1\}//'; }
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --prune) PRUNE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "unknown option: $arg" >&2; exit 2 ;;
+    *) REPO="$arg" ;;
+  esac
+done
+
+if [ -z "$REPO" ]; then
+  # Both the ssh and https forms of the remote, with or without the .git suffix.
+  remote="$(git -C "$DIR" remote get-url origin)"
+  REPO="$(printf '%s\n' "$remote" | sed -E 's#^(git@|https://)[^:/]+[:/]##; s#\.git$##')"
+fi
+
+case "$REPO" in
+  */*) ;;
+  *) echo "could not work out owner/repo from '$REPO'" >&2; exit 1 ;;
+esac
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+if command -v gh >/dev/null && gh auth status >/dev/null 2>&1; then
+  USE_GH=1
+else
+  USE_GH=0
+  TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  [ -n "$TOKEN" ] || {
+    echo "no gh login and no GH_TOKEN/GITHUB_TOKEN; need administration:write" >&2
+    exit 1
+  }
+fi
+
+api() { # api METHOD PATH [BODY_FILE]
+  local method="$1" path="$2" body="${3:-}"
+  if [ "$USE_GH" = 1 ]; then
+    if [ -n "$body" ]; then
+      gh api -X "$method" -H "Accept: application/vnd.github+json" "$path" --input "$body"
+    else
+      gh api -X "$method" -H "Accept: application/vnd.github+json" "$path"
+    fi
+  else
+    local -a args=(
+      -sS --fail-with-body -X "$method"
+      -H "Authorization: Bearer $TOKEN"
+      -H "Accept: application/vnd.github+json"
+      -H "X-GitHub-Api-Version: 2022-11-28"
+    )
+    # The API rejects a body sent as form data, so name the type even when
+    # there is no body: curl labels an empty POST as form-encoded otherwise.
+    args+=(-H "Content-Type: application/json")
+    [ -n "$body" ] && args+=(--data-binary "@$body")
+    curl "${args[@]}" "https://api.github.com/$path"
+  fi
+}
+
+echo "repository: $REPO"
+existing="$(api GET "repos/$REPO/rulesets?per_page=100")"
+
+managed=()
+for file in "$DIR"/*.json; do
+  [ -e "$file" ] || continue
+  name="$(jq -r '.name' "$file")"
+  managed+=("$name")
+  id="$(jq -r --arg n "$name" 'map(select(.name == $n)) | first | .id // empty' <<<"$existing")"
+
+  if [ "$DRY_RUN" = 1 ]; then
+    if [ -n "$id" ]; then
+      echo "would update '$name' (id $id) from $(basename "$file")"
+    else
+      echo "would create '$name' from $(basename "$file")"
+    fi
+    continue
+  fi
+
+  if [ -n "$id" ]; then
+    api PUT "repos/$REPO/rulesets/$id" "$file" | jq -r '"updated  \(.name) (id \(.id), \(.enforcement))"'
+  else
+    api POST "repos/$REPO/rulesets" "$file" | jq -r '"created  \(.name) (id \(.id), \(.enforcement))"'
+  fi
+done
+
+# Anything else on the repository was made by hand and is not tracked here.
+# Left alone rather than deleted -- say so, and let a human decide.
+unmanaged="$(jq -r --argjson m "$(printf '%s\n' "${managed[@]}" | jq -R . | jq -s .)" \
+  '.[] | select(.source_type == "Repository") | select(.name as $n | $m | index($n) | not)
+   | "  \(.name) (id \(.id), \(.enforcement))"' <<<"$existing")"
+
+if [ -z "$unmanaged" ]; then
+  exit 0
+fi
+
+echo
+echo "rulesets on this repository that are not defined here:"
+echo "$unmanaged"
+
+if [ "$PRUNE" != 1 ]; then
+  # Every matching ruleset applies, so one of these can still block a merge no
+  # matter what this directory says. Listing beats deleting something a human
+  # added on purpose.
+  echo "re-run with --prune to delete them, once you have read the list."
+  exit 0
+fi
+
+while read -r id; do
+  [ -n "$id" ] || continue
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "would delete ruleset $id"
+  else
+    api DELETE "repos/$REPO/rulesets/$id" >/dev/null
+    echo "deleted  ruleset $id"
+  fi
+done <<<"$(printf '%s\n' "$unmanaged" | sed -E 's/.*\(id ([0-9]+),.*/\1/')"

--- a/.github/rulesets/protected-branches.json
+++ b/.github/rulesets/protected-branches.json
@@ -1,0 +1,75 @@
+{
+  "name": "protected-branches",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/main",
+        "refs/heads/next"
+      ],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "require_extra_approval_for_unattributed_changes": false,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "ci-gate",
+            "integration_id": 15368
+          },
+          {
+            "context": "net-snmp-gate",
+            "integration_id": 15368
+          },
+          {
+            "context": "commitlint",
+            "integration_id": 15368
+          },
+          {
+            "context": "Analyze (python)",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/repo-settings.json
+++ b/.github/rulesets/repo-settings.json
@@ -1,0 +1,4 @@
+{
+  "delete_branch_on_merge": true,
+  "allow_auto_merge": true
+}

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -188,6 +188,43 @@ jobs:
           # A Codecov outage is not a reason to fail a build.
           fail_ci_if_error: false
 
+  # One check name for the branch ruleset to require, standing in for every
+  # gating job below. The test matrix cannot be named directly: its job names
+  # carry the Python version and the runner, the set of them changes with the
+  # labels on a pull request, and a required check that stops reporting is
+  # indistinguishable -- to a pull request -- from one that is failing. See
+  # .github/rulesets/README.md.
+  ci-gate:
+    name: ci-gate
+    # always(), or a failure anywhere upstream skips this job too, and a
+    # skipped required check never reports: the pull request would just hang.
+    if: always()
+    needs:
+      - pre-commit
+      - lint
+      - docs
+      - build
+      - setup-matrix
+      - run-unit-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless every gating job succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+
+          results = {name: job["result"] for name, job in json.loads(os.environ["NEEDS"]).items()}
+          for name, result in sorted(results.items()):
+              print(f"{name}: {result}")
+              # Skipped counts as a failure: a job that never ran has not
+              # passed, and a job whose dependency failed is skipped, not red.
+              if result != "success":
+                  print(f"::error::{name} did not succeed ({result})")
+          sys.exit(0 if all(r == "success" for r in results.values()) else 1)
+          PY
+
   publish:
     name: Build Release
     # Semantic release cuts tags from a branch, so keep this to branch refs and

--- a/.github/workflows/net-snmp-integration.yml
+++ b/.github/workflows/net-snmp-integration.yml
@@ -56,3 +56,34 @@ jobs:
       - name: Remove the Net-SNMP agent
         if: always()
         run: docker rm --force pysnmp-ci-net-snmp
+
+  # One check name for the branch ruleset to require, standing in for the whole
+  # matrix above. Those job names are built out of the profile list
+  # (`SNMP v3-auth-priv-des`), so naming them in the ruleset would turn adding
+  # or renaming a profile into a change that quietly blocks main and next. See
+  # .github/rulesets/README.md.
+  net-snmp-gate:
+    name: net-snmp-gate
+    # always(), or a failure anywhere upstream skips this job too, and a
+    # skipped required check never reports: the pull request would just hang.
+    if: always()
+    needs:
+      - net-snmp
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless every gating job succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+
+          results = {name: job["result"] for name, job in json.loads(os.environ["NEEDS"]).items()}
+          for name, result in sorted(results.items()):
+              print(f"{name}: {result}")
+              # Skipped counts as a failure: a job that never ran has not
+              # passed, and a job whose dependency failed is skipped, not red.
+              if result != "success":
+                  print(f"::error::{name} did not succeed ({result})")
+          sys.exit(0 if all(r == "success" for r in results.values()) else 1)
+          PY


### PR DESCRIPTION
## Summary

Retargeted to `next`. The branch was cut from `next`, where the new CI lives, so against `main` this showed the entire `next` promotion (264 commits, 352 files) rather than the change itself. Against `next` it is 5 files.

Adds `.github/rulesets/`, the branch protection policy for `main` and `next` as reviewable JSON, plus the aggregate CI check the ruleset requires. Part of a set applied across pysnmp, pysmi, pyasn1 and mibs.

## Key Changes

- **`.github/rulesets/protected-branches.json`** — `main` and `next` cannot be deleted or force-pushed, every change arrives through a pull request, and the required checks must pass. Written for a single maintainer: `required_approving_review_count: 0`, because GitHub does not let anyone approve their own pull request, while still dismissing stale reviews and requiring review threads to be resolved when a review does happen.
- **`.github/rulesets/apply.sh`** — idempotent create-or-update against the API, with `--dry-run` and `--prune`. Nothing applies it automatically: a workflow token able to rewrite the rules that gate it would defeat them.
- **`.github/rulesets/README.md`** — the rationale for each setting, and for what is deliberately left out.
- **`ci-gate`** in `build-test-release.yml` and **`net-snmp-gate`** in `net-snmp-integration.yml` — one job apiece depending on every gating job in its workflow.

## Notable Implementation Details

- The required checks cannot name either matrix directly: those job names carry the Python version and the runner, or the SNMP profile, and the set of them changes with the labels on a pull request. A required check that stops reporting is indistinguishable, to a pull request, from one that is failing, so dropping a Python version would deadlock both branches. The gate jobs give the ruleset one name that does not move.
- Both gates fail on *skipped* as well as failed, so a matrix that never ran cannot pass as green.
- Checks are pinned to `integration_id` 15368 (GitHub Actions), so no other app or token holding `checks:write` can post a passing check under the same name.
- Organization owners and repository admins bypass the rules, which the release depends on: `@semantic-release/git` pushes the `chore(release):` commit straight to the branch it released from.
- **This repository already carries two hand-made rulesets on `main`.** `main-2` requires an approving review with no bypass actors, which a lone maintainer can never satisfy. Rulesets stack, so it keeps blocking merges until removed — `apply.sh` lists both, and `--prune` deletes them.
- The ruleset names the checks the CI on this branch produces. `main` still runs the older workflow and will not report them until `next` is promoted, which that promotion satisfies by itself, since a pull request runs the workflows from its merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbpPfCrXM6xz2KCD7zbND9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added protected branch rules for `main` and `next`, requiring pull-request reviews, resolved discussions, and successful quality checks.
  * Prevented branch deletion and non-fast-forward updates.
  * Added automatic branch cleanup after merges and enabled auto-merge.
  * Added consolidated CI checks that clearly report failures across build, test, analysis, and Net-SNMP integration jobs.

* **Documentation**
  * Documented repository branch protections, required checks, release and administrator bypass behavior, and maintenance guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->