### PR TITLE
feat(smi): resolve MIBs from a corpus, when asked to

### DIFF
--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -61,6 +61,7 @@ Documentation
    /docs/smi-table-api
    /docs/device-report
    /docs/mib-tools
+   /docs/mib-corpus
    /docs/loader-contract
 
 Examples

--- a/docs/source/docs/mib-corpus.rst
+++ b/docs/source/docs/mib-corpus.rst
@@ -1,0 +1,191 @@
+.. _mib-corpus:
+
+Loading MIBs from a corpus
+==========================
+
+A **MIB corpus** is a SQLite database holding the SMI model as data: one row
+per node, keyed for lookup by OID and by name, and ordered so a GETNEXT walk is
+a range query. pysmi builds it (``mibcorpus --emit=core-db``) and pysnmp reads
+it with the standard library.
+
+It is **opt-in and additive**. Everything on this page is something you have to
+ask for. A ``MibBuilder`` with no corpus configured resolves exactly as it
+always has, and configuring one does not change what a module already on disk
+resolves to.
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Nothing changes unless you ask
+------------------------------
+
+This is the compatibility promise, and it is worth stating before the feature:
+
+* A ``MibBuilder`` with no corpus behaves identically to one from before this
+  existed -- same sources, same search order, same objects, same errors.
+* With a corpus configured, a module the MIB sources carry is still loaded
+  from the MIB sources. The corpus is where a module is found when nothing
+  else has it.
+* The corpus is consulted **before** the MIB compiler, so a deployment with
+  ``addMibCompiler()`` set up keeps compiling whatever the corpus does not
+  carry.
+
+So an existing deployment upgrades into this by doing nothing, and opts in by
+adding two lines.
+
+
+Why you might want one
+----------------------
+
+The published ``index-v2.csv`` already answers *which module owns this OID*, so
+lazy loading needs no corpus at all. Two things it cannot do are the reason
+this exists.
+
+**It cannot tell you what is at an OID.** The index is ``MODULE,OID`` and
+carries a module's *anchors*, so a leaf like ``ifDescr`` is not in it. Getting
+from an OID to a name, a syntax and an access level means loading the module --
+by compiling its ASN.1 on the trap path, or by parsing its whole JSON document.
+On ``CISCO-ENTITY-VENDORTYPE-OID-MIB`` that is 11 ms and 9,773 symbols to reach
+one of them; from a corpus it is one indexed row.
+
+**It cannot tell you what comes next.** An anchor index has no per-node
+ordering, so a walk cannot be served from one.
+
+There is a third reason, which is about what a corpus *is not*: a pysnmp MIB
+module is Python that ``MibBuilder`` runs through ``exec()``. A corpus is rows.
+Building a module from rows executes nothing.
+
+
+Using one
+---------
+
+.. code-block:: python
+
+   from pysnmp.smi.builder import MibBuilder
+   from pysnmp.smi.corpus import MibCorpus
+
+   mibBuilder = MibBuilder()
+   mibBuilder.setMibCorpus(MibCorpus("/mibs/core.db"))
+
+   # Resolves from the MIB sources if they have it, from the corpus if not.
+   (ifDescr,) = mibBuilder.importSymbols("IF-MIB", "ifDescr")
+
+With the SNMP engine:
+
+.. code-block:: python
+
+   from pysnmp.hlapi.v3arch.asyncio import SnmpEngine
+
+   snmpEngine = SnmpEngine()
+   mibBuilder = snmpEngine.get_mib_builder()
+   mibBuilder.setMibCorpus(MibCorpus("/mibs/core.db"))
+
+Pass ``None`` to stop using one. The corpus is opened read-only with SQLite's
+``immutable=1``, so it takes no locks and needs nothing writable near it --
+which is what lets it be mounted from a Kubernetes image volume.
+
+
+Resolving a trap OID without a compiler
+---------------------------------------
+
+The corpus can be queried directly, which is what a trap receiver wants: an
+arriving OID is an *instance* OID -- a column OID plus index arcs -- and
+appears in no MIB at all.
+
+.. code-block:: python
+
+   corpus = MibCorpus("/mibs/core.db")
+
+   # Which module answers for it? Longest-prefix, chopping an arc at a time.
+   corpus.find_module("1.3.6.1.2.1.2.2.1.2.7")     # -> 'IF-MIB'
+
+   # What is the node itself?
+   corpus.node("1.3.6.1.2.1.2.2.1.2")["name"]      # -> 'ifDescr'
+
+   # GETNEXT, over the whole corpus.
+   corpus.next_node("1.3.6.1.2.1.2.2.1.2")["name"] # -> 'ifType'
+
+   # Everything under a subtree, in OID order.
+   corpus.subtree("1.3.6.1.2.1.2.2")
+
+``find_module`` returning ``None`` is a **miss, not an error**: an OID nothing
+claims still decodes structurally as far as the longest known prefix reaches,
+and that is the behaviour a trap receiver wants.
+
+This replaces the older pattern of parsing ``index.csv`` into a dictionary and
+calling ``loadModules()`` on whatever it named. That pattern works and is not
+going away yet, but it needs a second file, a full ASN.1 compile per module on
+the trap path, and it cannot answer either of the questions above.
+
+
+What a corpus does not carry
+----------------------------
+
+**Prose.** No DESCRIPTION, no REFERENCE. They are roughly a third of a
+generated module's bytes, the runtime discards them under the default
+``loadTexts = False``, and pysmi's published ``json/`` tree already serves the
+one consumer that wants them -- a MIB browser.
+
+Because of that, ``setMibCorpus()`` **refuses** a textless corpus when
+``loadTexts`` is set:
+
+.. code-block:: python
+
+   mibBuilder.loadTexts = True
+   mibBuilder.setMibCorpus(corpus)   # raises SmiError
+
+Refused rather than silently satisfied: a caller that asked for descriptions
+and got a module with none has no way to tell that from a MIB that declares
+none. Load texts from the ``json/`` tree, or clear ``loadTexts``.
+
+
+How a module is built
+---------------------
+
+The objects are the ones the generated module would have produced --
+``MibScalar``, ``MibTable``, ``MibTableRow``, ``MibTableColumn``,
+``NotificationType`` and the rest -- with the same OIDs, the same syntax
+instances, the same ``maxAccess`` and the same index names. What differs is
+that the description of them arrived as data.
+
+Type names resolve in this order:
+
+1. A type the module declares itself. Its own TEXTUAL-CONVENTION shadows
+   anything of that name elsewhere.
+2. A base SMI type -- ``Integer32``, ``OCTET STRING``, ``Counter64`` and so on.
+3. Whatever the module's IMPORTS clause says defines it. This may load that
+   module, from disk or from the corpus, so a vendor module's ``DisplayString``
+   resolves to the one the already-loaded ``SNMPv2-TC`` exported.
+
+A type that resolves nowhere raises rather than falling back to a base type: a
+column silently typed ``OctetString`` instead of its TEXTUAL-CONVENTION renders
+every value wrong and looks like a device fault.
+
+A syntax is stored once in the corpus and referenced by id, and the class built
+for it is cached against that id, so two objects sharing a type share a class
+and ``isinstance`` never sees two classes for one type.
+
+
+Version gating
+--------------
+
+A corpus stamps a **schema version** -- the layout, which changes rarely -- and
+a **corpus version**, which is the build and changes often. They are separate
+so that a corpus rebuild does not require a pysnmp release.
+
+``MibCorpus`` refuses a schema version it does not implement, rather than
+reading the part it recognizes: a partial read resolves some OIDs and silently
+not others.
+
+.. code-block:: python
+
+   corpus.meta("schema_version")   # '1'
+   corpus.meta("corpus_version")   # whatever the build stamped
+   corpus.module("IF-MIB")         # tier, revision, content hash, node count
+
+The full file format is specified in pysmi's ``corpus-schema`` document, and
+pysmi publishes a conformance fixture that this repository's CI runs against
+this reader -- so the two halves of the contract are checked against each other
+rather than against themselves.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,17 @@ dev = [
     "coverage[toml] >=7.2.0,<8.0.0",
     "mypy >=1.15.0,<3.0.0",
     "ruff >=0.4.0,<1.0.0",
+    # pysmi is already a runtime dependency, and this raises its floor for
+    # development only. tests/test_corpus.py builds its fixture with
+    # pysmi.corpus.conformance, which 3.1.0rc1 is the first release to publish;
+    # the runtime floor stays where it is because nothing pysnmp ships imports
+    # pysmi to read a corpus -- that is the point of the format.
+    #
+    # The floor is load-bearing rather than documentary. It was absent, the lock
+    # resolved pysmi 3.0.0rc5, and `pysmi.corpus` did not exist there, so the
+    # module-level import of the fixture skipped the entire corpus suite and CI
+    # passed without running any of it.
+    "pysnmp-pysmi >=3.1.0rc1",
 ]
 
 [tool.pytest.ini_options]

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -445,6 +445,7 @@ class MibBuilder:
         self.__modPathsSeen: set[str] = set()
         self.__mibCompiler: Any = None
         self.__mibCorpus: Any = None
+        self.__corpusBuilding: set[str] = set()
         self.setMibSources(*sources)
 
     # MIB corpus management
@@ -488,6 +489,26 @@ class MibBuilder:
                 for descriptions and got a module with none has no way to
                 tell that from a MIB that declares none.
         """
+        self._checkCorpusTexts(mibCorpus)
+
+        self.__mibCorpus = mibCorpus
+
+        return self
+
+    def _checkCorpusTexts(self, mibCorpus: Any) -> None:
+        """Refuse a textless corpus while ``loadTexts`` asks for prose.
+
+        Called both when a corpus is attached and again before each synthesis,
+        because ``loadTexts`` is a plain attribute a caller may set at any
+        time. Checking only at attachment would leave a builder that turned
+        texts on afterwards silently building modules with none.
+
+        Args:
+            mibCorpus: the corpus about to be used, or ``None``
+
+        Raises:
+            SmiError: texts were asked for and the corpus has none.
+        """
         if (
             mibCorpus is not None
             and self.loadTexts
@@ -498,10 +519,6 @@ class MibBuilder:
                 f"texts; load descriptions from the published json/ tree, or "
                 f"clear loadTexts"
             )
-
-        self.__mibCorpus = mibCorpus
-
-        return self
 
     def _loadModuleFromCorpus(self, modName: str) -> bool:
         """Build a module out of the corpus, if one is configured and has it.
@@ -515,9 +532,37 @@ class MibBuilder:
         if self.__mibCorpus is None:
             return False
 
+        # Re-checked here, not only at setMibCorpus(). loadTexts is a plain
+        # attribute, so setting it after a corpus is attached would otherwise
+        # slip past the check and quietly build modules with no DESCRIPTION.
+        self._checkCorpusTexts(self.__mibCorpus)
+
+        if modName in self.__corpusBuilding:
+            # A module reached again while it is being built. Synthesis
+            # resolves imported types through importSymbols, which comes back
+            # here, so an import cycle -- A imports from B, B from A -- would
+            # otherwise recurse without limit. It cannot be caught by
+            # __modSeen: synthesis exports into mibSymbols only once it
+            # finishes, so marking the module loaded up front would make the
+            # re-entrant importSymbols raise MibNotFoundError instead.
+            from pysnmp.smi.corpus import MibCorpusCycleError
+
+            raise MibCorpusCycleError(
+                f"MIB module {modName} is being built from the corpus and was "
+                f"asked for again; its imports form a cycle"
+            )
+
         from pysnmp.smi import synthesis
 
-        if not synthesis.load_module(self, self.__mibCorpus, modName):
+        self.__corpusBuilding.add(modName)
+
+        try:
+            built = synthesis.load_module(self, self.__mibCorpus, modName)
+
+        finally:
+            self.__corpusBuilding.discard(modName)
+
+        if not built:
             return False
 
         # Recorded under a path no MIB source can produce, so that

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -444,7 +444,93 @@ class MibBuilder:
         self.__modSeen: dict[str, str] = {}
         self.__modPathsSeen: set[str] = set()
         self.__mibCompiler: Any = None
+        self.__mibCorpus: Any = None
         self.setMibSources(*sources)
+
+    # MIB corpus management
+
+    def getMibCorpus(self) -> Any:
+        """The corpus this builder falls back to, or ``None``.
+
+        Returns:
+            The :py:class:`~pysnmp.smi.corpus.MibCorpus`, or ``None`` when
+            none is configured -- which is the default and means this builder
+            resolves exactly as it always has.
+        """
+        return self.__mibCorpus
+
+    def setMibCorpus(self, mibCorpus: Any) -> Any:
+        """Resolve from a corpus what the MIB sources do not carry.
+
+        A corpus is a SQLite database pysmi produces, holding the SMI model as
+        data rather than as Python. Configuring one **adds a place to look**;
+        it does not replace the MIB sources, reorder them, or change what a
+        module already on disk resolves to. A module found by the ordinary
+        search is loaded the ordinary way, so an existing deployment that
+        configures a corpus keeps every answer it had and gains answers for
+        the modules it did not ship.
+
+        That ordering is the whole compatibility story, and it is deliberate:
+        the corpus is where a module is found when nothing else has it, which
+        is what makes this opt-in rather than a migration.
+
+        Args:
+            mibCorpus: an open
+                :py:class:`~pysnmp.smi.corpus.MibCorpus`, or ``None`` to stop
+                using one
+
+        Returns:
+            This builder.
+
+        Raises:
+            SmiError: ``loadTexts`` is set and the corpus carries no prose.
+                Refused rather than silently satisfied: a caller that asked
+                for descriptions and got a module with none has no way to
+                tell that from a MIB that declares none.
+        """
+        if (
+            mibCorpus is not None
+            and self.loadTexts
+            and not getattr(mibCorpus, "loadTexts", False)
+        ):
+            raise error.SmiError(
+                f"loadTexts is set but the corpus at {mibCorpus} carries no "
+                f"texts; load descriptions from the published json/ tree, or "
+                f"clear loadTexts"
+            )
+
+        self.__mibCorpus = mibCorpus
+
+        return self
+
+    def _loadModuleFromCorpus(self, modName: str) -> bool:
+        """Build a module out of the corpus, if one is configured and has it.
+
+        Args:
+            modName: the module to build
+
+        Returns:
+            Whether it was built.
+        """
+        if self.__mibCorpus is None:
+            return False
+
+        from pysnmp.smi import synthesis
+
+        if not synthesis.load_module(self, self.__mibCorpus, modName):
+            return False
+
+        # Recorded under a path no MIB source can produce, so that
+        # unloadModules() and the already-loaded check treat a synthesized
+        # module exactly like a loaded one.
+        self.__modSeen[modName] = f"corpus:{self.__mibCorpus.path}/{modName}"
+        self.__modPathsSeen.add(self.__modSeen[modName])
+
+        debug.logger & debug.flagBld and debug.logger(
+            f"loadModule: {modName} built from corpus {self.__mibCorpus.path}"
+        )
+
+        return True
 
     # MIB compiler management
 
@@ -613,7 +699,7 @@ class MibBuilder:
 
             break
 
-        if modName not in self.__modSeen:
+        if modName not in self.__modSeen and not self._loadModuleFromCorpus(modName):
             raise error.MibNotFoundError(
                 'MIB file "{}" not found in search path ({})'.format(
                     modName and modName + ".py[co]",

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -290,7 +290,10 @@ class MibCorpus:
                 f"reads version {SCHEMA_VERSION}"
             )
 
-        self._types: dict[int, dict[str, Any]] = {}
+        # A negative result is cached too: a dangling type id is a corpus
+        # defect, and re-querying for it on every node that carries it turns
+        # one defect into a per-row cost.
+        self._types: dict[int, dict[str, Any] | None] = {}
         self._modules: frozenset[str] | None = None
 
     def __repr__(self) -> str:

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -1,0 +1,573 @@
+#
+# This file is part of pysnmp software.
+#
+# Copyright (c) 2005-2019, Ilya Etingof deceased
+# License: https://www.pysnmp.com/pysnmp/license.html
+#
+"""Reading a MIB corpus, and building MIB objects from its rows.
+
+A corpus is a SQLite database pysmi produces -- ``core.db``, specified in
+pysmi's ``corpus-schema`` document. It carries the SMI model as data: one row
+per node, keyed for lookup by OID and by name and ordered for GETNEXT.
+
+**Nothing here is on the default path.** A ``MibBuilder`` with no corpus
+configured behaves exactly as it did: it searches its MIB sources, finds
+generated Python, and executes it. Configuring a corpus adds a place to look
+when that search comes up empty; it does not replace it, reorder it, or change
+what a module already on disk resolves to. That is what lets an existing
+deployment -- splunk-connect-for-snmp among them -- upgrade without changing
+anything, and opt in when it wants to.
+
+Why a corpus is worth opting into
+---------------------------------
+
+The published ``index-v2.csv`` already answers *which module owns this OID*, so
+lazy loading needs no corpus. What it cannot answer is *what is the node at
+this OID* -- it is ``MODULE,OID`` and carries anchors only, so a leaf like
+``ifDescr`` is not in it -- or *what comes after this OID*, which an anchor
+index has no ordering to answer at all.
+
+Answering the first from the published ``json/`` tree means parsing a whole
+module. Answering it from ASN.1 means running the compiler on the trap path.
+Here both are one indexed row.
+
+Reading, not writing
+--------------------
+
+pysmi owns the SMI model and every artifact shape; this repository owns the
+runtime object shape. So the writer is there and the reader is here, and the
+contract between them is a documented file format plus a conformance fixture
+that runs in this repository's CI (pysnmp/pysnmp#196, pysnmp/pysnmp#199).
+
+The consequence worth stating: **this module imports ``sqlite3`` and nothing
+from pysmi.** A corpus is read with the standard library, which is what lets
+pysmi be an optional dependency here rather than a deeper one.
+"""
+
+import json
+import os
+import sqlite3
+from typing import Any, Final, Union
+
+from pysnmp.smi import error
+
+__all__ = ["MibCorpus", "oid_from_key", "oid_key", "subtree_bound"]
+
+#: The corpus schema this reader understands.
+#:
+#: A corpus stamps its own version in ``meta`` and in the file's
+#: ``user_version`` header field. Refusing what we cannot read is deliberate:
+#: reading the subset we recognize out of a newer corpus would resolve some
+#: OIDs and silently not others.
+SCHEMA_VERSION: Final = 1
+
+#: SQLite's ``application_id`` for a corpus -- ``PSMI`` as big-endian ASCII.
+#: Checked before any table is trusted, so pointing this at an unrelated
+#: database is a clear error rather than a confusing one.
+APPLICATION_ID: Final = 0x50534D49
+
+#: Largest sub-identifier :py:func:`oid_key` encodes. RFC 2578 section 7.1.3
+#: makes a sub-identifier a 32-bit unsigned integer.
+MAX_ARC: Final = 0xFFFFFFFF
+
+
+def oid_key(oid: Union[str, "tuple[int, ...]"]) -> bytes:
+    """Encode an OID so that bytewise order is numeric order.
+
+    Each arc becomes a length byte followed by that many big-endian bytes.
+    Comparing two encodings compares the length bytes first, and a longer arc
+    is a larger arc, so the order is right without padding every arc to four
+    bytes. Two properties follow, and the corpus depends on both: an OID that
+    is a prefix of another encodes to a byte prefix of it, so a subtree is a
+    range; and a prefix sorts before everything under it, so ``oid_key > ?``
+    ascending is GETNEXT.
+
+    This is pysmi's encoding, reimplemented rather than imported. It is twenty
+    lines, and importing pysmi to read a file whose whole point is that it can
+    be read without pysmi would defeat the exercise.
+
+    Args:
+        oid: dotted decimal, or arcs as integers
+
+    Returns:
+        The sort key.
+
+    Raises:
+        SmiError: the OID is not one, or an arc is out of range.
+    """
+    if isinstance(oid, str):
+        try:
+            arcs = tuple(int(x) for x in oid.split("."))
+
+        except ValueError:
+            raise error.SmiError(f"not an OID: {oid!r}") from None
+
+    else:
+        arcs = tuple(oid)
+
+    if not arcs:
+        raise error.SmiError("empty OID")
+
+    out = bytearray()
+
+    for arc in arcs:
+        if arc < 0 or arc > MAX_ARC:
+            raise error.SmiError(f"sub-identifier out of range in {oid!r}: {arc}")
+
+        width = max(1, (arc.bit_length() + 7) // 8)
+        out.append(width)
+        out += arc.to_bytes(width, "big")
+
+    return bytes(out)
+
+
+def oid_from_key(key: bytes) -> str:
+    """Decode what :py:func:`oid_key` encoded.
+
+    Args:
+        key: the sort key
+
+    Returns:
+        The OID, dotted decimal.
+
+    Raises:
+        SmiError: the key is truncated.
+    """
+    arcs: list[str] = []
+    at = 0
+
+    while at < len(key):
+        width = key[at]
+        at += 1
+
+        if width < 1 or at + width > len(key):
+            raise error.SmiError(f"truncated OID key at byte {at}")
+
+        arcs.append(str(int.from_bytes(key[at : at + width], "big")))
+        at += width
+
+    if not arcs:
+        raise error.SmiError("empty OID key")
+
+    return ".".join(arcs)
+
+
+def subtree_bound(key: bytes) -> bytes:
+    """The exclusive upper bound of the subtree rooted at *key*.
+
+    ``oid_key >= key AND oid_key < subtree_bound(key)`` is every node at or
+    below that OID.
+
+    Args:
+        key: an encoded OID
+
+    Returns:
+        The first key sorting above every descendant.
+    """
+    out = bytearray(key)
+
+    while out and out[-1] == 0xFF:
+        out.pop()
+
+    if not out:
+        return bytes(key) + b"\xff"
+
+    out[-1] += 1
+
+    return bytes(out)
+
+
+class MibCorpus:
+    """A corpus database, opened read-only.
+
+    Args:
+        path: the ``core.db`` to open
+
+    Raises:
+        SmiError: the file is missing, is not a corpus, or carries a schema
+            version this pysnmp cannot read.
+    """
+
+    #: The queries, named. Kept together because they are the whole of what
+    #: this class is: a corpus is a file format, and a reader of it is these
+    #: statements plus the OID codec above.
+    QUERIES: Final[dict[str, str]] = {
+        "meta": "SELECT value FROM meta WHERE key = ?",
+        "find_module": "SELECT module FROM oid_index WHERE oid_key = ?",
+        "node_at": (
+            "SELECT module, name, oid, class, nodetype, status, maxaccess, "
+            "units, syntax, defval, indices, augments FROM node "
+            "WHERE oid_key = ? ORDER BY module LIMIT 1"
+        ),
+        "node_at_in": (
+            "SELECT module, name, oid, class, nodetype, status, maxaccess, "
+            "units, syntax, defval, indices, augments FROM node "
+            "WHERE oid_key = ? AND module = ?"
+        ),
+        "node_named": (
+            "SELECT module, name, oid, class, nodetype, status, maxaccess, "
+            "units, syntax, defval, indices, augments FROM node "
+            "WHERE module = ? AND name = ?"
+        ),
+        "nodes_of": (
+            "SELECT module, name, oid, class, nodetype, status, maxaccess, "
+            "units, syntax, defval, indices, augments FROM node "
+            "WHERE module = ? ORDER BY oid_key"
+        ),
+        "next_node": (
+            "SELECT module, name, oid, class, nodetype, status, maxaccess, "
+            "units, syntax, defval, indices, augments FROM node "
+            "WHERE oid_key > ? ORDER BY oid_key, module LIMIT 1"
+        ),
+        "subtree": (
+            "SELECT module, name, oid, class, nodetype, status, maxaccess, "
+            "units, syntax, defval, indices, augments FROM node "
+            "WHERE oid_key >= ? AND oid_key < ? ORDER BY oid_key, module"
+        ),
+        "symbols_of": (
+            "SELECT name, class, status, displayhint, type FROM symbol "
+            "WHERE module = ? ORDER BY name"
+        ),
+        "symbol": (
+            "SELECT name, class, status, displayhint, type FROM symbol "
+            "WHERE module = ? AND name = ?"
+        ),
+        "imports_of": "SELECT name, source FROM import WHERE module = ?",
+        "type": "SELECT spec FROM type WHERE id = ?",
+        "module": (
+            "SELECT name, tier, oid, lastupdated, revision, content_hash, nodes "
+            "FROM module WHERE name = ?"
+        ),
+        "modules": "SELECT name FROM module ORDER BY name",
+    }
+
+    #: The ``node`` columns :py:data:`QUERIES` selects, in order, so a row
+    #: becomes a dict without every caller repeating the list.
+    NODE_FIELDS: Final[tuple[str, ...]] = (
+        "module",
+        "name",
+        "oid",
+        "class",
+        "nodetype",
+        "status",
+        "maxaccess",
+        "units",
+        "syntax",
+        "defval",
+        "indices",
+        "augments",
+    )
+
+    def __init__(self, path: str):
+        if not os.path.exists(path):
+            raise error.SmiError(f"no MIB corpus at {path}")
+
+        self._path = os.path.abspath(path)
+
+        # immutable=1 says the file cannot change, so SQLite takes no locks and
+        # needs nothing writable near it -- which is what lets a corpus be
+        # mounted read-only from a container image volume.
+        self._db = sqlite3.connect(f"file:{self._path}?immutable=1", uri=True)
+
+        try:
+            application = self._db.execute("PRAGMA application_id").fetchone()[0]
+            version = self._db.execute("PRAGMA user_version").fetchone()[0]
+
+        except sqlite3.DatabaseError as exc:
+            self._db.close()
+            raise error.SmiError(f"{path} is not a MIB corpus: {exc}") from exc
+
+        if application != APPLICATION_ID:
+            self._db.close()
+            raise error.SmiError(
+                f"{path} is not a MIB corpus: application_id {application:#x}"
+            )
+
+        if version != SCHEMA_VERSION:
+            self._db.close()
+            raise error.SmiError(
+                f"MIB corpus {path} is schema version {version}; this pysnmp "
+                f"reads version {SCHEMA_VERSION}"
+            )
+
+        self._types: dict[int, dict[str, Any]] = {}
+        self._modules: frozenset[str] | None = None
+
+    def __repr__(self) -> str:
+        """The corpus and where it came from."""
+        return f"{self.__class__.__name__}({self._path!r})"
+
+    @property
+    def path(self) -> str:
+        """Where this corpus was opened from."""
+        return self._path
+
+    def close(self) -> None:
+        """Release the database."""
+        self._db.close()
+
+    def meta(self, key: str) -> str | None:
+        """One value from the corpus metadata.
+
+        Args:
+            key: ``schema_version``, ``corpus_version``, ``corpus_id``,
+                ``texts``, or one of the counts
+
+        Returns:
+            The value as a string, or ``None`` when the corpus carries none.
+        """
+        row = self._db.execute(self.QUERIES["meta"], (key,)).fetchone()
+
+        return row[0] if row else None
+
+    @property
+    def loadTexts(self) -> bool:
+        """Whether this corpus carries DESCRIPTION and REFERENCE.
+
+        Always false today: prose is roughly a third of a module's bytes, the
+        runtime discards it under the default, and the published ``json/``
+        tree already serves the consumer that wants it. The property exists so
+        a caller asking for texts can be told rather than quietly handed
+        nothing.
+        """
+        return self.meta("texts") == "1"
+
+    def modules(self) -> frozenset[str]:
+        """Every module this corpus carries."""
+        if self._modules is None:
+            self._modules = frozenset(
+                x[0] for x in self._db.execute(self.QUERIES["modules"])
+            )
+
+        return self._modules
+
+    def module(self, name: str) -> dict[str, Any] | None:
+        """What the corpus records about a module.
+
+        Args:
+            name: the module's descriptor
+
+        Returns:
+            Its tier, MODULE-IDENTITY OID, revision, content hash and node
+            count, or ``None`` when the corpus does not carry it.
+        """
+        row = self._db.execute(self.QUERIES["module"], (name,)).fetchone()
+
+        if row is None:
+            return None
+
+        return dict(
+            zip(
+                ("name", "tier", "oid", "lastupdated", "revision", "hash", "nodes"),
+                row,
+            )
+        )
+
+    def type_spec(self, identifier: int | None) -> dict[str, Any] | None:
+        """A type specification, by the id a node or symbol row carries.
+
+        Cached: a corpus repeats a handful of specifications tens of thousands
+        of times, and the id is what makes "the same type" answerable at all.
+
+        Args:
+            identifier: ``type.id``, or ``None``
+
+        Returns:
+            The specification, or ``None``.
+        """
+        if identifier is None:
+            return None
+
+        if identifier not in self._types:
+            row = self._db.execute(self.QUERIES["type"], (identifier,)).fetchone()
+            self._types[identifier] = json.loads(row[0]) if row else None
+
+        return self._types[identifier]
+
+    def _node(self, row: tuple[Any, ...] | None) -> dict[str, Any] | None:
+        """A ``node`` row as a dict, with its JSON columns decoded."""
+        if row is None:
+            return None
+
+        node = dict(zip(self.NODE_FIELDS, row))
+
+        for field in ("defval", "indices", "augments"):
+            node[field] = json.loads(node[field]) if node[field] else None
+
+        node["syntax"] = self.type_spec(node["syntax"])
+        node["arcs"] = tuple(int(x) for x in node["oid"].split("."))
+
+        return node
+
+    def find_module(self, oid: Union[str, "tuple[int, ...]"]) -> str | None:
+        """Which module answers for an OID.
+
+        The index carries a module's *anchors* -- what it registers arcs with
+        -- so this is a longest-prefix search rather than one lookup: chop an
+        arc at a time until one resolves. An instance OID from a trap is a
+        column OID plus index arcs and appears in no MIB at all, so chopping
+        is the normal case, not the exception.
+
+        Args:
+            oid: the OID to resolve
+
+        Returns:
+            The module name, or ``None`` when nothing claims a prefix of it.
+            A miss is not an error: an unresolved OID still decodes
+            structurally as far as the longest known prefix reaches.
+        """
+        arcs = [int(x) for x in oid.split(".")] if isinstance(oid, str) else list(oid)
+
+        while arcs:
+            row = self._db.execute(
+                self.QUERIES["find_module"], (oid_key(tuple(arcs)),)
+            ).fetchone()
+
+            if row:
+                return row[0]
+
+            arcs.pop()
+
+        return None
+
+    def node(
+        self, oid: Union[str, "tuple[int, ...]"], module: str | None = None
+    ) -> dict[str, Any] | None:
+        """The node at an exact OID.
+
+        Args:
+            oid: the OID, which must be the node's own and not an instance
+            module: which module's definition to take, where more than one
+                defines the OID. The first by name otherwise.
+
+        Returns:
+            The node, or ``None``.
+        """
+        key = oid_key(oid)
+
+        if module is None:
+            return self._node(
+                self._db.execute(self.QUERIES["node_at"], (key,)).fetchone()
+            )
+
+        return self._node(
+            self._db.execute(self.QUERIES["node_at_in"], (key, module)).fetchone()
+        )
+
+    def node_named(self, module: str, name: str) -> dict[str, Any] | None:
+        """The node a module declares under a descriptor.
+
+        This is the ``importSymbols(module, name)`` lookup, which is how a
+        manager usually arrives rather than by OID.
+
+        Args:
+            module: the module's descriptor
+            name: the symbol's descriptor
+
+        Returns:
+            The node, or ``None``.
+        """
+        return self._node(
+            self._db.execute(self.QUERIES["node_named"], (module, name)).fetchone()
+        )
+
+    def next_node(self, oid: Union[str, "tuple[int, ...]"]) -> dict[str, Any] | None:
+        """The first node ordered after an OID -- GETNEXT, over the corpus.
+
+        Args:
+            oid: where to start, exclusive
+
+        Returns:
+            The next node, or ``None`` at the end of the corpus, which is
+            ``endOfMibView`` and not an error.
+        """
+        return self._node(
+            self._db.execute(self.QUERIES["next_node"], (oid_key(oid),)).fetchone()
+        )
+
+    def subtree(self, oid: Union[str, "tuple[int, ...]"]) -> list[dict[str, Any]]:
+        """Every node at or below an OID, in OID order.
+
+        Args:
+            oid: the subtree root
+
+        Returns:
+            The nodes, root first.
+        """
+        low = oid_key(oid)
+
+        return [
+            self._node(row)  # type: ignore[misc]
+            for row in self._db.execute(
+                self.QUERIES["subtree"], (low, subtree_bound(low))
+            )
+        ]
+
+    def nodes_of(self, module: str) -> list[dict[str, Any]]:
+        """Every node a module declares, in OID order.
+
+        Args:
+            module: the module's descriptor
+
+        Returns:
+            The nodes.
+        """
+        return [
+            self._node(row)  # type: ignore[misc]
+            for row in self._db.execute(self.QUERIES["nodes_of"], (module,))
+        ]
+
+    def symbols_of(self, module: str) -> list[dict[str, Any]]:
+        """Every type a module declares -- its TEXTUAL-CONVENTIONs and type
+        assignments -- in name order.
+
+        Args:
+            module: the module's descriptor
+
+        Returns:
+            The symbols, each with its specification decoded.
+        """
+        return [
+            {
+                "name": row[0],
+                "class": row[1],
+                "status": row[2],
+                "displayhint": row[3],
+                "type": self.type_spec(row[4]),
+            }
+            for row in self._db.execute(self.QUERIES["symbols_of"], (module,))
+        ]
+
+    def symbol(self, module: str, name: str) -> dict[str, Any] | None:
+        """One declared type, by module and descriptor.
+
+        Args:
+            module: the module's descriptor
+            name: the type's descriptor
+
+        Returns:
+            The symbol, or ``None``.
+        """
+        row = self._db.execute(self.QUERIES["symbol"], (module, name)).fetchone()
+
+        if row is None:
+            return None
+
+        return {
+            "name": row[0],
+            "class": row[1],
+            "status": row[2],
+            "displayhint": row[3],
+            "type": self.type_spec(row[4]),
+        }
+
+    def imports_of(self, module: str) -> dict[str, str]:
+        """A module's IMPORTS, as symbol to the module defining it.
+
+        Args:
+            module: the module's descriptor
+
+        Returns:
+            Symbol name to source module.
+        """
+        return dict(self._db.execute(self.QUERIES["imports_of"], (module,)))

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -47,11 +47,30 @@ pysmi be an optional dependency here rather than a deeper one.
 import json
 import os
 import sqlite3
+import urllib.request
 from typing import Any, Final, Union
 
 from pysnmp.smi import error
 
-__all__ = ["MibCorpus", "oid_from_key", "oid_key", "subtree_bound"]
+__all__ = [
+    "MibCorpus",
+    "MibCorpusCycleError",
+    "oid_from_key",
+    "oid_key",
+    "subtree_bound",
+]
+
+
+class MibCorpusCycleError(error.SmiError):
+    """A module was asked for again while being built from the corpus.
+
+    Raised rather than recursed on: synthesis resolves imported types through
+    ``importSymbols``, which comes back to ``loadModule``, so a corpus whose
+    IMPORTS form a cycle would otherwise recurse without limit. It is its own
+    class so that the type resolver can tell it apart from the ordinary "that
+    module does not define this symbol", which it is allowed to recover from.
+    """
+
 
 #: The corpus schema this reader understands.
 #:
@@ -268,7 +287,14 @@ class MibCorpus:
         # immutable=1 says the file cannot change, so SQLite takes no locks and
         # needs nothing writable near it -- which is what lets a corpus be
         # mounted read-only from a container image volume.
-        self._db = sqlite3.connect(f"file:{self._path}?immutable=1", uri=True)
+        #
+        # The path is percent-encoded first because this is a URI, not a path.
+        # A directory named "we?ird" otherwise ends the path at the "?" and
+        # SQLite opens an empty database of that shorter name -- which does not
+        # raise, it simply answers nothing, and the corpus reads as a file with
+        # application_id 0.
+        uri = f"file:{urllib.request.pathname2url(self._path)}?immutable=1"
+        self._db = sqlite3.connect(uri, uri=True)
 
         try:
             application = self._db.execute("PRAGMA application_id").fetchone()[0]

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -259,6 +259,7 @@ class MibCorpus:
     )
 
     def __init__(self, path: str):
+        """Open the corpus at *path*, refusing one this pysnmp cannot read."""
         if not os.path.exists(path):
             raise error.SmiError(f"no MIB corpus at {path}")
 

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -293,8 +293,19 @@ class MibCorpus:
         # SQLite opens an empty database of that shorter name -- which does not
         # raise, it simply answers nothing, and the corpus reads as a file with
         # application_id 0.
+        #
+        # os.path.exists above says something is there, not that SQLite can
+        # open it: a directory, or a file this process may not read, gets past
+        # it and fails here. Every other rejection below is an SmiError, and a
+        # caller that catches one to fall back to its MIB sources should not
+        # have a bare sqlite3 error come through this one path instead.
         uri = f"file:{urllib.request.pathname2url(self._path)}?immutable=1"
-        self._db = sqlite3.connect(uri, uri=True)
+
+        try:
+            self._db = sqlite3.connect(uri, uri=True)
+
+        except sqlite3.Error as exc:
+            raise error.SmiError(f"cannot open MIB corpus {path}: {exc}") from exc
 
         try:
             application = self._db.execute("PRAGMA application_id").fetchone()[0]

--- a/pysnmp/smi/synthesis.py
+++ b/pysnmp/smi/synthesis.py
@@ -39,6 +39,7 @@ Prose. A corpus carries no DESCRIPTION or REFERENCE, so a builder with
 from typing import Any
 
 from pysnmp.smi import error
+from pysnmp.smi.corpus import MibCorpusCycleError
 
 __all__ = ["load_module", "synthesize_type"]
 
@@ -230,6 +231,14 @@ class _Resolver:
 
         return resolved
 
+    def imported_from(self, name: str) -> str | None:
+        """Which module this one's IMPORTS says defines a symbol."""
+        return self._imports.get(name)
+
+    def try_symbol(self, module: str, name: str) -> Any | None:
+        """A symbol, or ``None`` when that module does not offer one."""
+        return self._try(module, name)
+
     def _try(self, module: str, name: str) -> Any | None:
         """Import a symbol, or ``None`` if that module has no such thing.
 
@@ -242,6 +251,12 @@ class _Resolver:
         """
         try:
             (symbol,) = self._builder.importSymbols(module, name)
+
+        except MibCorpusCycleError:
+            # A cycle is a structural defect in the corpus, not "that module
+            # does not have this symbol". Swallowing it here would report the
+            # type as undefined and hide what is actually wrong.
+            raise
 
         except error.SmiError:
             return None
@@ -304,6 +319,11 @@ def synthesize_type(resolver: "_Resolver", spec: dict[str, Any]) -> Any:
     Returns:
         An instance ready to be handed to a ``MibScalar`` or a column.
     """
+    if not spec.get("type"):
+        # _textual_convention already refuses this; a node's syntax deserves
+        # the same answer rather than a KeyError from three frames down.
+        raise error.SmiError(f"type specification carries no type: {spec!r}")
+
     base = resolver.type_class(spec["type"])
     instance = base()
 
@@ -421,6 +441,68 @@ def _build_node(resolver: "_Resolver", node: dict[str, Any]) -> Any:
     return obj
 
 
+def _wire_augmentations(
+    resolver: "_Resolver", modName: str, nodes: list, symbols: dict[str, Any]
+) -> None:
+    """Give every augmenting row the index names of the row it augments.
+
+    An augmenting row declares AUGMENTS and no INDEX: it is indexed by the row
+    it extends. A generated module emits two things for it, and both matter --
+    the base row is told it has an augmentation, and this row adopts the base
+    row's index names. Without the second, a ``MibTableRow`` cannot turn an
+    instance OID into index values or build one, so the table is unreadable and
+    unwritable while looking perfectly well-formed. It is not a rare shape:
+    1,181 rows in pysnmp/mibs' corpus use AUGMENTS and every one declares no
+    INDEX.
+
+    A separate pass because the base row is usually in *this* module --
+    ``ifXEntry`` augments ``ifEntry``, both in ``IF-MIB`` -- so it has to be
+    resolved from what this build has made rather than through
+    ``importSymbols``, which would re-enter the load of a module already being
+    built.
+
+    Args:
+        resolver: the module's resolver, for a base row in another module
+        modName: the module being built
+        nodes: its corpus rows
+        symbols: what has been built so far, keyed by descriptor
+    """
+    for node in nodes:
+        augments = node.get("augments")
+
+        if node["nodetype"] != "row" or not augments or node.get("indices"):
+            continue
+
+        base = symbols.get(augments["object"])
+
+        if base is None:
+            # Not this module's own row. The reference names the defining
+            # module, but a corpus built from MIBs nobody controls carries
+            # references that name the wrong one, so a miss here is resolved
+            # the ordinary way rather than trusted.
+            base = resolver.try_symbol(augments["module"], augments["object"])
+
+        if base is None:
+            # The reference is supposed to name the defining module, and for
+            # AUGMENTS it frequently names the importing one instead --
+            # CISCO-TCP-MIB::ciscoTcpConnEntry records its base as
+            # CISCO-TCP-MIB::tcpConnEntry, though tcpConnEntry is TCP-MIB's.
+            # The IMPORTS clause knows where it actually came from.
+            source = resolver.imported_from(augments["object"])
+
+            if source:
+                base = resolver.try_symbol(source, augments["object"])
+
+        if base is None or not hasattr(base, "getIndexNames"):
+            # An augmentation that cannot be resolved costs this row its index
+            # names, which is what it had before; refusing the whole module
+            # over it would be a worse trade.
+            continue
+
+        base.registerAugmentions((modName, node["name"]))
+        symbols[node["name"]].setIndexNames(*base.getIndexNames())
+
+
 def load_module(builder: Any, corpus: Any, modName: str) -> bool:
     """Build a module's symbols from the corpus and export them.
 
@@ -491,8 +573,9 @@ def load_module(builder: Any, corpus: Any, modName: str) -> bool:
         declare(name)
 
     identity = None
+    nodes = corpus.nodes_of(modName)
 
-    for node in corpus.nodes_of(modName):
+    for node in nodes:
         symbols[node["name"]] = _build_node(resolver, node)
 
         if node["class"] == "moduleidentity":
@@ -502,5 +585,10 @@ def load_module(builder: Any, corpus: Any, modName: str) -> bool:
         symbols[builder.moduleID] = identity
 
     builder.exportSymbols(modName, **symbols)
+
+    # After the export, not before: resolving a base row in another module
+    # loads that module, and it may import a type back from this one. Wiring
+    # first would ask for symbols this build had not published yet.
+    _wire_augmentations(resolver, modName, nodes, symbols)
 
     return True

--- a/pysnmp/smi/synthesis.py
+++ b/pysnmp/smi/synthesis.py
@@ -470,7 +470,11 @@ def load_module(builder: Any, corpus: Any, modName: str) -> bool:
             spec = declared[name].get("type") or {}
             dependency = spec.get("type")
 
-            if dependency in declared and dependency != name:
+            if (
+                isinstance(dependency, str)
+                and dependency != name
+                and dependency in declared
+            ):
                 declare(dependency)
 
             cls = _textual_convention(resolver, declared[name])

--- a/pysnmp/smi/synthesis.py
+++ b/pysnmp/smi/synthesis.py
@@ -1,0 +1,475 @@
+#
+# This file is part of pysnmp software.
+#
+# Copyright (c) 2005-2019, Ilya Etingof deceased
+# License: https://www.pysnmp.com/pysnmp/license.html
+#
+"""Building MIB objects from corpus rows instead of executing generated Python.
+
+A pysnmp MIB module is Python that calls back into ``MibBuilder``: it imports
+the SMI classes, constructs a ``MibScalar`` or a ``MibTableColumn`` per object,
+and exports them. Loading one means running it.
+
+This module produces the same objects from :py:mod:`pysnmp.smi.corpus` rows.
+The classes, the constructor arguments and the resulting registrations are the
+same ones the generated module would have produced -- what changes is that the
+description of them arrived as data rather than as code.
+
+Three consequences, in the order they matter:
+
+**Nothing is executed.** A corpus row is read; no ``exec`` runs, so a corpus
+fetched from anywhere cannot be a way to run code in the process that reads it.
+
+**One module at a time, on demand.** The corpus is indexed by OID, so the
+module that answers for a trap is found and only that module is built.
+
+**Types keep their identity.** A syntax is stored once in the corpus and
+referenced by id, and the class synthesized for it is cached against that id --
+so two objects sharing a type share a class, and ``isinstance`` cannot see two
+classes for one type (pysnmp/pysnmp#145).
+
+What is not here
+----------------
+
+Prose. A corpus carries no DESCRIPTION or REFERENCE, so a builder with
+``loadTexts`` set is told rather than quietly handed a module with none: see
+:py:func:`load_module`.
+"""
+
+from typing import Any
+
+from pysnmp.smi import error
+
+__all__ = ["load_module", "synthesize_type"]
+
+#: SMI type names as a MIB may spell them, mapped to the pysnmp class that
+#: implements each.
+#:
+#: The jsondoc a corpus is built from records the type name *exactly as the
+#: MIB declares it* and never resolves it to an implementation -- that binding
+#: is the runtime's, and this table is it. The spellings come from pysmi's own
+#: ``typeClasses``, which is the other half of the same contract.
+TYPE_CLASSES: dict[str, tuple[str, str]] = {
+    "COUNTER32": ("SNMPv2-SMI", "Counter32"),
+    "COUNTER64": ("SNMPv2-SMI", "Counter64"),
+    "GAUGE32": ("SNMPv2-SMI", "Gauge32"),
+    "INTEGER": ("SNMPv2-SMI", "Integer32"),
+    "INTEGER32": ("SNMPv2-SMI", "Integer32"),
+    "IPADDRESS": ("SNMPv2-SMI", "IpAddress"),
+    "NETWORKADDRESS": ("SNMPv2-SMI", "IpAddress"),
+    "OBJECT IDENTIFIER": ("ASN1", "ObjectIdentifier"),
+    "OCTET STRING": ("ASN1", "OctetString"),
+    "OPAQUE": ("SNMPv2-SMI", "Opaque"),
+    "TIMETICKS": ("SNMPv2-SMI", "TimeTicks"),
+    "UNSIGNED32": ("SNMPv2-SMI", "Unsigned32"),
+    "BITS": ("SNMPv2-SMI", "Bits"),
+    "COUNTER": ("SNMPv2-SMI", "Counter32"),
+    "GAUGE": ("SNMPv2-SMI", "Gauge32"),
+}
+
+#: The node classes, by what the corpus records the symbol as.
+#:
+#: ``objecttype`` is absent because one row is not enough to place it: a
+#: ``nodetype`` of table, row or column decides, and :py:func:`_object_class`
+#: reads it.
+NODE_CLASSES: dict[str, str] = {
+    "moduleidentity": "ModuleIdentity",
+    "objectidentity": "ObjectIdentity",
+    "notificationtype": "NotificationType",
+    "objectgroup": "ObjectGroup",
+    "notificationgroup": "NotificationGroup",
+    "modulecompliance": "ModuleCompliance",
+    "agentcapabilities": "AgentCapabilities",
+}
+
+#: ``nodetype`` to the class an OBJECT-TYPE becomes.
+OBJECT_CLASSES: dict[str, str] = {
+    "scalar": "MibScalar",
+    "table": "MibTable",
+    "row": "MibTableRow",
+    "column": "MibTableColumn",
+}
+
+#: Where each node class is imported from.
+CLASS_SOURCES: dict[str, str] = {
+    "ModuleIdentity": "SNMPv2-SMI",
+    "ObjectIdentity": "SNMPv2-SMI",
+    "NotificationType": "SNMPv2-SMI",
+    "MibIdentifier": "SNMPv2-SMI",
+    "MibScalar": "SNMPv2-SMI",
+    "MibTable": "SNMPv2-SMI",
+    "MibTableRow": "SNMPv2-SMI",
+    "MibTableColumn": "SNMPv2-SMI",
+    "ObjectGroup": "SNMPv2-CONF",
+    "NotificationGroup": "SNMPv2-CONF",
+    "ModuleCompliance": "SNMPv2-CONF",
+    "AgentCapabilities": "SNMPv2-CONF",
+}
+
+
+class _Resolver:
+    """Turns corpus type specifications into pysnmp classes, for one module.
+
+    Held for the length of one :py:func:`load_module` because most of what it
+    does is answer the same few questions repeatedly -- what is
+    ``DisplayString``, what is ``MibTableColumn`` -- and each answer costs an
+    ``importSymbols`` that may load another module.
+    """
+
+    def __init__(self, builder: Any, corpus: Any, module: str):
+        self._builder = builder
+        self._corpus = corpus
+        self._module = module
+        self._imports = corpus.imports_of(module)
+        self._local: dict[str, Any] = {}
+        self._cache: dict[str, Any] = {}
+
+    def base(self, name: str) -> Any:
+        """One of the SMI classes a generated module imports at its top."""
+        if name not in self._cache:
+            source = CLASS_SOURCES.get(name)
+
+            if source is None:
+                raise error.SmiError(f"no source known for SMI class {name}")
+
+            (self._cache[name],) = self._builder.importSymbols(source, name)
+
+        return self._cache[name]
+
+    def refinement(self, name: str) -> Any:
+        """One of the constraint classes, from ``ASN1-REFINEMENT``."""
+        if name not in self._cache:
+            (self._cache[name],) = self._builder.importSymbols("ASN1-REFINEMENT", name)
+
+        return self._cache[name]
+
+    @property
+    def builder(self) -> Any:
+        """The builder this resolver imports through."""
+        return self._builder
+
+    def declare(self, name: str, cls: Any) -> None:
+        """Record a type this module declares, so its own objects can use it."""
+        self._local[name] = cls
+
+    def declared(self, name: str) -> Any | None:
+        """A type this module has already declared, or ``None``."""
+        return self._local.get(name)
+
+    def type_class(self, name: str) -> Any:
+        """The class implementing an SMI type name.
+
+        Resolution order, and each step is there for a reason:
+
+        1. A type this module declares itself. A module's own
+           TEXTUAL-CONVENTION shadows anything of the same name elsewhere.
+        2. A base SMI type, through :py:data:`TYPE_CLASSES`.
+        3. Whatever the module's IMPORTS says defines it -- which may load
+           that module, from disk or from the corpus, and is how a vendor
+           module's ``DisplayString`` resolves to the one the precompiled
+           ``SNMPv2-TC`` already exported.
+
+        Args:
+            name: the type name as the MIB declares it
+
+        Returns:
+            The class.
+
+        Raises:
+            SmiError: nothing defines the name. Loudly, rather than
+                substituting a base type: a column silently typed
+                ``OctetString`` instead of its TEXTUAL-CONVENTION renders
+                every value wrong and looks like a device fault.
+        """
+        if name in self._local:
+            return self._local[name]
+
+        if name in self._cache:
+            return self._cache[name]
+
+        spelling = TYPE_CLASSES.get(name.upper()) or TYPE_CLASSES.get(name)
+
+        if spelling:
+            module, symbol = spelling
+            (resolved,) = self._builder.importSymbols(module, symbol)
+
+        elif name in self._imports:
+            (resolved,) = self._builder.importSymbols(self._imports[name], name)
+
+        else:
+            # Not imported and not declared here. Some MIBs use a standard
+            # type without importing it, which is a defect in the MIB that
+            # every compiler has had to tolerate; try the two modules that
+            # define almost all of them before giving up.
+            resolved = None
+
+            for module in ("SNMPv2-SMI", "SNMPv2-TC"):
+                try:
+                    (resolved,) = self._builder.importSymbols(module, name)
+                    break
+
+                except error.SmiError:
+                    continue
+
+            if resolved is None:
+                raise error.SmiError(
+                    f"{self._module}: no definition for type {name!r}, which it "
+                    f"neither declares nor imports"
+                )
+
+        self._cache[name] = resolved
+
+        return resolved
+
+    def constraints(self, spec: dict[str, Any]) -> Any | None:
+        """The subtype constraint a specification asks for, or ``None``.
+
+        Args:
+            spec: a corpus type specification
+
+        Returns:
+            A single constraint, or a union of several.
+        """
+        declared = spec.get("constraints") or {}
+        parts = []
+
+        if "range" in declared:
+            rangeConstraint = self.refinement("ValueRangeConstraint")
+            parts += [rangeConstraint(x["min"], x["max"]) for x in declared["range"]]
+
+        if "size" in declared:
+            sizeConstraint = self.refinement("ValueSizeConstraint")
+            parts += [sizeConstraint(x["min"], x["max"]) for x in declared["size"]]
+
+        if "enumeration" in declared:
+            singleValue = self.refinement("SingleValueConstraint")
+            parts.append(singleValue(*sorted(declared["enumeration"].values())))
+
+        if not parts:
+            return None
+
+        if len(parts) == 1:
+            return parts[0]
+
+        return self.refinement("ConstraintsUnion")(*parts)
+
+    def enumeration(self, spec: dict[str, Any]) -> Any | None:
+        """The ``NamedValues`` a specification asks for, or ``None``."""
+        declared = (spec.get("constraints") or {}).get("enumeration")
+        bits = spec.get("bits")
+        labels = declared or bits
+
+        if not labels:
+            return None
+
+        (namedValues,) = self._builder.importSymbols("ASN1-ENUMERATION", "NamedValues")
+
+        return namedValues(*sorted(labels.items(), key=lambda x: x[1]))
+
+
+def synthesize_type(resolver: "_Resolver", spec: dict[str, Any]) -> Any:
+    """An instance of the type a specification describes, constrained.
+
+    Args:
+        resolver: the module's resolver
+        spec: a corpus type specification
+
+    Returns:
+        An instance ready to be handed to a ``MibScalar`` or a column.
+    """
+    base = resolver.type_class(spec["type"])
+    instance = base()
+
+    values = resolver.enumeration(spec)
+
+    if values is not None:
+        instance = instance.clone(namedValues=values)
+
+    constraint = resolver.constraints(spec)
+
+    if constraint is not None:
+        instance = instance.subtype(subtypeSpec=constraint)
+
+    return instance
+
+
+def _textual_convention(resolver: "_Resolver", symbol: dict[str, Any]) -> Any:
+    """The class a TEXTUAL-CONVENTION or type assignment becomes.
+
+    Built with :py:func:`type` rather than executed, but otherwise the class a
+    generated module declares: the base type and ``TextualConvention`` as
+    bases, and the status, display hint and constraints as class attributes.
+    """
+    spec = symbol.get("type") or {}
+
+    if not spec.get("type"):
+        raise error.SmiError(f"{symbol['name']}: type declaration carries no type")
+
+    base = resolver.type_class(spec["type"])
+    attributes: dict[str, Any] = {}
+
+    if symbol.get("status"):
+        attributes["status"] = symbol["status"]
+
+    if symbol.get("displayhint"):
+        attributes["displayHint"] = symbol["displayhint"]
+
+    constraint = resolver.constraints(spec)
+
+    if constraint is not None:
+        attributes["subtypeSpec"] = base.subtypeSpec + constraint
+
+    values = resolver.enumeration(spec)
+
+    if values is not None:
+        attributes["namedValues"] = values
+
+    if symbol["class"] == "textualconvention":
+        (convention,) = resolver.builder.importSymbols("SNMPv2-TC", "TextualConvention")
+        bases: tuple[Any, ...] = (base, convention)
+
+    else:
+        bases = (base,)
+
+    return type(symbol["name"], bases, attributes)
+
+
+def _object_class(resolver: "_Resolver", node: dict[str, Any]) -> Any:
+    """The class a node row becomes."""
+    if node["class"] == "objecttype":
+        name = OBJECT_CLASSES.get(node["nodetype"] or "")
+
+        if name is None:
+            raise error.SmiError(
+                f"{node['module']}::{node['name']}: OBJECT-TYPE with "
+                f"unknown nodetype {node['nodetype']!r}"
+            )
+
+        return resolver.base(name)
+
+    name = NODE_CLASSES.get(node["class"])
+
+    if name is None:
+        # A class the corpus carries and this runtime has no object for. Fall
+        # back to a bare registration rather than dropping the arc: the OID is
+        # still real and a walk should still see it.
+        return resolver.base("MibIdentifier")
+
+    return resolver.base(name)
+
+
+def _build_node(resolver: "_Resolver", node: dict[str, Any]) -> Any:
+    """One MIB object, from one corpus row."""
+    cls = _object_class(resolver, node)
+    arcs = node["arcs"]
+
+    if node["class"] == "objecttype" and node["nodetype"] in ("scalar", "column"):
+        if not node["syntax"]:
+            raise error.SmiError(
+                f"{node['module']}::{node['name']}: {node['nodetype']} with no syntax"
+            )
+
+        obj = cls(arcs, synthesize_type(resolver, node["syntax"]))
+
+    else:
+        obj = cls(arcs)
+
+    if node.get("maxaccess") and hasattr(obj, "setMaxAccess"):
+        # The runtime compares against the hyphenless spelling, which is what
+        # the generated modules carry; the corpus keeps the MIB's own.
+        obj = obj.setMaxAccess(node["maxaccess"].replace("-", ""))
+
+    if node.get("units") and hasattr(obj, "setUnits"):
+        obj = obj.setUnits(node["units"])
+
+    if node["nodetype"] == "row":
+        if node.get("indices"):
+            obj = obj.setIndexNames(
+                *[
+                    (int(x.get("implied", 0)), x["module"], x["object"])
+                    for x in node["indices"]
+                ]
+            )
+
+    return obj
+
+
+def load_module(builder: Any, corpus: Any, modName: str) -> bool:
+    """Build a module's symbols from the corpus and export them.
+
+    Args:
+        builder: the ``MibBuilder`` to export into
+        corpus: an open :py:class:`~pysnmp.smi.corpus.MibCorpus`
+        modName: the module to build
+
+    Returns:
+        Whether the corpus carried the module. ``False`` leaves the builder
+        untouched, so a caller can go on looking elsewhere.
+
+    Raises:
+        SmiError: the corpus carries the module but it could not be built --
+            an unresolvable type, an OBJECT-TYPE the runtime has no class for.
+            Loudly on purpose: a half-built module resolves some OIDs and not
+            others, which is worse to diagnose than a module that would not
+            load at all.
+    """
+    if modName not in corpus.modules():
+        return False
+
+    resolver = _Resolver(builder, corpus, modName)
+    symbols: dict[str, Any] = {}
+
+    # Types first: a module's own objects refer to them, and its TCs may refer
+    # to each other. Corpus order is by name, which is not declaration order,
+    # so a TC built on another declared later is resolved on demand rather
+    # than assumed to be present.
+    declared = {x["name"]: x for x in corpus.symbols_of(modName)}
+    building: set[str] = set()
+
+    def declare(name: str) -> Any:
+        existing = resolver.declared(name)
+
+        if existing is not None:
+            return existing
+
+        if name in building:
+            raise error.SmiError(
+                f"{modName}: type {name!r} is defined in terms of itself"
+            )
+
+        building.add(name)
+
+        try:
+            spec = declared[name].get("type") or {}
+            dependency = spec.get("type")
+
+            if dependency in declared and dependency != name:
+                declare(dependency)
+
+            cls = _textual_convention(resolver, declared[name])
+
+        finally:
+            building.discard(name)
+
+        resolver.declare(name, cls)
+        symbols[name] = cls
+
+        return cls
+
+    for name in declared:
+        declare(name)
+
+    identity = None
+
+    for node in corpus.nodes_of(modName):
+        symbols[node["name"]] = _build_node(resolver, node)
+
+        if node["class"] == "moduleidentity":
+            identity = symbols[node["name"]]
+
+    if identity is not None:
+        symbols[builder.moduleID] = identity
+
+    builder.exportSymbols(modName, **symbols)
+
+    return True

--- a/pysnmp/smi/synthesis.py
+++ b/pysnmp/smi/synthesis.py
@@ -118,6 +118,7 @@ class _Resolver:
     """
 
     def __init__(self, builder: Any, corpus: Any, module: str):
+        """Resolve types for ``module``, against ``corpus`` and ``builder``."""
         self._builder = builder
         self._corpus = corpus
         self._module = module
@@ -536,6 +537,14 @@ def load_module(builder: Any, corpus: Any, modName: str) -> bool:
     building: set[str] = set()
 
     def declare(name: str) -> Any:
+        """Build this module's type ``name``, and whatever it is defined on.
+
+        Corpus symbols come back ordered by name rather than by declaration, so
+        a TEXTUAL-CONVENTION whose base is declared later in that order is
+        built on demand here instead of being assumed present. ``building``
+        makes a type defined in terms of itself an error rather than a
+        recursion.
+        """
         existing = resolver.declared(name)
 
         if existing is not None:

--- a/pysnmp/smi/synthesis.py
+++ b/pysnmp/smi/synthesis.py
@@ -193,33 +193,60 @@ class _Resolver:
             module, symbol = spelling
             (resolved,) = self._builder.importSymbols(module, symbol)
 
-        elif name in self._imports:
-            (resolved,) = self._builder.importSymbols(self._imports[name], name)
-
         else:
-            # Not imported and not declared here. Some MIBs use a standard
-            # type without importing it, which is a defect in the MIB that
-            # every compiler has had to tolerate; try the two modules that
-            # define almost all of them before giving up.
             resolved = None
 
-            for module in ("SNMPv2-SMI", "SNMPv2-TC"):
-                try:
-                    (resolved,) = self._builder.importSymbols(module, name)
-                    break
+            if name in self._imports:
+                # Where IMPORTS says it comes from, which is right almost
+                # always and wrong in one recurring way: a vendor module
+                # written against an older revision of a standard module
+                # imports a type that revision defined and the current one
+                # does not. BRIDGE-MIB is the case that keeps coming up --
+                # RFC 1493 defined MacAddress, RFC 4188 imports it from
+                # SNMPv2-TC instead -- and the corpus carries the newer
+                # revision because that is what the ranking rule picks.
+                resolved = self._try(self._imports[name], name)
 
-                except error.SmiError:
-                    continue
+            if resolved is None:
+                # Not where the MIB said, or not imported at all. Some MIBs
+                # simply use a standard type without importing it. Either way
+                # the two modules that define almost all of them are worth
+                # trying before giving up on the whole module: an unresolved
+                # import is a degrade, and refusing to load anything is worse
+                # than resolving a type from where it actually lives.
+                for module in ("SNMPv2-TC", "SNMPv2-SMI"):
+                    resolved = self._try(module, name)
+
+                    if resolved is not None:
+                        break
 
             if resolved is None:
                 raise error.SmiError(
                     f"{self._module}: no definition for type {name!r}, which it "
-                    f"neither declares nor imports"
+                    f"neither declares nor imports from anything that has it"
                 )
 
         self._cache[name] = resolved
 
         return resolved
+
+    def _try(self, module: str, name: str) -> Any | None:
+        """Import a symbol, or ``None`` if that module has no such thing.
+
+        Args:
+            module: where to look
+            name: the symbol
+
+        Returns:
+            The symbol, or ``None``.
+        """
+        try:
+            (symbol,) = self._builder.importSymbols(module, name)
+
+        except error.SmiError:
+            return None
+
+        return symbol
 
     def constraints(self, spec: dict[str, Any]) -> Any | None:
         """The subtype constraint a specification asks for, or ``None``.

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -134,6 +134,18 @@ class TestCorpusOpen:
         with pytest.raises(error.SmiError, match="no MIB corpus"):
             MibCorpus(str(tmp_path / "absent.db"))
 
+    def test_a_path_sqlite_cannot_open(self, tmp_path):
+        # os.path.exists passes for a directory, and sqlite3.connect raises
+        # OperationalError rather than returning something the checks below it
+        # can reject. Everything else this class covers is an SmiError, and a
+        # caller catching one to fall back to its MIB sources would not catch
+        # a bare sqlite3 error.
+        directory = tmp_path / "corpus.db"
+        directory.mkdir()
+
+        with pytest.raises(error.SmiError, match="cannot open MIB corpus"):
+            MibCorpus(str(directory))
+
     def test_not_a_corpus(self, tmp_path):
         import sqlite3
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -24,6 +24,16 @@ import os
 
 import pytest
 
+# Imported rather than skipped over. This was a ``pytest.importorskip``, and
+# because the dev group's pysmi floor still named a release predating
+# ``pysmi.corpus``, the skip fired for the whole module -- every test in this
+# file, not just the vectors -- and CI reported success without running any of
+# it. A skip that can hide the entire suite it guards is worse than a
+# collection error, and there is nothing for it to protect: pytest itself comes
+# from the same dev group as pysmi, so anything able to collect this file has
+# the group installed and therefore has a pysmi that publishes the fixture.
+from pysmi.corpus import conformance as pysmi_conformance
+
 from pysnmp.smi import error
 from pysnmp.smi.builder import MibBuilder
 from pysnmp.smi.corpus import (
@@ -33,11 +43,6 @@ from pysnmp.smi.corpus import (
     oid_from_key,
     oid_key,
     subtree_bound,
-)
-
-pysmi_conformance = pytest.importorskip(
-    "pysmi.corpus.conformance",
-    reason="the conformance fixture is published by pysmi, a dev dependency",
 )
 
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,0 +1,496 @@
+"""Reading a MIB corpus, and building MIB objects out of it.
+
+Two things are being pinned here and they pull in opposite directions.
+
+**Nothing changes for anyone who does not ask for it.** A ``MibBuilder`` with
+no corpus configured resolves exactly as it did: same sources, same search
+order, same objects, same errors. splunk-connect-for-snmp and every other
+existing deployment upgrade into this without touching anything, so a test that
+a corpus-free builder is untouched is as load-bearing as any test of the corpus
+itself.
+
+**What the corpus resolves is the same thing the generated module would have.**
+A synthesized ``ifDescr`` is a ``MibTableColumn`` with a ``DisplayString``
+syntax and ``readonly`` access, because that is what loading ``IF-MIB.py``
+produces. Anything less is a second, subtly different runtime.
+
+The fixture is pysmi's conformance corpus (``pysnmp/pysmi#184``), built here
+rather than committed, so the reader is checked against the writer that
+produces real corpora rather than against a hand-written database that agrees
+with the reader by construction.
+"""
+
+import os
+
+import pytest
+
+from pysnmp.smi import error
+from pysnmp.smi.builder import MibBuilder
+from pysnmp.smi.corpus import (
+    APPLICATION_ID,
+    SCHEMA_VERSION,
+    MibCorpus,
+    oid_from_key,
+    oid_key,
+    subtree_bound,
+)
+
+pysmi_conformance = pytest.importorskip(
+    "pysmi.corpus.conformance",
+    reason="the conformance fixture is published by pysmi, a dev dependency",
+)
+
+
+@pytest.fixture(scope="module")
+def corpus_path(tmp_path_factory):
+    """pysmi's conformance corpus, built fresh."""
+    directory = tmp_path_factory.mktemp("corpus")
+
+    return pysmi_conformance.build_fixture(str(directory / "conformance.db"))
+
+
+@pytest.fixture
+def corpus(corpus_path):
+    """An open corpus, closed afterwards."""
+    opened = MibCorpus(corpus_path)
+
+    yield opened
+
+    opened.close()
+
+
+class TestOidKey:
+    """The encoding the whole file format's ordering rests on.
+
+    pysmi writes these keys and pysnmp reads them, and neither imports the
+    other, so the two implementations agreeing is a thing to test rather than
+    a thing to assume.
+    """
+
+    @pytest.mark.parametrize(
+        "oid", ["1", "1.3.6", "1.3.6.1.4.1.9", "2.0", "1.3.6.1.4.1.4294967295"]
+    )
+    def test_round_trips(self, oid):
+        assert oid_from_key(oid_key(oid)) == oid
+
+    def test_accepts_arcs_as_well_as_text(self):
+        assert oid_key((1, 3, 6)) == oid_key("1.3.6")
+
+    def test_byte_order_is_numeric_order(self):
+        # 1.3.10 below 1.3.9 is what string comparison gets wrong; 1.3.256 is
+        # what one byte per arc gets wrong.
+        oids = ["1.3.6", "1.3.6.1", "1.3.7", "1.3.9", "1.3.10", "1.3.256", "2.0"]
+
+        assert sorted(oids, key=oid_key) == sorted(
+            oids, key=lambda x: tuple(int(a) for a in x.split("."))
+        )
+
+    def test_prefix_encodes_to_byte_prefix(self):
+        assert oid_key("1.3.6.1").startswith(oid_key("1.3.6"))
+
+    def test_parent_sorts_before_children(self):
+        assert oid_key("1.3.6") < oid_key("1.3.6.0")
+
+    def test_subtree_bound_brackets_the_subtree(self):
+        low = oid_key("1.3.6")
+        high = subtree_bound(low)
+
+        assert low <= oid_key("1.3.6.1.4.1.99") < high
+        assert not low <= oid_key("1.3.7") < high
+
+    def test_subtree_bound_carries_past_a_full_byte(self):
+        key = oid_key("1.255")
+
+        assert subtree_bound(key) > oid_key("1.255.1")
+
+    @pytest.mark.parametrize("bad", ["", "1.3.six", "not an oid"])
+    def test_rejects_what_is_not_an_oid(self, bad):
+        with pytest.raises(error.SmiError):
+            oid_key(bad)
+
+    def test_rejects_arc_out_of_range(self):
+        with pytest.raises(error.SmiError):
+            oid_key("1.4294967296")
+
+    def test_agrees_with_pysmi(self):
+        # The two implementations are separate on purpose -- importing pysmi
+        # to read a file whose point is that it needs no pysmi would defeat
+        # the layering -- so they have to be checked against each other.
+        from pysmi.corpus.db import oid_key as writer_key
+
+        for oid in ("1.3.6.1.2.1.2.2.1.2", "1.3.256.9.10", "2.0", "1"):
+            assert oid_key(oid) == writer_key(oid)
+
+
+class TestCorpusOpen:
+    """What a corpus refuses to be opened as."""
+
+    def test_missing_file(self, tmp_path):
+        with pytest.raises(error.SmiError, match="no MIB corpus"):
+            MibCorpus(str(tmp_path / "absent.db"))
+
+    def test_not_a_corpus(self, tmp_path):
+        import sqlite3
+
+        path = tmp_path / "other.db"
+        connection = sqlite3.connect(str(path))
+        connection.execute("CREATE TABLE t (x)")
+        connection.commit()
+        connection.close()
+
+        with pytest.raises(error.SmiError, match="not a MIB corpus"):
+            MibCorpus(str(path))
+
+    def test_unreadable_schema_version(self, corpus_path, tmp_path):
+        import shutil
+        import sqlite3
+
+        path = tmp_path / "future.db"
+        shutil.copy(corpus_path, path)
+        connection = sqlite3.connect(str(path))
+        connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 1}")
+        connection.close()
+
+        # Refused rather than read as far as we understand it: a partial read
+        # resolves some OIDs and silently not others.
+        with pytest.raises(error.SmiError, match="schema version"):
+            MibCorpus(str(path))
+
+    def test_opens_without_a_writable_directory(self, corpus_path, tmp_path):
+        # A corpus is mounted read-only from an image volume, so nothing near
+        # it is writable and SQLite must not want to be.
+        import shutil
+
+        directory = tmp_path / "ro"
+        directory.mkdir()
+        path = directory / "core.db"
+        shutil.copy(corpus_path, path)
+        os.chmod(directory, 0o500)
+
+        try:
+            opened = MibCorpus(str(path))
+            assert opened.modules()
+            opened.close()
+
+        finally:
+            os.chmod(directory, 0o700)
+
+    def test_carries_the_application_id(self, corpus_path):
+        import sqlite3
+
+        connection = sqlite3.connect(corpus_path)
+
+        try:
+            assert (
+                connection.execute("PRAGMA application_id").fetchone()[0]
+                == APPLICATION_ID
+            )
+
+        finally:
+            connection.close()
+
+
+class TestConformance:
+    """pysmi's vectors, run against this reader.
+
+    The vectors are the contract; this is the half of it that lives here. A
+    failure means pysnmp reads a corpus differently from how pysmi says it
+    should be read, which is exactly the defect neither repository's own tests
+    can see.
+    """
+
+    def _answer(self, corpus, vector):
+        operation = vector["op"]
+
+        if operation == "meta":
+            return corpus.meta(vector["key"])
+
+        if operation == "find_module":
+            return corpus.find_module(vector["oid"])
+
+        if operation in ("node", "syntax", "defval", "indices"):
+            node = corpus.node(vector["oid"], vector["module"])
+
+            if node is None:
+                return None
+
+            if operation == "syntax":
+                return node["syntax"]
+
+            if operation == "defval":
+                return node["defval"]
+
+            if operation == "indices":
+                return node["indices"]
+
+            return {
+                key: node[key]
+                for key in (
+                    "name",
+                    "class",
+                    "nodetype",
+                    "maxaccess",
+                    "status",
+                    "units",
+                    "syntax",
+                )
+            }
+
+        if operation == "node_by_name":
+            node = corpus.node_named(vector["module"], vector["name"])
+
+            return node["oid"] if node else None
+
+        if operation == "next_node":
+            node = corpus.next_node(vector["oid"])
+
+            return node["oid"] if node else None
+
+        if operation == "walk":
+            out = []
+            at = vector["start"]
+
+            for _ in range(vector["count"]):
+                node = corpus.next_node(at)
+
+                if node is None:
+                    break
+
+                out.append(node["oid"])
+                at = node["oid"]
+
+            return out
+
+        if operation == "subtree":
+            seen = []
+
+            for node in corpus.subtree(vector["oid"]):
+                if node["oid"] not in seen:
+                    seen.append(node["oid"])
+
+            return seen
+
+        if operation == "symbol":
+            symbol = corpus.symbol(vector["module"], vector["name"])
+
+            return (
+                None
+                if symbol is None
+                else {
+                    key: symbol[key]
+                    for key in ("class", "status", "displayhint", "type")
+                }
+            )
+
+        if operation == "same_syntax":
+            left = corpus.node(vector["left"][1], vector["left"][0])
+            right = corpus.node(vector["right"][1], vector["right"][0])
+
+            return left["syntax"] is right["syntax"]
+
+        if operation == "import_source":
+            return corpus.imports_of(vector["module"]).get(vector["name"])
+
+        if operation == "module_field":
+            record = corpus.module(vector["module"])
+            field = "hash" if vector["field"] == "content_hash" else vector["field"]
+
+            return record[field] if record else None
+
+        raise AssertionError(f"unknown conformance operation {operation!r}")
+
+    @pytest.mark.parametrize("vector", pysmi_conformance.VECTORS, ids=lambda x: x["id"])
+    def test_vector(self, corpus, vector):
+        assert self._answer(corpus, vector) == vector["expect"], vector["why"]
+
+
+class TestBuilderUnchangedWithoutACorpus:
+    """The compatibility promise, stated as tests.
+
+    Every existing deployment is this configuration. If any of these change,
+    an upgrade breaks someone who never asked for a corpus.
+    """
+
+    def test_no_corpus_by_default(self):
+        assert MibBuilder().getMibCorpus() is None
+
+    def test_modules_still_load_from_sources(self):
+        builder = MibBuilder()
+
+        (level,) = builder.importSymbols("SNMP-FRAMEWORK-MIB", "SnmpSecurityLevel")
+
+        assert dict(level.namedValues) == {
+            "noAuthNoPriv": 1,
+            "authNoPriv": 2,
+            "authPriv": 3,
+        }
+
+    def test_missing_module_still_raises_mib_not_found(self):
+        builder = MibBuilder()
+
+        # loadModule, not loadModules: with no compiler configured the plural
+        # form swallows MibNotFoundError, and has since long before any of
+        # this. Pinned here because the corpus fallback lives in the singular
+        # form, so a change there must not start or stop that happening.
+        with pytest.raises(error.MibNotFoundError):
+            builder.loadModule("NO-SUCH-MIB")
+
+    def test_loadmodules_still_swallows_a_missing_module(self):
+        builder = MibBuilder()
+
+        builder.loadModules("NO-SUCH-MIB")
+
+        assert "NO-SUCH-MIB" not in builder.mibSymbols
+
+    def test_a_corpus_does_not_displace_a_module_on_disk(self, corpus):
+        # The corpus is where a module is found when nothing else has it. A
+        # module the sources carry keeps resolving from the sources, which is
+        # what makes configuring a corpus safe on a running deployment.
+        plain = MibBuilder()
+        (fromDisk,) = plain.importSymbols("SNMP-FRAMEWORK-MIB", "SnmpSecurityLevel")
+
+        withCorpus = MibBuilder()
+        withCorpus.setMibCorpus(corpus)
+        (fromBoth,) = withCorpus.importSymbols(
+            "SNMP-FRAMEWORK-MIB", "SnmpSecurityLevel"
+        )
+
+        assert dict(fromBoth.namedValues) == dict(fromDisk.namedValues)
+        assert "corpus:" not in withCorpus._MibBuilder__modSeen["SNMP-FRAMEWORK-MIB"]
+
+
+class TestBuilderWithACorpus:
+    """What opting in adds."""
+
+    @pytest.fixture
+    def builder(self, corpus):
+        built = MibBuilder()
+        built.setMibCorpus(corpus)
+
+        return built
+
+    def test_corpus_is_reported(self, builder, corpus):
+        assert builder.getMibCorpus() is corpus
+
+    def test_module_absent_from_sources_resolves_from_the_corpus(self, builder):
+        (scalar,) = builder.importSymbols("FIXTURE-MIB", "fixtureScalar")
+
+        assert scalar.getName() == (1, 3, 6, 1, 4, 1, 99999, 1)
+        assert scalar.maxAccess == "readonly"
+        assert scalar.getUnits() == "seconds"
+
+    def test_table_row_and_column_get_their_classes(self, builder):
+        table, row, column = builder.importSymbols(
+            "FIXTURE-MIB", "fixtureTable", "fixtureEntry", "fixtureDescr"
+        )
+
+        assert type(table).__name__ == "MibTable"
+        assert type(row).__name__ == "MibTableRow"
+        assert type(column).__name__ == "MibTableColumn"
+
+    def test_row_keeps_its_index_names(self, builder):
+        (row,) = builder.importSymbols("FIXTURE-MIB", "fixtureEntry")
+
+        assert row.getIndexNames() == ((0, "FIXTURE-MIB", "fixtureIndex"),)
+
+    def test_textual_convention_becomes_a_class(self, builder):
+        (convention,) = builder.importSymbols("FIXTURE-MIB", "FixtureString")
+
+        assert convention.displayHint == "255a"
+        assert convention.status == "current"
+
+    def test_column_syntax_resolves_to_the_module_s_own_convention(self, builder):
+        convention, column = builder.importSymbols(
+            "FIXTURE-MIB", "FixtureString", "fixtureDescr"
+        )
+
+        # Not merely an OctetString: a column silently typed as its base
+        # renders every value wrong and looks like a device fault.
+        assert isinstance(column.syntax, convention)
+
+    def test_enumeration_survives(self, builder):
+        (column,) = builder.importSymbols("FIXTURE-MIB", "fixtureBig")
+
+        assert dict(column.syntax.namedValues) == {"up": 1, "down": 2}
+
+    def test_range_constraint_survives(self, builder):
+        (column,) = builder.importSymbols("FIXTURE-MIB", "fixtureIndex")
+
+        column.syntax.clone(5)
+
+        with pytest.raises(Exception):
+            column.syntax.clone(0)
+
+    def test_module_identity_is_exported_under_the_module_id(self, builder):
+        builder.loadModules("FIXTURE-MIB")
+
+        assert builder.mibSymbols["FIXTURE-MIB"][builder.moduleID] is not None
+
+    def test_module_the_corpus_lacks_still_raises(self, builder):
+        with pytest.raises(error.MibNotFoundError):
+            builder.loadModule("NO-SUCH-MIB")
+
+    def test_loading_twice_is_a_no_op(self, builder):
+        builder.loadModules("FIXTURE-MIB")
+        builder.loadModules("FIXTURE-MIB")
+
+        assert "FIXTURE-MIB" in builder.mibSymbols
+
+    def test_synthesized_module_can_be_unloaded(self, builder):
+        builder.loadModules("FIXTURE-MIB")
+        builder.unloadModules("FIXTURE-MIB")
+
+        assert "FIXTURE-MIB" not in builder.mibSymbols
+
+    def test_load_texts_with_a_textless_corpus_is_refused(self, corpus):
+        # A caller that asked for descriptions and got a module with none has
+        # no way to tell that from a MIB that declares none.
+        builder = MibBuilder()
+        builder.loadTexts = True
+
+        with pytest.raises(error.SmiError, match="no texts"):
+            builder.setMibCorpus(corpus)
+
+    def test_corpus_can_be_removed(self, builder):
+        builder.setMibCorpus(None)
+
+        assert builder.getMibCorpus() is None
+
+        with pytest.raises(error.MibNotFoundError):
+            builder.loadModule("FIXTURE-MIB")
+
+
+class TestTrapPath:
+    """The access pattern sc4snmp runs on every trap, without a compiler."""
+
+    def test_instance_oid_resolves_to_its_module(self, corpus):
+        # A trap carries an instance OID: a column OID plus index arcs, which
+        # appears in no MIB at all.
+        assert corpus.find_module("1.3.6.1.4.1.99999.2.1.9.1.2.3") == "FIXTURE-MIB"
+
+    def test_unknown_oid_is_a_miss_not_an_error(self, corpus):
+        assert corpus.find_module("1.3.6.1.4.1.1") is None
+
+    def test_shadowed_oid_resolves_by_rank_not_by_row_order(self, corpus):
+        # Two modules define this OID. The ranked index decides, which is the
+        # 1.3.6.1.6.3.1 collision in miniature.
+        assert corpus.find_module("1.3.6.1.4.1.99999.1") == "FIXTURE-MIB"
+
+    def test_walk_visits_a_shadowed_oid_once(self, corpus):
+        # Once per module and a GETNEXT loop never terminates.
+        first = corpus.next_node("1.3.6.1.4.1.99999")
+        second = corpus.next_node(first["oid"])
+
+        assert first["oid"] == "1.3.6.1.4.1.99999.1"
+        assert second["oid"] == "1.3.6.1.4.1.99999.2"
+
+    def test_walk_off_the_end_is_not_an_error(self, corpus):
+        assert corpus.next_node("1.3.6.1.4.1.99999.99") is None
+
+    def test_type_identity_is_shared(self, corpus):
+        # The same specification object, not merely an equal one: a reader
+        # caching a synthesized class against it must not make two.
+        left = corpus.node("1.3.6.1.4.1.99999.1", "FIXTURE-MIB")
+        right = corpus.node("1.3.6.1.4.1.99999.2.1.10", "FIXTURE-MIB")
+
+        assert left["syntax"] is right["syntax"]

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -451,6 +451,58 @@ class TestBuilderWithACorpus:
         with pytest.raises(error.SmiError, match="no texts"):
             builder.setMibCorpus(corpus)
 
+    def test_type_resolves_when_imports_names_a_module_without_it(
+        self, builder, corpus, monkeypatch
+    ):
+        # A vendor module written against an older revision of a standard
+        # module imports a type that revision defined and the current one does
+        # not -- BRIDGE-MIB is the recurring case, since RFC 1493 defined
+        # MacAddress and RFC 4188 imports it from SNMPv2-TC instead. The
+        # corpus carries the newer revision because that is what the ranking
+        # rule picks, so following IMPORTS literally fails. Refusing to build
+        # the whole module over one type is worse than resolving it from where
+        # it actually lives.
+        monkeypatch.setattr(
+            corpus,
+            "imports_of",
+            lambda module: (
+                {"OCTET STRING": "NO-SUCH-MIB"}
+                if module == "FIXTURE-MIB"
+                else corpus.__class__.imports_of(corpus, module)
+            ),
+        )
+
+        (column,) = builder.importSymbols("FIXTURE-MIB", "fixtureDescr")
+
+        assert column.getName() == (1, 3, 6, 1, 4, 1, 99999, 2, 1, 9)
+
+    def test_type_that_resolves_nowhere_still_raises(
+        self, builder, corpus, monkeypatch
+    ):
+        # The fallback must not become a silent substitution: a column typed
+        # as its base instead of its TEXTUAL-CONVENTION renders every value
+        # wrong and looks like a device fault.
+        monkeypatch.setattr(
+            corpus,
+            "symbols_of",
+            lambda module: (
+                [
+                    {
+                        "name": "Bogus",
+                        "class": "textualconvention",
+                        "status": "current",
+                        "displayhint": None,
+                        "type": {"type": "NoSuchTypeAnywhere", "class": "type"},
+                    }
+                ]
+                if module == "FIXTURE-MIB"
+                else corpus.__class__.symbols_of(corpus, module)
+            ),
+        )
+
+        with pytest.raises(error.SmiError, match="no definition for type"):
+            builder.loadModule("FIXTURE-MIB")
+
     def test_corpus_can_be_removed(self, builder):
         builder.setMibCorpus(None)
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -175,6 +175,29 @@ class TestCorpusOpen:
         finally:
             os.chmod(directory, 0o700)
 
+    @pytest.mark.parametrize("directory", ["we?ird", "ha#sh", "sp ace", "per%cent"])
+    def test_opens_from_a_path_needing_uri_escaping(
+        self, corpus_path, tmp_path, directory
+    ):
+        # The connection string is a URI, not a path. Unescaped, a directory
+        # named "we?ird" ends the path at the "?" and SQLite opens an empty
+        # database of the shorter name -- which does not raise, it answers
+        # nothing, and the corpus reads as a file with application_id 0.
+        import shutil
+
+        target = tmp_path / directory
+        target.mkdir()
+        path = target / "core.db"
+        shutil.copy(corpus_path, path)
+
+        opened = MibCorpus(str(path))
+
+        try:
+            assert "FIXTURE-MIB" in opened.modules()
+
+        finally:
+            opened.close()
+
     def test_carries_the_application_id(self, corpus_path):
         import sqlite3
 
@@ -462,19 +485,48 @@ class TestBuilderWithACorpus:
         # rule picks, so following IMPORTS literally fails. Refusing to build
         # the whole module over one type is worse than resolving it from where
         # it actually lives.
+        # The type has to be one TYPE_CLASSES does *not* map, or resolution
+        # never reaches the IMPORTS step and the test passes whether or not
+        # the fallback exists. DisplayString is a TEXTUAL-CONVENTION, so it
+        # can only come from a module -- exactly the shape that fails.
         monkeypatch.setattr(
             corpus,
             "imports_of",
             lambda module: (
-                {"OCTET STRING": "NO-SUCH-MIB"}
+                {"DisplayString": "NO-SUCH-MIB"}
                 if module == "FIXTURE-MIB"
                 else corpus.__class__.imports_of(corpus, module)
             ),
         )
+        monkeypatch.setattr(
+            corpus,
+            "node_named",
+            lambda module, name: (
+                dict(
+                    corpus.__class__.node_named(corpus, module, name),
+                    syntax={"class": "type", "type": "DisplayString"},
+                )
+                if (module, name) == ("FIXTURE-MIB", "fixtureDescr")
+                else corpus.__class__.node_named(corpus, module, name)
+            ),
+        )
+        monkeypatch.setattr(
+            corpus,
+            "nodes_of",
+            lambda module: [
+                dict(node, syntax={"class": "type", "type": "DisplayString"})
+                if node["name"] == "fixtureDescr"
+                else node
+                for node in corpus.__class__.nodes_of(corpus, module)
+            ],
+        )
 
+        (convention,) = builder.importSymbols("SNMPv2-TC", "DisplayString")
         (column,) = builder.importSymbols("FIXTURE-MIB", "fixtureDescr")
 
-        assert column.getName() == (1, 3, 6, 1, 4, 1, 99999, 2, 1, 9)
+        # Resolved from SNMPv2-TC, where it actually lives, rather than the
+        # module IMPORTS named.
+        assert isinstance(column.syntax, convention)
 
     def test_type_that_resolves_nowhere_still_raises(
         self, builder, corpus, monkeypatch
@@ -501,6 +553,147 @@ class TestBuilderWithACorpus:
         )
 
         with pytest.raises(error.SmiError, match="no definition for type"):
+            builder.loadModule("FIXTURE-MIB")
+
+    def test_augmenting_row_adopts_the_base_row_index_names(
+        self, builder, corpus, monkeypatch
+    ):
+        # An augmenting row declares AUGMENTS and no INDEX, so without this it
+        # gets no index names at all and the runtime cannot decode an instance
+        # OID into index values or build one -- while the row looks perfectly
+        # well-formed. 1,181 rows in pysnmp/mibs' corpus are this shape and
+        # every one of them declares no INDEX.
+        augmenting = {
+            "module": "FIXTURE-MIB",
+            "name": "fixtureAugEntry",
+            "oid": "1.3.6.1.4.1.99999.3.1",
+            "arcs": (1, 3, 6, 1, 4, 1, 99999, 3, 1),
+            "class": "objecttype",
+            "nodetype": "row",
+            "status": "current",
+            "maxaccess": "not-accessible",
+            "units": None,
+            "syntax": None,
+            "defval": None,
+            "indices": None,
+            "augments": {
+                "module": "FIXTURE-MIB",
+                "name": "fixtureAugEntry",
+                "object": "fixtureEntry",
+            },
+        }
+        monkeypatch.setattr(
+            corpus,
+            "nodes_of",
+            lambda module: (
+                [*corpus.__class__.nodes_of(corpus, module), augmenting]
+                if module == "FIXTURE-MIB"
+                else corpus.__class__.nodes_of(corpus, module)
+            ),
+        )
+
+        row, base = builder.importSymbols(
+            "FIXTURE-MIB", "fixtureAugEntry", "fixtureEntry"
+        )
+
+        assert row.getIndexNames() == base.getIndexNames()
+        assert row.getIndexNames() == ((0, "FIXTURE-MIB", "fixtureIndex"),)
+
+    def test_augmentation_is_registered_on_the_base_row(
+        self, builder, corpus, monkeypatch
+    ):
+        # A generated module emits both halves: the base row is told it has an
+        # augmentation, and the augmenting row adopts its index names. Copying
+        # the names alone would leave the base row unaware of the augmentation.
+        augmenting = {
+            "module": "FIXTURE-MIB",
+            "name": "fixtureAugEntry",
+            "oid": "1.3.6.1.4.1.99999.3.1",
+            "arcs": (1, 3, 6, 1, 4, 1, 99999, 3, 1),
+            "class": "objecttype",
+            "nodetype": "row",
+            "status": "current",
+            "maxaccess": "not-accessible",
+            "units": None,
+            "syntax": None,
+            "defval": None,
+            "indices": None,
+            "augments": {
+                "module": "FIXTURE-MIB",
+                "name": "fixtureAugEntry",
+                "object": "fixtureEntry",
+            },
+        }
+        monkeypatch.setattr(
+            corpus,
+            "nodes_of",
+            lambda module: (
+                [*corpus.__class__.nodes_of(corpus, module), augmenting]
+                if module == "FIXTURE-MIB"
+                else corpus.__class__.nodes_of(corpus, module)
+            ),
+        )
+
+        (base,) = builder.importSymbols("FIXTURE-MIB", "fixtureEntry")
+
+        assert ("FIXTURE-MIB", "fixtureAugEntry") in base.augmentingRows
+
+    def test_syntax_without_a_type_is_refused(self, builder, corpus, monkeypatch):
+        # A KeyError three frames down is the wrong answer for a corpus that
+        # is malformed; load_module documents SmiError for exactly this.
+        monkeypatch.setattr(
+            corpus,
+            "nodes_of",
+            lambda module: [
+                dict(node, syntax={"class": "type"})
+                if node["name"] == "fixtureScalar"
+                else node
+                for node in corpus.__class__.nodes_of(corpus, module)
+            ],
+        )
+
+        with pytest.raises(error.SmiError, match="carries no type"):
+            builder.loadModule("FIXTURE-MIB")
+
+    def test_import_cycle_is_refused_rather_than_recursing(
+        self, builder, corpus, monkeypatch
+    ):
+        # Synthesis resolves imported types through importSymbols, which comes
+        # back to loadModule, so a module importing a type from itself by way
+        # of another would recurse without limit. It cannot be caught by
+        # marking the module loaded first: synthesis exports only when it
+        # finishes, so the re-entrant importSymbols would raise
+        # MibNotFoundError instead of resolving.
+        monkeypatch.setattr(
+            corpus,
+            "imports_of",
+            lambda module: (
+                {"CycleType": "FIXTURE-MIB"}
+                if module == "FIXTURE-MIB"
+                else corpus.__class__.imports_of(corpus, module)
+            ),
+        )
+        monkeypatch.setattr(
+            corpus,
+            "nodes_of",
+            lambda module: [
+                dict(node, syntax={"class": "type", "type": "CycleType"})
+                if node["name"] == "fixtureScalar"
+                else node
+                for node in corpus.__class__.nodes_of(corpus, module)
+            ],
+        )
+
+        with pytest.raises(error.SmiError, match="cycle"):
+            builder.loadModule("FIXTURE-MIB")
+
+    def test_load_texts_set_after_attaching_is_still_refused(self, builder):
+        # loadTexts is a plain attribute, so a caller can turn it on after the
+        # corpus is attached. Checking only at attachment would let that build
+        # modules with no DESCRIPTION and say nothing.
+        builder.loadTexts = True
+
+        with pytest.raises(error.SmiError, match="no texts"):
             builder.loadModule("FIXTURE-MIB")
 
     def test_corpus_can_be_removed(self, builder):

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -897,15 +897,15 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pysmi"
-version = "3.0.0rc5"
+version = "3.1.0rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/83/c166def683c38e29730ea158d1b99bbb1f62af11b9c6b5859aca1536297e/pysnmp_pysmi-3.0.0rc5.tar.gz", hash = "sha256:21d84f555536a975391d93cf3a099ffe6fe98598ae5bed998bd07aa9e0dc666c", size = 4309060, upload-time = "2026-09-08T14:57:53.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/80/cf40deb545a51e64b6c3f9f47f7eea3818adc5b7a244aff428e760abbf19/pysnmp_pysmi-3.1.0rc1.tar.gz", hash = "sha256:05da27dedea8dc15c38d5c9a482793f79e6307ec2209099a2bebdf873b24fbd3", size = 4391709, upload-time = "2026-09-09T04:43:53.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/03/ec6e9b52c8828e6bd4e879818754d47e72b9f0e3867f97be60d322e236d7/pysnmp_pysmi-3.0.0rc5-py3-none-any.whl", hash = "sha256:fdbeedc6c5a448e800bf0e0a0a129d499c0edba32743309adbfa00dc9b21a4a2", size = 3101842, upload-time = "2026-09-08T14:57:51.922Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cf/cbf3bc83426d1a80a6f56ed9ef6de81bed3d17e60c31391ba1a9d3bb5c2e/pysnmp_pysmi-3.1.0rc1-py3-none-any.whl", hash = "sha256:2fae9b288c4753c4d11fa5d5b10fd11462293e7a70bfee07d3321129229023ac", size = 3155590, upload-time = "2026-09-09T04:43:51.752Z" },
 ]
 
 [[package]]
@@ -923,6 +923,7 @@ dev = [
     { name = "coverage", extra = ["toml"] },
     { name = "mypy" },
     { name = "myst-parser" },
+    { name = "pysnmp-pysmi" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -941,6 +942,7 @@ dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.2.0,<8.0.0" },
     { name = "mypy", specifier = ">=1.15.0,<3.0.0" },
     { name = "myst-parser", specifier = ">=4.0.0,<5.0.0" },
+    { name = "pysnmp-pysmi", specifier = ">=3.1.0rc1" },
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "ruff", specifier = ">=0.4.0,<1.0.0" },
     { name = "sphinx", specifier = ">=7.0.0,<9.0.0" },
@@ -1057,7 +1059,7 @@ name = "roman-numerals-py"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "roman-numerals" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
 wheels = [
@@ -1106,23 +1108,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -1139,23 +1141,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals-py" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.11'" },
+    { name = "babel", marker = "python_full_version >= '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "imagesize", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [


### PR DESCRIPTION
Retargeted from `main` to `next` after opening. Based on `main` this PR carried all 293
commits of `next` and described them. The working agreement in #196 is `next`.

Reader half of #199, with the class synthesis of #145. Writer half is
pysnmp/pysmi#230, now merged and released as pysmi 3.1.0rc1.

## What this is

A MIB corpus is pysmi's `core.db`: the SMI model as data, one row per node, keyed by OID
and by name and ordered so a walk is a range query. This adds a reader for it and builds
MIB objects out of its rows.

## Nothing changes unless you ask

This is the part worth reviewing first, because every existing deployment is the
configuration it describes:

- A `MibBuilder` with **no corpus** resolves exactly as before — same sources, same
  search order, same objects, same errors.
- With a corpus configured, **a module the MIB sources carry is still loaded from the
  MIB sources.** The corpus is only consulted when the ordinary search comes up empty.
- The corpus is consulted **before** the MIB compiler, so a deployment using
  `addMibCompiler()` keeps compiling whatever the corpus does not carry.

splunk-connect-for-snmp upgrades into this by doing nothing. `TestBuilderUnchangedWithoutACorpus`
exists to fail if that stops being true.

Verified no regression: 1101 passed, 13 skipped, no failures. An earlier revision of this
description reported 87 failures and 75 errors against unmodified `next`; those were
environment gaps — snmpsim, and no precompiled bundle — and pysmi 3.1.0rc1's fuller
bundle closes them, so the number is now zero rather than merely unchanged.

## Why a corpus is worth opting into

`index-v2.csv` already answers *which module owns this OID*, so lazy loading needs no
corpus. Two things it cannot do are the reason this exists.

**It cannot say what is at an OID.** The index is `MODULE,OID` and carries a module's
anchors, so a leaf like `ifDescr` is not in it. Getting from an OID to a name, a syntax
and an access level meant compiling the module's ASN.1 on the trap path — measured at
0.45–0.63 s for a large vendor module — or parsing its whole JSON document, 11 ms and
9,773 symbols of `CISCO-ENTITY-VENDORTYPE-OID-MIB` to reach one of them. Here it is one
indexed row, ~3 µs.

**It cannot say what comes next.** An anchor index has no per-node ordering, so a GETNEXT
walk cannot be served from one at all.

There is a third reason about what a corpus *is not*: a pysnmp MIB module is Python that
`MibBuilder` runs through `exec()`. A corpus is rows.

## Changes

- `pysnmp/smi/corpus.py` — `MibCorpus`: `immutable=1` open, schema-version and
  `application_id` gating, `find_module`, `node`, `node_named`, `next_node`, `subtree`,
  `modules`, `module`, `symbols_of`, `imports_of`, cached type specifications
- `pysnmp/smi/synthesis.py` — MIB objects from rows
- `pysnmp/smi/builder.py` — `setMibCorpus()` / `getMibCorpus()` and the fallback in
  `loadModule`
- `docs/source/docs/mib-corpus.rst`
- `tests/test_corpus.py` — 88 tests
- `pyproject.toml` — the dev-group pysmi floor that makes those tests run at all; see below

## Notable decisions

**The OID key codec is reimplemented, not imported.** Twenty lines, and importing pysmi
to read a file whose whole point is that it needs no pysmi would defeat the layering.
A test asserts the two implementations agree.

**pysmi's conformance vectors run here** (pysnmp/pysmi#184), so the two halves of the
contract are checked against each other rather than against themselves. They did not,
until 29df876d. The fixture was reached through a module-level `pytest.importorskip`, and
the lockfile resolved pysmi 3.0.0rc5, which predates `pysmi.corpus` — a skip raised at
module scope takes the whole file with it, so all of `test_corpus.py` was skipped and CI
reported success without running any of it. The import is now a plain import, which is a
collection error rather than silence if the floor ever slips again.

**Type identity is preserved.** A syntax is stored once in the corpus and referenced by
id; the class built for it is cached against that id, so two objects sharing a type share
a class and `isinstance` never sees two classes for one type.

**Failures are loud.** A type that resolves nowhere raises rather than falling back to a
base type — a column silently typed `OctetString` instead of its TEXTUAL-CONVENTION
renders every value wrong and looks like a device fault. `setMibCorpus()` likewise
refuses a textless corpus when `loadTexts` is set, and a path SQLite cannot open — a
directory, or a file this process may not read — raises `SmiError` like every other
rejection rather than a bare `sqlite3.OperationalError`.

**One tolerance, deliberately.** A vendor module written against an older revision of a
standard module imports a type that revision defined and the current one does not —
`BRIDGE-MIB` is the recurring case, since RFC 1493 defined `MacAddress` and RFC 4188
imports it from `SNMPv2-TC` instead, and a corpus carries the newer revision because
that is what the ranking rule picks. A named source that turns out not to define the
symbol falls through to the same search an unimported type gets, rather than failing the
whole module over one type.

## Measured on real data

Against a corpus built from pysnmp/mibs' real sources with pysmi 3.1.0rc1 — 5,510
modules, 767,450 nodes, 47,226 types, 98,867 indexed OIDs, 255.9 MB:

- **210/210** standard modules synthesize
- **398/400** random vendor modules synthesize

The two failures are faithful rather than gaps. One imports a type its source module does
not define at the revision the corpus carries. The other is `HPNSAPCI-MIB`, whose
`hpnsaPciVendorId` declares `apple-computer-inc` and `madge-networks` at the same
enumeration value; pyasn1 rejects that and a generated `.py` would fail identically.

End to end against that database, through the ordinary `loadModule` path: `ifDescr`
resolves to a `MibTableColumn` with a `DisplayString` syntax and `readonly` access, which
is what loading `IF-MIB.py` produces; `1.3.6.1.2.1.2.2.1.2` resolves to `IF-MIB::ifDescr`
and its GETNEXT successor to `ifType`; and `ifXEntry` carries `ifIndex` as its index name,
which is the AUGMENTS fix on real data rather than on a fixture.

## Not in this PR

- #144's `MibStore` abstraction proper — this is the concrete SQLite reader plus a hook
- #200's version policy, implemented provisionally as *refuse what we do not implement*
- Making `pysnmp-pysmi` optional. Nothing on the default path imports it, but the
  dependency is still declared required
- The override table (#143, #145)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WREB8ZXBpKJE6PNRUbJpBU