### PR TITLE
build(deps): allow pysmi 3.x, so a release exists for pysnmp/mibs to pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ readme = "README.md"
 # floors back on a GA before cutting the 6.0.0 GA, or a released pysnmplib lets
 # an installer resolve a sibling release candidate.
 dependencies = [
-    "pysnmp-pysmi >=2.4.0rc2,<3.0.0",
+    "pysnmp-pysmi >=3.0.0rc5,<4.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
     "pysnmp-pyasn1 >=2.0.0rc2,<3.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -897,15 +897,15 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pysmi"
-version = "2.4.0rc2"
+version = "3.0.0rc5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/d5/62b604a0986f87e94fc433f62746589f6e95590713f0d84871fee7b31db9/pysnmp_pysmi-2.4.0rc2.tar.gz", hash = "sha256:85e634eab29ce0dda077f0c24b4450127559c006f01ed8eb4e0470318da9d976", size = 3368569, upload-time = "2026-09-07T19:17:53.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/83/c166def683c38e29730ea158d1b99bbb1f62af11b9c6b5859aca1536297e/pysnmp_pysmi-3.0.0rc5.tar.gz", hash = "sha256:21d84f555536a975391d93cf3a099ffe6fe98598ae5bed998bd07aa9e0dc666c", size = 4309060, upload-time = "2026-09-08T14:57:53.978Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/cc/48aebbc17439c85bb9489559f475bcdd538a9281df461aff9d7acf271363/pysnmp_pysmi-2.4.0rc2-py3-none-any.whl", hash = "sha256:0c2e88ea54d7e323bfe4e76e5c64f0686b05042c267b126eb06e179110d92fd4", size = 4795922, upload-time = "2026-09-07T19:17:51.839Z" },
+    { url = "https://files.pythonhosted.org/packages/24/03/ec6e9b52c8828e6bd4e879818754d47e72b9f0e3867f97be60d322e236d7/pysnmp_pysmi-3.0.0rc5-py3-none-any.whl", hash = "sha256:fdbeedc6c5a448e800bf0e0a0a129d499c0edba32743309adbfa00dc9b21a4a2", size = 3101842, upload-time = "2026-09-08T14:57:51.922Z" },
 ]
 
 [[package]]
@@ -933,7 +933,7 @@ dev = [
 requires-dist = [
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
     { name = "pysnmp-pyasn1", specifier = ">=2.0.0rc2,<3.0.0" },
-    { name = "pysnmp-pysmi", specifier = ">=2.4.0rc2,<3.0.0" },
+    { name = "pysnmp-pysmi", specifier = ">=3.0.0rc5,<4.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Refs pysnmp/mibs#381.

## Why

pysnmp/mibs#381 found that its `tests/runtime-compile-contract.py` cannot observe the base-layer convergence #198 landed. That repository's dev pin is `pysnmp>=7,<8`, which resolves to **lextudio/pysnmp 7.1.29**, not to this distribution — so no release of ours will ever flip the RMON known failure, and the check keeps reporting a defect that is fixed.

The decision on that issue is that the contract is against **pysnmp/pysnmp**, so the pin becomes `pysnmplib`. It cannot today:

```
× No solution found when resolving dependencies:
╰─▶ Because only pysnmplib<=6.0.0rc9 is available and pysnmplib==6.0.0rc9
    depends on pysnmp-pysmi>=2.1.0rc3,<3.0.0, ... and your project depends on
    pysnmp-pysmi>=3.0.0rc4, we can conclude that your project and
    pysnmp-mibs:dev are incompatible.
```

| | requires |
|---|---|
| `pysnmp/mibs` `main` | `pysnmp-pysmi >=3.0.0rc4,<4` |
| this branch's `next` | `pysnmp-pysmi >=2.4.0rc2,<3.0.0` |
| released `pysnmplib` 6.0.0rc9 | `pysnmp-pysmi >=2.1.0rc3,<3.0.0` |

pysmi has released through 3.0.0rc5; we are the ones still capped. Raising the ceiling here, and releasing, is what unblocks the pin change over there.

## Why pysmi 3 is safe for us

Its three breaking changes are all either ours already or compiler-side:

- **`feat(codegen)!: target the loader contract instead of inferring it`** — this is what #197 published `loaderContract` *for*. The generator now targets a declared version instead of sniffing `mibBuilder.version`; the `> (4, 4, 0)` branches and the `_NO_SET_REFERENCE` list are gone from its output.
- **`feat(mibs)!: hold the 275 bundled modules nothing in the corpus imports`** — moves modules pysmi's own corpus does not import into a `future/` tier. The searched bundle shrinks; nothing we load is in it.
- **`fix(compiler)!: omit only the failed MIB and what imports it`** — per-MIB failure isolation in pysmi's compiler.

## Verified

Full suite against `pysnmp-pysmi 3.0.0rc5`:

```
1013 passed, 13 skipped, 50 warnings in 36.19s
ruff check .              All checks passed!
ruff format --check .     200 files already formatted
mypy pysnmp               Success: no issues found in 137 source files
```

And the base layer still loads from pysmi's generated modules rather than a freeze, which is the thing that would break if the held-module tier had taken something we need:

```
SNMPv2-MIB                 ok   71 symbols
IF-MIB                     ok   95 symbols
SNMP-VIEW-BASED-ACM-MIB    ok   39 symbols
RFC1213-MIB                ok  203 symbols
SNMP-COMMUNITY-MIB         ok   27 symbols
HOST-RESOURCES-MIB         ok  108 symbols
```

## Sequencing

This is step 1 of 3. Step 2 is a `pysnmplib` release carrying it; step 3 is pysnmp/mibs swapping its dev pin to `pysnmplib` and moving the RMON entry out of `KNOWN_FAILURES`. Recorded on pysnmp/mibs#381 so the order is not lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oXcuP2UeukjKfetRm7cvv

---
_Generated by [Claude Code](https://claude.ai/code/session_013oXcuP2UeukjKfetRm7cvv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported dependency version range for improved compatibility with newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->