### PR TITLE
fix(tests): do not name a directory "we?ird" on a platform that forbids it

### DIFF
--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -192,7 +192,17 @@ class TestCorpusOpen:
         finally:
             os.chmod(directory, 0o700)
 
-    @pytest.mark.parametrize("directory", ["we?ird", "ha#sh", "sp ace", "per%cent"])
+    # "?" is the character that motivated the escaping and the only one here
+    # Windows will not accept in a filename -- mkdir fails with WinError 123
+    # before any of this is reached. It is parametrized wherever a directory
+    # can be named that, which is every platform but Windows; the other three
+    # run everywhere. Nothing is lost by the skip: pathname2url escapes on the
+    # character, not on the platform, and the case it guards cannot arise
+    # where the name cannot exist.
+    @pytest.mark.parametrize(
+        "directory",
+        (["we?ird"] if os.name != "nt" else []) + ["ha#sh", "sp ace", "per%cent"],
+    )
     def test_opens_from_a_path_needing_uri_escaping(
         self, corpus_path, tmp_path, directory
     ):


### PR DESCRIPTION
`next` is red on Windows since #211 merged. This is the fix.

## What broke

The URI-escaping test creates directories whose names carry the punctuation a `file:` URI gives meaning to. `?` is the character that motivated the escaping — and it is also the one Windows will not accept in a filename, so `mkdir` fails before any of the test is reached:

```
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect
```

Both Windows jobs failed, `py3.10` and `py3.14`. **Every Ubuntu and macOS job passed**, because `?` is a legal filename character on both.

## Why the pull request was green and the merge was not

The matrix is narrow on a pull request and broad on a push:

```yaml
BROAD: ${{ github.event_name != 'pull_request'
        || contains(github.event.pull_request.labels.*.name, 'ci:full-matrix') }}
```

So Windows never ran on #211, and ran immediately on the merge commit. Worth knowing generally: a green pull request here does not mean Windows is green, unless it carried `ci:full-matrix`.

## The fix

`?` is parametrized wherever a directory can be named that — every platform but Windows. `#`, a space and `%` run everywhere, Windows included.

Nothing is lost by the skip: `pathname2url` escapes on the character, not on the platform, and the case it guards cannot arise where the name cannot exist.

## The same mistake in pysmi

pysmi's copy of this test has the identical defect and turned its `next` red too; fixed in pysnmp/pysmi#237.

## Verified

Suite 1101 passed, 13 skipped; ruff, ruff format and mypy clean over 139 files. The parametrized list resolves to four entries on POSIX and three on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WREB8ZXBpKJE6PNRUbJpBU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WREB8ZXBpKJE6PNRUbJpBU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated path-handling test coverage for platform compatibility.
  * Retained URI-escaping coverage for directories containing special characters across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->