### PR TITLE
perf: lazy-load the MIB compiler import in smi/rfc1902.py

### DIFF
--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -13,7 +13,6 @@ from pysnmp import debug
 from pysnmp.proto import rfc1902, rfc1905
 from pysnmp.proto.api import v2c
 from pysnmp.smi.builder import ZipMibSource
-from pysnmp.smi.compiler import addMibCompiler
 from pysnmp.smi.error import SmiError
 
 __all__ = ["NotificationType", "ObjectIdentity", "ObjectType"]
@@ -362,6 +361,15 @@ class ObjectIdentity:
         >>>
 
         """
+        # Imported here rather than at module level: pysnmp.smi.compiler imports
+        # pysmi, which transitively pulls in requests, urllib3, certifi, idna,
+        # charset_normalizer, ssl and socket, plus pysmi's lexer and parser
+        # tables -- 251 modules and ~136 ms measured at pysmi 2.0.1. Nothing at
+        # import time uses addMibCompiler; this method is its only caller, so
+        # every manager and trap receiver that never compiles a MIB was paying
+        # for it on `import pysnmp.smi.rfc1902`. See pysnmp/pysnmp#140.
+        from pysnmp.smi.compiler import addMibCompiler
+
         if self.__mibSourcesToAdd is not None:
             debug.logger & debug.flagMIB and debug.logger(
                 "adding MIB sources {}".format(", ".join(self.__mibSourcesToAdd))

--- a/tests/test_rfc1902_lazy_compiler.py
+++ b/tests/test_rfc1902_lazy_compiler.py
@@ -1,0 +1,156 @@
+"""The MIB compiler is imported when it is used, not when rfc1902 is imported.
+
+``pysnmp.smi.compiler`` imports pysmi at module level, which transitively pulls
+in ``requests``, ``urllib3``, ``certifi``, ``idna``, ``charset_normalizer``,
+``ssl`` and ``socket``, plus pysmi's ASN.1 lexer and parser tables. Every
+consumer of ``ObjectIdentity`` / ``ObjectType`` / ``NotificationType`` paid that
+cost, including managers and trap receivers that never compile a MIB.
+
+Nothing at import time uses ``addMibCompiler``: it is referenced only inside
+``ObjectIdentity.resolveWithMib()``. So the import belongs at the call site.
+
+Two things are asserted here, and they pull in opposite directions:
+
+* the cost is actually deferred -- a fresh interpreter that imports
+  ``pysnmp.smi.rfc1902`` must not have pysmi in ``sys.modules``
+* nothing else changed -- ``resolveWithMib()`` still attaches a compiler, with
+  the same arguments, on both of its branches
+
+Without the second set the first is trivially satisfiable by breaking
+resolution. See pysnmp/pysnmp#140.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from pysnmp.smi import builder, rfc1902, view
+from pysnmp.smi.rfc1902 import ObjectIdentity
+
+
+def _fresh_interpreter(body: str) -> str:
+    """Run *body* in a new interpreter and return its stdout.
+
+    A subprocess rather than ``importlib.reload``: pysmi is imported by other
+    tests in this suite and by pysnmp's own MIB loading, so ``sys.modules`` in
+    this process says nothing about what importing rfc1902 costs on its own.
+    """
+    completed = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    return completed.stdout.strip()
+
+
+class TestImportIsDeferred:
+    """Importing the module must not import the compiler."""
+
+    def test_import_does_not_load_pysmi(self):
+        """No pysmi module is imported by ``import pysnmp.smi.rfc1902``."""
+        loaded = _fresh_interpreter(
+            """
+            import sys
+            import pysnmp.smi.rfc1902  # noqa: F401
+
+            print(",".join(sorted(
+                m for m in sys.modules
+                if m == "pysmi" or m.startswith("pysmi.")
+            )))
+            """
+        )
+
+        assert loaded == "", f"importing rfc1902 pulled in pysmi: {loaded}"
+
+    def test_import_does_not_load_requests_or_ssl(self):
+        """The transitive network stack stays out too.
+
+        ``requests`` and ``ssl`` are the expensive part of what pysmi drags in,
+        and they are what a trap receiver most obviously has no use for. They
+        are asserted separately from pysmi because a future pysmi could stop
+        importing them, and that would make this pass for the right reason
+        rather than silently stop testing anything.
+        """
+        loaded = _fresh_interpreter(
+            """
+            import sys
+            import pysnmp.smi.rfc1902  # noqa: F401
+
+            print(",".join(
+                name for name in ("requests", "ssl") if name in sys.modules
+            ))
+            """
+        )
+
+        assert loaded == "", f"importing rfc1902 pulled in {loaded}"
+
+    def test_compiler_still_reachable_from_its_own_module(self):
+        """``addMibCompiler`` keeps its home in ``pysnmp.smi.compiler``.
+
+        It was never in rfc1902's ``__all__``, so moving the import off the
+        module namespace is not an API change -- but the function it moved
+        away from must still be importable where it is documented to live.
+        """
+        from pysnmp.smi.compiler import addMibCompiler
+
+        assert callable(addMibCompiler)
+
+
+class TestResolutionUnchanged:
+    """``resolveWithMib()`` behaves as it did before the import moved."""
+
+    @pytest.fixture
+    def mib_view_controller(self):
+        return view.MibViewController(builder.MibBuilder())
+
+    @pytest.fixture
+    def recorded_calls(self, monkeypatch):
+        """Capture ``addMibCompiler`` calls made during resolution."""
+        calls = []
+
+        def recorder(mibBuilder, **kwargs):
+            calls.append(kwargs)
+
+        monkeypatch.setattr(rfc1902, "addMibCompiler", recorder, raising=False)
+        monkeypatch.setattr(
+            "pysnmp.smi.compiler.addMibCompiler", recorder, raising=False
+        )
+
+        return calls
+
+    def test_resolution_still_works(self, mib_view_controller):
+        """A MIB name resolves to the OID it always did."""
+        identity = ObjectIdentity("SNMPv2-MIB", "sysDescr")
+        identity.resolveWithMib(mib_view_controller)
+
+        assert str(identity) == "1.3.6.1.2.1.1.1"
+
+    def test_default_branch_passes_if_available_and_if_not_added(
+        self, mib_view_controller, recorded_calls
+    ):
+        """With no ASN.1 sources configured, the compiler is attached softly.
+
+        ``ifAvailable=True`` is what keeps a missing pysmi a no-op rather than
+        an error, and ``ifNotAdded=True`` is what stops a second compiler being
+        attached. Both are load-bearing for the default path.
+        """
+        identity = ObjectIdentity("SNMPv2-MIB", "sysDescr")
+        identity.resolveWithMib(mib_view_controller)
+
+        assert recorded_calls == [{"ifAvailable": True, "ifNotAdded": True}]
+
+    def test_configured_sources_are_passed_through(
+        self, mib_view_controller, recorded_calls
+    ):
+        """``addAsn1MibSource()`` forwards its sources and options verbatim."""
+        identity = ObjectIdentity("SNMPv2-MIB", "sysDescr").addAsn1MibSource(
+            "file:///tmp/mibs"
+        )
+        identity.resolveWithMib(mib_view_controller)
+
+        assert len(recorded_calls) == 1
+        assert recorded_calls[0]["sources"] == ("file:///tmp/mibs",)


### PR DESCRIPTION
Closes #140.

`pysnmp/smi/compiler.py` imports pysmi at module level, which transitively pulls in
`requests`, `urllib3`, `certifi`, `idna`, `charset_normalizer`, `ssl` and `socket`, plus
pysmi's ASN.1 lexer and parser tables. `rfc1902` imported it at module level in turn, so
every consumer of `ObjectIdentity` / `ObjectType` / `NotificationType` paid that cost,
including managers and trap receivers that never compile a MIB.

`addMibCompiler` is referenced only inside `ObjectIdentity.resolveWithMib()`. Nothing at
import time uses it, so the import moves to the call site.

## Measured

`import pysnmp.smi.rfc1902` in a fresh interpreter, on this tree, three runs each:

| | modules | time | pysmi modules | `requests` / `ssl` |
|---|---|---|---|---|
| before | 396 | ~111 ms | 47 | loaded |
| after | **137** | **~27 ms** | **0** | **absent** |

259 modules and ~84 ms, for an import the default path never invokes. Close to the
figures in #140 (251 modules, ~136 ms, measured at pysmi 2.0.1).

## Behaviour is unchanged

`addMibCompiler` already takes `ifAvailable=True` on the default path, so a missing pysmi
remains a no-op. It was never in `rfc1902.__all__`, so moving it off the module namespace
is not an API change; `from pysnmp.smi.compiler import addMibCompiler` is unaffected and
is asserted.

## Tests, written first

`tests/test_rfc1902_lazy_compiler.py` — six tests in two groups, which pull in opposite
directions on purpose:

- **the deferral happened** — a fresh interpreter importing `rfc1902` has no pysmi module
  in `sys.modules`, and no `requests` or `ssl`
- **nothing else changed** — resolution still yields `1.3.6.1.2.1.1.1`, the default branch
  still passes `ifAvailable=True, ifNotAdded=True`, and `addAsn1MibSource()` still forwards
  its sources verbatim

Without the second group the first is trivially satisfiable by breaking resolution.

**Before this change the four behaviour tests passed and the two deferral tests failed;
after it, all six pass.** That ordering is the point — the behaviour tests are
characterization tests that pin what must not move, and they were run against the
unmodified module first.

The deferral is checked in a subprocess rather than with `importlib.reload`: pysmi is
imported by other tests in this suite and by pysnmp's own MIB loading, so in-process
`sys.modules` says nothing about what importing `rfc1902` costs on its own.

## Checks run locally

- `pytest tests` (excluding `test_netsnmp_integration.py`, which needs net-snmp): **964
  passed, 2 skipped**
- `ruff check` and `ruff format --check` on both changed files: clean
- `mypy pysnmp/smi/rfc1902.py`: no issues

## Scope

Deliberately just the import move. #140's follow-up note — that `resolveWithMib()` calls
`addMibCompiler(..., ifAvailable=True, ifNotAdded=True)` unconditionally, so pysmi is
still imported on the *first symbol resolution* even with no ASN.1 sources configured —
is a behaviour change and is not touched here. It deserves its own issue.

Part of #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBV5NVv7NB6R1Wx9vRypt6

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBV5NVv7NB6R1Wx9vRypt6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior by delaying MIB compiler loading until MIB resolution is requested.
  * Preserved existing MIB resolution behavior and compiler configuration options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->