### PR TITLE
test(smi): let pysmi's vectors own the codec, and keep what is ours

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dev = [
     # resolved pysmi 3.0.0rc5, and `pysmi.corpus` did not exist there, so the
     # module-level import of the fixture skipped the entire corpus suite and CI
     # passed without running any of it.
-    "pysnmp-pysmi >=3.1.0rc1",
+    "pysnmp-pysmi >=3.1.0rc2",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -65,62 +65,42 @@ def corpus(corpus_path):
 
 
 class TestOidKey:
-    """The encoding the whole file format's ordering rests on.
+    """What this codec owes beyond the format's own rules.
 
-    pysmi writes these keys and pysnmp reads them, and neither imports the
-    other, so the two implementations agreeing is a thing to test rather than
-    a thing to assume.
+    The encoding itself -- round-tripping, bytewise order being numeric order,
+    a prefix staying a prefix, a parent sorting before its children, the
+    subtree bounds, and refusing what is not an OID -- is specified by pysmi
+    and asserted by its conformance vectors, which :py:class:`TestConformance`
+    runs against *this* implementation. Restating those properties here was
+    transcribing a specification into the repository that consumes it, where
+    the copy agrees with the original exactly until the original changes.
+
+    What is left is what the vectors cannot say, because it is pysnmp's rather
+    than the format's.
     """
 
-    @pytest.mark.parametrize(
-        "oid", ["1", "1.3.6", "1.3.6.1.4.1.9", "2.0", "1.3.6.1.4.1.4294967295"]
-    )
-    def test_round_trips(self, oid):
-        assert oid_from_key(oid_key(oid)) == oid
-
     def test_accepts_arcs_as_well_as_text(self):
+        # pysmi's codec takes a dotted string. This one also takes the arcs,
+        # because callers here hold OIDs as tuples far more often than as
+        # text, so it is an affordance of this implementation rather than a
+        # property of the encoding.
         assert oid_key((1, 3, 6)) == oid_key("1.3.6")
 
-    def test_byte_order_is_numeric_order(self):
-        # 1.3.10 below 1.3.9 is what string comparison gets wrong; 1.3.256 is
-        # what one byte per arc gets wrong.
-        oids = ["1.3.6", "1.3.6.1", "1.3.7", "1.3.9", "1.3.10", "1.3.256", "2.0"]
-
-        assert sorted(oids, key=oid_key) == sorted(
-            oids, key=lambda x: tuple(int(a) for a in x.split("."))
-        )
-
-    def test_prefix_encodes_to_byte_prefix(self):
-        assert oid_key("1.3.6.1").startswith(oid_key("1.3.6"))
-
-    def test_parent_sorts_before_children(self):
-        assert oid_key("1.3.6") < oid_key("1.3.6.0")
-
-    def test_subtree_bound_brackets_the_subtree(self):
-        low = oid_key("1.3.6")
-        high = subtree_bound(low)
-
-        assert low <= oid_key("1.3.6.1.4.1.99") < high
-        assert not low <= oid_key("1.3.7") < high
-
-    def test_subtree_bound_carries_past_a_full_byte(self):
-        key = oid_key("1.255")
-
-        assert subtree_bound(key) > oid_key("1.255.1")
-
-    @pytest.mark.parametrize("bad", ["", "1.3.six", "not an oid"])
-    def test_rejects_what_is_not_an_oid(self, bad):
+    @pytest.mark.parametrize("bad", ["", "1.3.six", "not an oid", "1.4294967296"])
+    def test_refuses_as_an_smi_error(self, bad):
+        # The vectors say a codec must refuse these. They cannot say what it
+        # must raise, and the type is this library's contract: a caller
+        # catching SmiError to fall back to its MIB sources does not catch
+        # ValueError.
         with pytest.raises(error.SmiError):
             oid_key(bad)
-
-    def test_rejects_arc_out_of_range(self):
-        with pytest.raises(error.SmiError):
-            oid_key("1.4294967296")
 
     def test_agrees_with_pysmi(self):
         # The two implementations are separate on purpose -- importing pysmi
         # to read a file whose point is that it needs no pysmi would defeat
-        # the layering -- so they have to be checked against each other.
+        # the layering. The vectors pin each side to the specification; this
+        # pins them to each other, which is the cheaper check when a vector
+        # has not yet been written for some shape.
         from pysmi.corpus.db import oid_key as writer_key
 
         for oid in ("1.3.6.1.2.1.2.2.1.2", "1.3.256.9.10", "2.0", "1"):
@@ -251,6 +231,35 @@ class TestConformance:
 
     def _answer(self, corpus, vector):
         operation = vector["op"]
+
+        # The codec operations take no corpus. They run against *this*
+        # module's oid_key, which is a separate implementation from pysmi's
+        # on purpose -- reading a corpus is meant to need no pysmi -- so the
+        # vectors are what check it against the specification rather than
+        # against its own transcription of the specification.
+        if operation == "oid_key":
+            return oid_key(vector["oid"]).hex()
+
+        if operation == "oid_from_key":
+            return oid_from_key(bytes.fromhex(vector["key"]))
+
+        if operation == "subtree_bound":
+            return subtree_bound(oid_key(vector["oid"])).hex()
+
+        if operation == "oid_key_order":
+            return sorted(vector["oids"], key=oid_key)
+
+        if operation == "oid_key_prefix":
+            return oid_key(vector["under"]).startswith(oid_key(vector["oid"]))
+
+        if operation == "oid_key_refuses":
+            try:
+                oid_key(vector["oid"])
+
+            except Exception:  # noqa: BLE001
+                return "refused"
+
+            return "accepted"
 
         if operation == "meta":
             return corpus.meta(vector["key"])

--- a/uv.lock
+++ b/uv.lock
@@ -897,15 +897,15 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pysmi"
-version = "3.1.0rc1"
+version = "3.1.0rc2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/80/cf40deb545a51e64b6c3f9f47f7eea3818adc5b7a244aff428e760abbf19/pysnmp_pysmi-3.1.0rc1.tar.gz", hash = "sha256:05da27dedea8dc15c38d5c9a482793f79e6307ec2209099a2bebdf873b24fbd3", size = 4391709, upload-time = "2026-09-09T04:43:53.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bd/ff68cedd9aac27d8eeb5f7187b1b9c4550146abc8e99752601bc1345180f/pysnmp_pysmi-3.1.0rc2.tar.gz", hash = "sha256:cd321706ae3abb9df24fc395f223d4dfa5a0fc72e0960e46dba125b74ebdb40e", size = 4400448, upload-time = "2026-09-09T14:38:20.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/cf/cbf3bc83426d1a80a6f56ed9ef6de81bed3d17e60c31391ba1a9d3bb5c2e/pysnmp_pysmi-3.1.0rc1-py3-none-any.whl", hash = "sha256:2fae9b288c4753c4d11fa5d5b10fd11462293e7a70bfee07d3321129229023ac", size = 3155590, upload-time = "2026-09-09T04:43:51.752Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d9/c266e5dfde7d34d4957a27619616cad3553fe04c817b61886638c21b2ed1/pysnmp_pysmi-3.1.0rc2-py3-none-any.whl", hash = "sha256:f26068ea5aa5f7ee0564a129d5011a6445dad7bb5ae5af8ff168771b117e2827", size = 3159437, upload-time = "2026-09-09T14:38:18.843Z" },
 ]
 
 [[package]]
@@ -942,7 +942,7 @@ dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.2.0,<8.0.0" },
     { name = "mypy", specifier = ">=1.15.0,<3.0.0" },
     { name = "myst-parser", specifier = ">=4.0.0,<5.0.0" },
-    { name = "pysnmp-pysmi", specifier = ">=3.1.0rc1" },
+    { name = "pysnmp-pysmi", specifier = ">=3.1.0rc2" },
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "ruff", specifier = ">=0.4.0,<1.0.0" },
     { name = "sphinx", specifier = ">=7.0.0,<9.0.0" },


### PR DESCRIPTION
The other half of pysnmp/pysmi#238, now that 3.1.0rc2 is released.

## The duplication

The OID key encoding is specified by pysmi and **reimplemented here** — deliberately, since reading a corpus is meant to need no pysmi. So both repositories hand-wrote the same eleven property tests: round-tripping, bytewise order being numeric order, a prefix staying a prefix, a parent sorting before its children, the subtree bounds, refusing what is not an OID.

Those are properties of the **format**. Restating them here transcribed a specification into the repository that consumes it, where the copy agrees with the original exactly until the original changes. And the conformance fixture — which exists to be that contract — had **no codec vectors at all**, so the single most format-specific thing in the reader was the one thing the contract was silent about.

pysmi 3.1.0rc2 adds thirteen, with the encodings pinned as bytes rather than described. `TestConformance` now dispatches them, so they run against **this** codec.

## Proved, not assumed

The whole justification is that the vectors exercise *this* implementation. So I broke it — `width` forced to one byte per arc, the classic wrong codec:

```
21 failed, 22 passed
```

21 of the 43 vectors catch it. The dev-group pysmi floor moves to `3.1.0rc2`, which is what makes them arrive: on `3.1.0rc1` the dispatcher is inert and only 30 vectors run.

## Three tests stay, because the vectors cannot say these things

| kept | why it is not the format's |
|---|---|
| `oid_key` accepts arcs as well as text | pysmi's takes a dotted string; callers here hold OIDs as tuples far more often, so it is an affordance of this implementation |
| refusal raises **`SmiError`** specifically | the vectors say a codec must refuse `1.3.six`; they cannot say what it must *raise*, and the type is this library's contract — a caller catching `SmiError` to fall back to its MIB sources does not catch `ValueError` |
| the two implementations agree with each other | the cheaper check when a vector has not yet been written for some shape |

That distinction is the point of the change rather than an exception to it: what belongs here is what only this library can promise.

## Verified

91 corpus tests; suite **1104 passed, 13 skipped**, pytest exit 0; ruff, ruff format and mypy clean over 139 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WREB8ZXBpKJE6PNRUbJpBU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WREB8ZXBpKJE6PNRUbJpBU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependency Updates**
  * Raised the minimum development dependency version for `pysnmp-pysmi`.

* **Tests**
  * Expanded conformance-vector coverage for OID codec behavior.
  * Consolidated OID validation tests, including handling of invalid and out-of-range arcs.
  * Removed redundant tests whose behavior is now covered by shared conformance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->