### PR TITLE
chore(deps): bump pysnmp-pysmi to 2.3.0

### DIFF
--- a/docs/source/faq/pass-custom-mib-to-manager.rst
+++ b/docs/source/faq/pass-custom-mib-to-manager.rst
@@ -10,8 +10,16 @@ A. Starting from PySNMP 4.3.x, plain-text (ASN.1) MIBs can be
    automatically, parsed PySNMP MIB will be cached in
    $HOME/.pysnmp/mibs/ (default location).
 
+   PySMI bundles the standard MIB set -- ``SNMPv2-SMI``, ``IF-MIB`` and the
+   rest of what a vendor MIB imports -- and searches it alongside whatever
+   sources you configure, so a MIB that only imports standard modules
+   compiles with no source configured at all and no network. Where a copy
+   you configure carries a newer ``MODULE-IDENTITY`` revision than the
+   bundled one, yours is used.
+
    MIB compiler could be configured to search for plain-text
-   MIBs at multiple local and remote locations. As for remote
+   MIBs at multiple local and remote locations, which is what a MIB
+   importing something outside that set needs. As for remote
    MIB repos, you are welcome to use our collection of ASN.1
    MIB files at
    `https://pysnmp.github.io/mibs/asn1/ <https://pysnmp.github.io/mibs/asn1/>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,26 +27,25 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 readme = "README.md"
-# The two sibling floors name a release candidate on purpose, and naming one is
-# the only way to say this: dependabot offers a prerelease when the current
-# version is already one OR when a requirement string names one, and there is no
+# The pyasn1 floor names a release candidate on purpose, and naming one is the
+# only way to say this: dependabot offers a prerelease when the current version
+# is already one OR when a requirement string names one, and there is no
 # configuration key for it (dependabot/dependabot-core#1926, closed as not
-# planned). PEP 440 admits prereleases per specifier, so this puts pysmi and
-# pyasn1 -- and only them, pycryptodomex keeps its stable floor -- on the rc
-# stream, and this repository integrates against the siblings it is released
-# alongside instead of against their last GA.
+# planned). PEP 440 admits prereleases per specifier, so this puts pyasn1 -- and
+# only pyasn1, pysmi and pycryptodomex keep stable floors -- on the rc stream,
+# and this repository integrates against the sibling rc it is released alongside
+# instead of against its last GA.
 #
-# Each floor names the last rc of the line its GA is on, so it sits one hair
-# below the GA rather than above it. Resolution takes the newest allowed
-# version regardless, so today these still resolve to pysmi 2.1.0 and pyasn1
-# 2.0.0; the rc floors only start to matter once a sibling publishes an rc
-# ahead of its next GA.
+# The floor names the last rc of the line its GA is on, so it sits one hair
+# below the GA rather than above it. Resolution takes the newest allowed version
+# regardless, so today this still resolves to pyasn1 2.0.0; the rc floor only
+# starts to matter once pyasn1 publishes an rc ahead of its next GA.
 #
-# This belongs to the 6.0.0 rc cycle, not to the package forever. Put both
-# floors back on a GA before cutting the 6.0.0 GA, or a released pysnmplib
-# lets an installer resolve sibling release candidates.
+# This belongs to the 6.0.0 rc cycle, not to the package forever. Put the floor
+# back on a GA before cutting the 6.0.0 GA, or a released pysnmplib lets an
+# installer resolve a sibling release candidate.
 dependencies = [
-    "pysnmp-pysmi >=2.1.0rc3,<3.0.0",
+    "pysnmp-pysmi >=2.3.0,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
     "pysnmp-pyasn1 >=2.0.0rc2,<3.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -897,15 +897,15 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pysmi"
-version = "2.1.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/99/248d447747728ffb86997aec2fe6c2b4cfc8283a603930f63464a384727d/pysnmp_pysmi-2.1.0.tar.gz", hash = "sha256:a12ce0f8cd4023951054d5f018cdb3fc47def35a98aa45153b7407655ef63eb1", size = 497322, upload-time = "2026-09-06T01:48:57.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/1f/a12894cb260e4e4abc16126997d925f80e927f69d3360a94f06a4f4519f2/pysnmp_pysmi-2.3.0.tar.gz", hash = "sha256:9808f9dfb95d25a4dc9af936d755426e1584601c2e4b097ad3cb2955895f143e", size = 2630836, upload-time = "2026-09-06T18:58:13.576Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/e4/cc811b7239f893387b2908d85486d8f4742779c8cc300ad0cc92b7af99a0/pysnmp_pysmi-2.1.0-py3-none-any.whl", hash = "sha256:52f76c530bc54e3afb5e1ea425eea34631c9546e94641e3d17ba5af8ab64aa89", size = 367524, upload-time = "2026-09-06T01:48:55.853Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d4/a76de32f351a168c7a563b66e200b48f826bceffe56dad713526933e7b36/pysnmp_pysmi-2.3.0-py3-none-any.whl", hash = "sha256:4bbba0ae590e058bdcb6a079d6ea12653cba0db357aab336b6f80125fe4aae2e", size = 3729538, upload-time = "2026-09-06T18:58:11.591Z" },
 ]
 
 [[package]]
@@ -933,7 +933,7 @@ dev = [
 requires-dist = [
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
     { name = "pysnmp-pyasn1", specifier = ">=2.0.0rc2,<3.0.0" },
-    { name = "pysnmp-pysmi", specifier = ">=2.1.0rc3,<3.0.0" },
+    { name = "pysnmp-pysmi", specifier = ">=2.3.0,<3.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1057,7 +1057,7 @@ name = "roman-numerals-py"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "roman-numerals" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
 wheels = [
@@ -1106,23 +1106,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -1139,23 +1139,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals-py" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.11'" },
+    { name = "babel", marker = "python_full_version >= '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "imagesize", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [


### PR DESCRIPTION
Moves the `pysnmp-pysmi` floor from 2.1.0rc3 to the 2.3.0 GA and relocks.

## What 2.3.0 brings

PySMI 2.2.0/2.3.0 bundle the standard MIB set (`SNMPv2-SMI`, `IF-MIB`, `IANAifType-MIB` and the rest of what a vendor MIB imports) and search it alongside whatever sources the caller configures. `MibCompiler` registers the bundle by default (`useBundledMibs=True`), so [pysnmp/smi/compiler.py](pysnmp/smi/compiler.py) needs no change to pick it up — a vendor MIB importing only standard modules now compiles with **no MIB source configured and no network**.

Precedence is unchanged for a caller who supplies their own copy: where both the bundle and a configured source have a module, the newest `MODULE-IDENTITY` revision wins.

No API breaks. The public surface pysnmp uses — `MibCompiler`, `PySnmpCodeGen`, `baseMibs`, `getReadersFromUrls`, `StubSearcher`, `PyPackageSearcher`, `PyFileWriter`, `PyFileBorrower` — is identical between 2.1.0 and 2.3.0.

## The floor is a GA

pysmi comes off the prerelease stream the rc floors put it on: the floor reads `>=2.3.0`, not an rc. Only pyasn1 is still on that stream, so the note above the dependency table now speaks for the pyasn1 floor alone instead of for two siblings.

## Verification

- `pytest` — 959 passed, 12 skipped
- `mypy pysnmp` — no issues in 148 source files
- `ruff check` / `ruff format --check` — clean
- Sphinx `-n -W` — build succeeded
- Compiled a MIB importing `IF-MIB` against the bundle alone: `IF-MIB.py`, `IANAifType-MIB.py` and `SNMPv2-MIB.py` were written from bundled sources with no local directory and no remote reader.

Docs: the "pass MIB to the Manager" FAQ now says the standard set is bundled, so the remote repo is what a MIB importing something *outside* that set needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that PySMI includes standard MIBs and can compile modules importing only those bundled definitions without configured sources or network access.
  - Documented that configured copies with newer `MODULE-IDENTITY` revisions take precedence.
  - Clarified when additional local or remote MIB sources are required for imports outside the bundled set.

- **Chores**
  - Updated the supported `pysnmp-pysmi` version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->