### PR TITLE
build(deps): put the pysmi floor on the rc stream, at 2.4.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,25 +27,39 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 readme = "README.md"
-# The pyasn1 floor names a release candidate on purpose, and naming one is the
-# only way to say this: dependabot offers a prerelease when the current version
-# is already one OR when a requirement string names one, and there is no
+# The pyasn1 and pysmi floors name release candidates on purpose, and naming one
+# is the only way to say this: dependabot offers a prerelease when the current
+# version is already one OR when a requirement string names one, and there is no
 # configuration key for it (dependabot/dependabot-core#1926, closed as not
-# planned). PEP 440 admits prereleases per specifier, so this puts pyasn1 -- and
-# only pyasn1, pysmi and pycryptodomex keep stable floors -- on the rc stream,
+# planned). PEP 440 admits prereleases per specifier, so this puts both siblings
+# -- pycryptodomex is the only one left on a stable floor -- on the rc stream,
 # and this repository integrates against the sibling rc it is released alongside
 # instead of against its last GA.
 #
-# The floor names the last rc of the line its GA is on, so it sits one hair
-# below the GA rather than above it. Resolution takes the newest allowed version
-# regardless, so today this still resolves to pyasn1 2.0.0; the rc floor only
-# starts to matter once pyasn1 publishes an rc ahead of its next GA.
+# The two are not the same shape, and the difference decides whether the floor
+# does anything at all. Resolution takes the newest allowed version, so what
+# matters is where the named rc sorts against the sibling's newest GA:
 #
-# This belongs to the 6.0.0 rc cycle, not to the package forever. Put the floor
-# back on a GA before cutting the 6.0.0 GA, or a released pysnmplib lets an
-# installer resolve a sibling release candidate.
+#   pyasn1  2.0.0rc2 < 2.0.0   inert. The floor names the last rc of the line
+#                              its GA is on, so it sits one hair below that GA
+#                              and resolution still picks 2.0.0. It starts to
+#                              matter only once pyasn1 publishes an rc ahead of
+#                              its next GA.
+#   pysmi   2.4.0rc1 > 2.3.0   active. This names an rc of the *next* line, so
+#                              it outranks the newest GA and is what resolves.
+#                              Deliberate: 2.3.0 carries none of the work this
+#                              repository needs -- a loadable precompiled bundle
+#                              (pysnmp/pysmi#196) and a structural hash that no
+#                              longer depends on whether texts were generated
+#                              (pysnmp/pysmi#190, #191, #192, #198) -- which
+#                              pysnmp/pysnmp#198 builds on. A `>=2.3.0` floor
+#                              silently resolved to the GA without them.
+#
+# This belongs to the 6.0.0 rc cycle, not to the package forever. Put both
+# floors back on a GA before cutting the 6.0.0 GA, or a released pysnmplib lets
+# an installer resolve a sibling release candidate.
 dependencies = [
-    "pysnmp-pysmi >=2.3.0,<3.0.0",
+    "pysnmp-pysmi >=2.4.0rc1,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
     "pysnmp-pyasn1 >=2.0.0rc2,<3.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -897,15 +897,15 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pysmi"
-version = "2.3.0"
+version = "2.4.0rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/1f/a12894cb260e4e4abc16126997d925f80e927f69d3360a94f06a4f4519f2/pysnmp_pysmi-2.3.0.tar.gz", hash = "sha256:9808f9dfb95d25a4dc9af936d755426e1584601c2e4b097ad3cb2955895f143e", size = 2630836, upload-time = "2026-09-06T18:58:13.576Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/68/dac0c33ebcd44fe13df5bb59c33f44477e0883ff897aa44b5980e9c84624/pysnmp_pysmi-2.4.0rc1.tar.gz", hash = "sha256:3e9617a8ea253d401f931199095e835541cf5020c8be348145caa901088b068e", size = 3361570, upload-time = "2026-09-07T16:09:10.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/d4/a76de32f351a168c7a563b66e200b48f826bceffe56dad713526933e7b36/pysnmp_pysmi-2.3.0-py3-none-any.whl", hash = "sha256:4bbba0ae590e058bdcb6a079d6ea12653cba0db357aab336b6f80125fe4aae2e", size = 3729538, upload-time = "2026-09-06T18:58:11.591Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/d2/12dae24251da63facf449fc54842d42c4cdd6cd168f0a73027a66fb748f3/pysnmp_pysmi-2.4.0rc1-py3-none-any.whl", hash = "sha256:727cd2fe7f5bb205da0e87dcb2fc03876fcf89d2863f10e9ea9a98fa8b9b815e", size = 4785436, upload-time = "2026-09-07T16:09:08.499Z" },
 ]
 
 [[package]]
@@ -933,7 +933,7 @@ dev = [
 requires-dist = [
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
     { name = "pysnmp-pyasn1", specifier = ">=2.0.0rc2,<3.0.0" },
-    { name = "pysnmp-pysmi", specifier = ">=2.3.0,<3.0.0" },
+    { name = "pysnmp-pysmi", specifier = ">=2.4.0rc1,<3.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Unblocks #198. One dependency line, plus the comment that explains why it is an rc.

## Why

#198 builds on two things pysmi shipped this cycle, neither of which is in a pysmi GA:

- a precompiled bundle that **loads when registered ahead of pysnmp's own MIB sources**
  (pysnmp/pysmi#196) — the ordering #198 needs, and the one that failed **19 of 19**
  modules before that fix
- a structural hash that no longer depends on whether texts were generated
  (pysnmp/pysmi#190, #191, #192, #198)

The floor was `>=2.3.0`, and none of that work is in 2.3.0. Verified by ancestry against
the tags rather than assumed:

| commit | meaning | in v2.3.0 | in v2.4.0-rc.1 |
|---|---|---|---|
| `95d56fe` | #196 stub set | no | **yes** |
| `e9f74e2` | #190/#191/#192 text gating | no | **yes** |
| `e5d67a2` | #198 variations | no | **yes** |
| `54f85b1` | #200 schema | no | **yes** |
| `126bf58` | #201 status | no | **yes** |

## The part worth reading in the comment

Naming an rc in the specifier is what puts a sibling on the rc stream — the same
mechanism the pyasn1 floor already uses, for the same dependabot reason
(dependabot/dependabot-core#1926). What that mechanism does *not* make obvious is that
whether such a floor does anything depends on where the named rc sorts against the
sibling's newest GA:

```
pyasn1  2.0.0rc2 < 2.0.0   inert  — resolution still picks the GA
pysmi   2.4.0rc1 > 2.3.0   active — the rc is what resolves
```

That distinction is not academic here. An earlier pysmi rc, **2.2.0-rc.3**, carried
exactly the same five commits but sorted *below* the 2.3.0 GA, so no `>=` floor could
reach it — a specifier naming it would have resolved to 2.3.0, without the work, and
said nothing. pysmi renumbered to 2.4.0-rc.1 so the rc outranks the GA. The comment now
records both shapes so the next person choosing a floor knows which one they have.

## Verified against the published wheel, not just the tag

```
precompiled modules shipped: 362
loaded: 358/362   (pysmi.mibs.pysnmp registered FIRST)
failures: DSA-MIB, RDBMS-MIB, RFC-1212, RFC-1215
```

The four are the known externals, each already tracked, and none is a regression:

- **`DSA-MIB`, `RDBMS-MIB`** — import `applIndex` / `DistinguishedName` from RFC 2248's
  `APPLICATION-MIB`, which RFC 2788 renamed to `NETWORK-SERVICES-MIB`; the bundle
  carries RFC 2287's unrelated module of the same name (pysnmp/pysmi#199)
- **`RFC-1212`, `RFC-1215`** — need `SNMPv2-SMI::ObjectName`, which the copy *this*
  repository ships does not export, and `SNMPv2-SMI` is one of the three modules pysmi
  cannot generate. That is one of the gaps #198 exists to close, so it flips there

## Checks

- `pytest tests` on the locked resolution: **983 passed, 13 skipped**
- Same result when run against the rc by override before locking, so the lock is not
  hiding anything
- `uv.lock` moves `pysnmp-pysmi` and nothing else
- `ruff check` / `ruff format --check`: clean

## Before the GA

The comment already said to put the floor back on a GA before cutting 6.0.0, or a
released pysnmplib lets an installer resolve a sibling release candidate. That now
applies to two floors rather than one, and the text says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBV5NVv7NB6R1Wx9vRypt6

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBV5NVv7NB6R1Wx9vRypt6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release-candidate compatibility settings for the upcoming 6.0.0 release.
  - Clarified how prerelease versions are selected during release-candidate testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->