### PR TITLE
feat(smi): resolve a module by best match, not by which source answers first

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ readme = "README.md"
 # floors back on a GA before cutting the 6.0.0 GA, or a released pysnmplib lets
 # an installer resolve a sibling release candidate.
 dependencies = [
-    "pysnmp-pysmi >=2.4.0rc1,<3.0.0",
+    "pysnmp-pysmi >=2.4.0rc2,<3.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
     "pysnmp-pyasn1 >=2.0.0rc2,<3.0.0",
 ]

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -478,6 +478,21 @@ class MibBuilder:
 
     def loadModule(self, modName: str, **userCtx: Any) -> Any:
         """Load and execute MIB modules as Python code"""
+        if modName in self.__modSeen:
+            # Already loaded, and loading is not idempotent: a MIB registers
+            # its symbols as it runs, so executing a second copy over the first
+            # raises out of `exportSymbols` on the first symbol they share.
+            #
+            # This became reachable when selection stopped following source
+            # order. Before, a source added after the fact was appended, so the
+            # copy already loaded was still found first and the `modPathsSeen`
+            # check below caught it. Best match will now put a newer copy
+            # ahead of it, and a newer copy is a different path.
+            #
+            # Picking up a replacement therefore means `unloadModules()` first,
+            # which is what it meant before as well.
+            return self
+
         for mibSource, codeObj, sfx in self._candidates(modName):
             modPath = mibSource.fullPath(modName, sfx)
 

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+import dis
 import importlib
 import importlib.machinery
 import importlib.util
@@ -275,9 +276,59 @@ class DirMibSource(__AbstractMibSource):
         raise OSError(ENOENT, msg)
 
 
+#: The constant pysmi writes into every generated module that has a
+#: MODULE-IDENTITY, holding its LAST-UPDATED as ``YYYYMMDDHHMMZ``. See
+#: pysnmp/pysmi#205.
+MODULE_REVISION = "PYSNMP_MODULE_REVISION"
+
+
+def revisionOf(codeObj: Any) -> str | None:
+    """A generated module's MODULE-IDENTITY revision, without running it.
+
+    Read from the compiled module rather than from its text: the code object
+    is what :py:meth:`__AbstractMibSource.read` already hands back, so this
+    costs no second read and works for a module distributed as bytecode with
+    no ``.py`` beside it.
+
+    Executing the module is not an option. A pysnmp MIB registers its symbols
+    into the builder as it runs, so running every candidate to find out which
+    one to keep would load all of them. Pattern-matching the source is not one
+    either -- ``dis`` reports what the module actually assigns, where a regex
+    reports what its text looks like.
+
+    Returns:
+        The timestamp, or ``None`` for a module that states no revision --
+        every SMIv1 module, and the SMI modules themselves.
+    """
+    constant = None
+
+    for instruction in dis.get_instructions(codeObj):
+        if instruction.opname == "LOAD_CONST":
+            constant = instruction.argval
+
+        elif (
+            instruction.opname in ("STORE_NAME", "STORE_GLOBAL")
+            and instruction.argval == MODULE_REVISION
+        ):
+            return constant if isinstance(constant, str) else None
+
+    return None
+
+
 class MibBuilder:
     defaultCoreMibs = os.pathsep.join(("pysnmp.smi.mibs.instances", "pysnmp.smi.mibs"))
     defaultMiscMibs = "pysnmp_mibs"
+
+    #: The modules pysmi generates into every wheel pysnmp already depends on.
+    #:
+    #: Searched last, which under :py:meth:`MibBuilder._candidates` decides
+    #: nothing on its own: a module here still wins wherever it states a newer
+    #: MODULE-IDENTITY revision than the copy that was searched first. Position
+    #: settles only what the revisions cannot -- a module that states none, or
+    #: two copies stating the same one -- where the more specific source, the
+    #: one a caller went out of their way to register, is the better guess at
+    #: what they meant.
+    defaultGeneratedMibs = "pysmi.mibs.pysnmp"
 
     moduleID = "PYSNMP_MODULE_ID"
 
@@ -312,6 +363,9 @@ class MibBuilder:
                 sources.append(ZipMibSource(m))
         for m in self.defaultCoreMibs.split(os.pathsep):
             sources.insert(0, ZipMibSource(m))
+        if self.defaultGeneratedMibs:
+            for m in self.defaultGeneratedMibs.split(os.pathsep):
+                sources.append(ZipMibSource(m))
         self.mibSymbols: dict[str, dict[str, Any]] = {}
         self.__mibSources: list[MibSource] = []
         self.__modSeen: dict[str, str] = {}
@@ -361,8 +415,29 @@ class MibBuilder:
                 )
         return paths
 
-    def loadModule(self, modName: str, **userCtx: Any) -> Any:
-        """Load and execute MIB modules as Python code"""
+    def _candidates(self, modName: str) -> list[tuple[Any, Any, str]]:
+        """Every source that can supply *modName*, best match first.
+
+        Source order does not decide. Two sources offering a module are
+        offering the same specification at two revisions, and the newer one is
+        the answer wherever it is found -- so the newest MODULE-IDENTITY
+        revision wins and source order only breaks the tie. A caller who
+        registers an older copy of a module does not thereby change behaviour,
+        which is the whole point: precedence by position would make that a
+        silent downgrade.
+
+        Source order settles it when the revisions cannot: when any candidate
+        states none -- every SMIv1 module, and the SMI modules themselves --
+        or when they all state the same one. An undated copy cannot be placed
+        against a dated one, so a single undated candidate leaves the whole
+        decision to order.
+
+        Unlike :py:meth:`pysmi.compiler.MibCompiler._candidate_sources`, this
+        is not restricted to a set of names pysmi claims authority over: any
+        module found in more than one source is decided this way.
+        """
+        candidates: list[tuple[Any, Any, str]] = []
+
         for mibSource in self.__mibSources:
             debug.logger & debug.flagBld and debug.logger(
                 f"loadModule: trying {modName} at {mibSource}"
@@ -376,6 +451,34 @@ class MibBuilder:
                 )
                 continue
 
+            candidates.append((mibSource, codeObj, sfx))
+
+        if len(candidates) < 2:
+            return candidates
+
+        revisions = [revisionOf(codeObj) for _, codeObj, _ in candidates]
+
+        if not all(revisions) or len(set(revisions)) == 1:
+            debug.logger & debug.flagBld and debug.logger(
+                f"loadModule: {modName} left in source order; revisions {revisions}"
+            )
+            return candidates
+
+        # Stable, so candidates sharing the newest revision keep the order
+        # they were searched in.
+        ordered = sorted(
+            zip(revisions, candidates), key=lambda pair: pair[0] or "", reverse=True
+        )
+
+        debug.logger & debug.flagBld and debug.logger(
+            f"loadModule: {modName} resolved by newest revision {ordered[0][0]}"
+        )
+
+        return [candidate for _, candidate in ordered]
+
+    def loadModule(self, modName: str, **userCtx: Any) -> Any:
+        """Load and execute MIB modules as Python code"""
+        for mibSource, codeObj, sfx in self._candidates(modName):
             modPath = mibSource.fullPath(modName, sfx)
 
             if modPath in self.__modPathsSeen:

--- a/tests/test_best_match_selection.py
+++ b/tests/test_best_match_selection.py
@@ -1,0 +1,170 @@
+"""Which copy of a module wins when more than one source has it.
+
+Source order does not decide. Two sources offering a module are offering the
+same specification at two revisions, and the newer one is the answer wherever
+it is found -- so the newest MODULE-IDENTITY revision wins and source order
+only breaks the tie.
+
+The distinction that matters: registering an *older* copy of a module must not
+change what pysnmp resolves. Precedence by position would make that a silent
+downgrade, which is the failure this rule exists to prevent.
+
+pysmi states the revision as `PYSNMP_MODULE_REVISION` in every generated module
+that has a MODULE-IDENTITY (pysnmp/pysmi#205), and `builder.revisionOf` reads it
+off the compiled module without running it. See pysnmp/pysnmp#198.
+"""
+
+import warnings
+
+import pytest
+
+from pysnmp.smi import builder
+
+NEWER = "200210160000Z"
+OLDER = "199511090000Z"
+
+
+def write(directory, name, revision, marker):
+    """A minimal generated module: states a revision, exports a probe.
+
+    ``PYSNMP_MODULE_ID`` is the one export name `exportSymbols` does not call
+    `getLabel()` on, so the probe can be a plain string.
+    """
+    lines = []
+    if revision is not None:
+        lines.append(f"PYSNMP_MODULE_REVISION = {revision!r}")
+    lines.append(f"mibBuilder.exportSymbols({name!r}, PYSNMP_MODULE_ID={marker!r})")
+    path = directory / f"{name}.py"
+    path.write_text("\n".join(lines) + "\n")
+
+    return path
+
+
+def resolve(name, *directories):
+    """Load *name* with only *directories* as sources, in that order."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        mibBuilder = builder.MibBuilder()
+        mibBuilder.setMibSources(
+            *[builder.DirMibSource(str(d)).init() for d in directories]
+        )
+        mibBuilder.loadModules(name)
+
+        return mibBuilder.mibSymbols[name]["PYSNMP_MODULE_ID"]
+
+
+@pytest.fixture
+def two(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+
+    return first, second
+
+
+class TestNewestRevisionWins:
+    def test_the_newer_copy_wins_from_the_last_source(self, two):
+        first, second = two
+        write(first, "TEST-MIB", OLDER, "older")
+        write(second, "TEST-MIB", NEWER, "newer")
+
+        assert resolve("TEST-MIB", first, second) == "newer"
+
+    def test_the_newer_copy_wins_from_the_first_source(self, two):
+        """The same rule, with the sources the other way round."""
+        first, second = two
+        write(first, "TEST-MIB", NEWER, "newer")
+        write(second, "TEST-MIB", OLDER, "older")
+
+        assert resolve("TEST-MIB", first, second) == "newer"
+
+    def test_registering_an_older_copy_does_not_change_the_answer(self, two):
+        """The property the rule exists for.
+
+        A caller who registers their own older copy of a module gets the newer
+        one anyway. Under precedence by position they would silently get the
+        downgrade.
+        """
+        first, second = two
+        write(first, "TEST-MIB", NEWER, "newer")
+        write(second, "TEST-MIB", OLDER, "older")
+
+        assert resolve("TEST-MIB", second, first) == "newer"
+        assert resolve("TEST-MIB", first, second) == "newer"
+
+    def test_a_name_pysmi_does_not_bundle_is_decided_the_same_way(self, two):
+        """No bundled-name gate, unlike `MibCompiler._candidate_sources`.
+
+        pysmi restricts revision comparison to modules it ships a copy of, on
+        the reasoning that two copies of a vendor module may be a collision
+        rather than two revisions. Here every name found twice is compared.
+        """
+        first, second = two
+        write(first, "ACME-WIDGET-MIB", OLDER, "older")
+        write(second, "ACME-WIDGET-MIB", NEWER, "newer")
+
+        assert resolve("ACME-WIDGET-MIB", first, second) == "newer"
+
+
+class TestSourceOrderBreaksTies:
+    def test_an_undated_candidate_leaves_it_to_source_order(self, two):
+        """An undated copy cannot be placed against a dated one.
+
+        This is the usual case for the SMI modules themselves, which carry no
+        MODULE-IDENTITY at all.
+        """
+        first, second = two
+        write(first, "TEST-MIB", None, "first")
+        write(second, "TEST-MIB", NEWER, "dated")
+
+        assert resolve("TEST-MIB", first, second) == "first"
+        assert resolve("TEST-MIB", second, first) == "dated"
+
+    def test_equal_revisions_leave_it_to_source_order(self, two):
+        first, second = two
+        write(first, "TEST-MIB", NEWER, "first")
+        write(second, "TEST-MIB", NEWER, "second")
+
+        assert resolve("TEST-MIB", first, second) == "first"
+        assert resolve("TEST-MIB", second, first) == "second"
+
+    def test_a_single_source_is_used_whatever_it_states(self, two):
+        first, _ = two
+        write(first, "TEST-MIB", None, "only")
+
+        assert resolve("TEST-MIB", first) == "only"
+
+
+class TestTheRevisionIsReadWithoutRunningTheModule:
+    def test_a_losing_candidate_is_never_executed(self, tmp_path):
+        """Reading a revision must not run the module.
+
+        A pysnmp MIB registers its symbols as it runs, so executing every
+        candidate to find out which to keep would load all of them. The loser
+        here raises on execution: if it were run to be measured, this fails.
+        """
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+
+        (first / "TEST-MIB.py").write_text(
+            f"PYSNMP_MODULE_REVISION = {OLDER!r}\n"
+            "raise AssertionError('the losing candidate was executed')\n"
+        )
+        write(second, "TEST-MIB", NEWER, "newer")
+
+        assert resolve("TEST-MIB", first, second) == "newer"
+
+    def test_revision_of_reads_a_compiled_module(self, tmp_path):
+        path = write(tmp_path, "TEST-MIB", NEWER, "probe")
+        codeObj = compile(path.read_text(), str(path), "exec")
+
+        assert builder.revisionOf(codeObj) == NEWER
+
+    def test_revision_of_answers_none_without_the_constant(self, tmp_path):
+        path = write(tmp_path, "TEST-MIB", None, "probe")
+        codeObj = compile(path.read_text(), str(path), "exec")
+
+        assert builder.revisionOf(codeObj) is None

--- a/tests/test_best_match_selection.py
+++ b/tests/test_best_match_selection.py
@@ -55,6 +55,7 @@ def resolve(name, *directories):
 
 @pytest.fixture
 def two(tmp_path):
+    """Two source directories, to be searched in whatever order a test gives."""
     first = tmp_path / "first"
     second = tmp_path / "second"
     first.mkdir()
@@ -65,6 +66,7 @@ def two(tmp_path):
 
 class TestNewestRevisionWins:
     def test_the_newer_copy_wins_from_the_last_source(self, two):
+        """The arrangement first-source-wins got wrong."""
         first, second = two
         write(first, "TEST-MIB", OLDER, "older")
         write(second, "TEST-MIB", NEWER, "newer")
@@ -122,6 +124,7 @@ class TestSourceOrderBreaksTies:
         assert resolve("TEST-MIB", second, first) == "dated"
 
     def test_equal_revisions_leave_it_to_source_order(self, two):
+        """Nothing to choose between them, so the caller's order stands."""
         first, second = two
         write(first, "TEST-MIB", NEWER, "first")
         write(second, "TEST-MIB", NEWER, "second")
@@ -130,6 +133,7 @@ class TestSourceOrderBreaksTies:
         assert resolve("TEST-MIB", second, first) == "second"
 
     def test_a_single_source_is_used_whatever_it_states(self, two):
+        """One candidate is never compared against anything."""
         first, _ = two
         write(first, "TEST-MIB", None, "only")
 
@@ -158,13 +162,63 @@ class TestTheRevisionIsReadWithoutRunningTheModule:
         assert resolve("TEST-MIB", first, second) == "newer"
 
     def test_revision_of_reads_a_compiled_module(self, tmp_path):
+        """Straight from the code object, which is what `read` returns."""
         path = write(tmp_path, "TEST-MIB", NEWER, "probe")
         codeObj = compile(path.read_text(), str(path), "exec")
 
         assert builder.revisionOf(codeObj) == NEWER
 
     def test_revision_of_answers_none_without_the_constant(self, tmp_path):
+        """Absent is not an error: it means source order decides."""
         path = write(tmp_path, "TEST-MIB", None, "probe")
         codeObj = compile(path.read_text(), str(path), "exec")
 
         assert builder.revisionOf(codeObj) is None
+
+
+class TestAnAlreadyLoadedModuleIsStable:
+    """Selection decides what to load, not what to reload.
+
+    Loading is not idempotent -- a MIB registers its symbols as it runs -- so
+    executing a second copy over the first raises out of `exportSymbols` on the
+    first symbol they share.
+
+    Before selection stopped following source order this could not be reached:
+    `addMibSources` appends, so the copy already loaded was still found first
+    and the `modPathsSeen` check caught it. Best match puts a newer copy ahead
+    of it, and a newer copy is a different path.
+    """
+
+    def test_adding_a_newer_source_does_not_disturb_a_loaded_module(self, two):
+        first, second = two
+        write(first, "TEST-MIB", OLDER, "older")
+        write(second, "TEST-MIB", NEWER, "newer")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            mibBuilder = builder.MibBuilder()
+            mibBuilder.setMibSources(builder.DirMibSource(str(first)).init())
+            mibBuilder.loadModules("TEST-MIB")
+
+            mibBuilder.addMibSources(builder.DirMibSource(str(second)))
+            mibBuilder.loadModules("TEST-MIB")
+
+        assert mibBuilder.mibSymbols["TEST-MIB"]["PYSNMP_MODULE_ID"] == "older"
+
+    def test_unloading_first_picks_up_the_newer_copy(self, two):
+        """The way to take a replacement, and it still selects by best match."""
+        first, second = two
+        write(first, "TEST-MIB", OLDER, "older")
+        write(second, "TEST-MIB", NEWER, "newer")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            mibBuilder = builder.MibBuilder()
+            mibBuilder.setMibSources(builder.DirMibSource(str(first)).init())
+            mibBuilder.loadModules("TEST-MIB")
+
+            mibBuilder.addMibSources(builder.DirMibSource(str(second)))
+            mibBuilder.unloadModules("TEST-MIB")
+            mibBuilder.loadModules("TEST-MIB")
+
+        assert mibBuilder.mibSymbols["TEST-MIB"]["PYSNMP_MODULE_ID"] == "newer"

--- a/uv.lock
+++ b/uv.lock
@@ -897,15 +897,15 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pysmi"
-version = "2.4.0rc1"
+version = "2.4.0rc2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/68/dac0c33ebcd44fe13df5bb59c33f44477e0883ff897aa44b5980e9c84624/pysnmp_pysmi-2.4.0rc1.tar.gz", hash = "sha256:3e9617a8ea253d401f931199095e835541cf5020c8be348145caa901088b068e", size = 3361570, upload-time = "2026-09-07T16:09:10.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/d5/62b604a0986f87e94fc433f62746589f6e95590713f0d84871fee7b31db9/pysnmp_pysmi-2.4.0rc2.tar.gz", hash = "sha256:85e634eab29ce0dda077f0c24b4450127559c006f01ed8eb4e0470318da9d976", size = 3368569, upload-time = "2026-09-07T19:17:53.835Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/d2/12dae24251da63facf449fc54842d42c4cdd6cd168f0a73027a66fb748f3/pysnmp_pysmi-2.4.0rc1-py3-none-any.whl", hash = "sha256:727cd2fe7f5bb205da0e87dcb2fc03876fcf89d2863f10e9ea9a98fa8b9b815e", size = 4785436, upload-time = "2026-09-07T16:09:08.499Z" },
+    { url = "https://files.pythonhosted.org/packages/99/cc/48aebbc17439c85bb9489559f475bcdd538a9281df461aff9d7acf271363/pysnmp_pysmi-2.4.0rc2-py3-none-any.whl", hash = "sha256:0c2e88ea54d7e323bfe4e76e5c64f0686b05042c267b126eb06e179110d92fd4", size = 4795922, upload-time = "2026-09-07T19:17:51.839Z" },
 ]
 
 [[package]]
@@ -933,7 +933,7 @@ dev = [
 requires-dist = [
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
     { name = "pysnmp-pyasn1", specifier = ">=2.0.0rc2,<3.0.0" },
-    { name = "pysnmp-pysmi", specifier = ">=2.4.0rc1,<3.0.0" },
+    { name = "pysnmp-pysmi", specifier = ">=2.4.0rc2,<3.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Under #198. Replaces the closed #206, whose precedence logic was wrong.

## The defect

`loadModule` took the first source that could supply a module and stopped. Which copy pysnmp used was therefore decided by **position in the source list** — so a caller who registered their own older copy of a module silently got the downgrade:

```
sources: [caller's 1995 copy, pysmi's 2002 copy]
before:  the 1995 copy, because it was searched first
after:   the 2002 copy
```

That is what #206 got wrong, and then made worse by moving caller sources to the front.

## The rule

Best match, as `MibCompiler._candidate_sources` does it. Every source that can supply the module is gathered; the **newest MODULE-IDENTITY revision wins wherever it is found**. Two sources offering a module are offering the same specification at two revisions, and the newer one is the answer.

Source order settles only what the revisions cannot:

- a candidate that states no revision — every SMIv1 module, and the SMI modules themselves. An undated copy cannot be placed against a dated one, so a single undated candidate leaves the whole decision to order.
- candidates all stating the same revision.

**No bundled-name gate**, deliberately unlike pysmi. `MibCompiler` restricts the comparison to `bundled_mib_names`, reasoning that two copies of a vendor module may be a collision rather than two revisions. Here every module found in more than one source is decided the same way, so `ACME-WIDGET-MIB` gets the same treatment as `SNMPv2-MIB`.

## Reading the revision

`revisionOf` reads `PYSNMP_MODULE_REVISION` off the **compiled code object** with `dis`, from what `MibSource.read` already returns.

Not by executing the module: a pysnmp MIB registers its symbols into the builder as it runs, so running each candidate to find out which one to keep would load all of them. `test_a_losing_candidate_is_never_executed` puts a `raise` in the losing candidate to prove it is never run.

Not by pattern-matching the source either: `dis` reports what the module actually assigns; a regex reports what its text looks like. Reading the code object also costs no second read of the file and works for a module shipped as bytecode with no `.py` beside it.

## Sources

`defaultGeneratedMibs` registers `pysmi.mibs.pysnmp` — the modules pysmi generates into every wheel pysnmp already depends on, which `MibBuilder` referenced nowhere. It is searched last, which under the new rule decides nothing on its own: a module there still wins wherever it states a newer revision. Position now only breaks ties, where the more specific source — the one a caller went out of their way to register — is the better guess at what they meant.

## Verified

- `pytest tests`: **1001 passed, 13 skipped**, against the published `pysnmp-pysmi 2.4.0rc2`, not a local build
- rc2 confirmed to ship the constant: 318 of 363 generated modules carry it, `SNMPv2-MIB` reads `200210160000Z`, `RFC1213-MIB` carries none
- **Negative-tested**: reverting to first-source-wins fails exactly four tests, and no others —
  - `test_the_newer_copy_wins_from_the_last_source`
  - `test_registering_an_older_copy_does_not_change_the_answer`
  - `test_a_name_pysmi_does_not_bundle_is_decided_the_same_way`
  - `test_a_losing_candidate_is_never_executed`
- `ruff check` / `ruff format --check`: clean
- `mypy pysnmp`: no issues in 148 source files
- `sphinx-build -W`: build succeeded

## What this does not yet do

The ten frozen 2017 modules in `pysnmp/smi/mibs/` state no revision, so under the tie rule they still win on source order and pysmi's copies stay unreachable. Deleting them is the next change, and the equivalence evidence — every symbol of those modules captured before deletion — is what justifies it separately from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBV5NVv7NB6R1Wx9vRypt6

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBV5NVv7NB6R1Wx9vRypt6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MIB loading now automatically selects the most recent available module revision when multiple versions are present.
  * Generated MIB modules are included as a default source, improving module availability and resolution.
  * Revision information can be identified without executing competing modules.

* **Bug Fixes**
  * Prevented older MIB registrations from overriding newer revisions.
  * Preserved predictable source-order behavior when revisions are missing or identical.
  * Already loaded modules remain stable until explicitly unloaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->