### PR TITLE
fix(deps): put the pyasn1 floor back on a GA

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,27 +27,20 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 readme = "README.md"
-# The pyasn1 and pysmi floors name release candidates on purpose, and naming one
-# is the only way to say this: dependabot offers a prerelease when the current
-# version is already one OR when a requirement string names one, and there is no
+# The pysmi floor names a release candidate on purpose, and naming one is the
+# only way to say this: dependabot offers a prerelease when the current version
+# is already one OR when a requirement string names one, and there is no
 # configuration key for it (dependabot/dependabot-core#1926, closed as not
-# planned). PEP 440 admits prereleases per specifier, so this puts both siblings
-# -- pycryptodomex is the only one left on a stable floor -- on the rc stream,
-# and this repository integrates against the sibling rc it is released alongside
-# instead of against its last GA.
+# planned). PEP 440 admits prereleases per specifier, so this puts pysmi on the
+# rc stream, and this repository integrates against the sibling rc it is
+# released alongside instead of against its last GA.
 #
-# The two are not the same shape, and the difference decides whether the floor
-# does anything at all. Resolution takes the newest allowed version, so what
-# matters is where the named rc sorts against the sibling's newest GA:
+# What matters is where a named rc sorts against that sibling's newest GA,
+# because resolution takes the newest allowed version:
 #
-#   pyasn1  2.0.0rc2 < 2.0.0   inert. The floor names the last rc of the line
-#                              its GA is on, so it sits one hair below that GA
-#                              and resolution still picks 2.0.0. It starts to
-#                              matter only once pyasn1 publishes an rc ahead of
-#                              its next GA.
 #   pysmi   3.1.0rc3 > 3.0.0   active. This names an rc of the *next* line, so
 #                              it outranks the newest GA and is what resolves.
-#                              Deliberate, and now load-bearing at runtime: the
+#                              Deliberate, and load-bearing at runtime: the
 #                              five base modules pysnmp used to carry its own
 #                              hand-edited copies of are gone, so what loads is
 #                              pysmi's bundle plus the behavior fragments it
@@ -60,13 +53,14 @@ readme = "README.md"
 #                              publish pysmi.corpus.conformance, which
 #                              tests/test_corpus.py builds its fixture with.
 #
-# This belongs to the 6.0.0 rc cycle, not to the package forever. Put both
-# floors back on a GA before cutting the 6.0.0 GA, or a released pysnmplib lets
-# an installer resolve a sibling release candidate.
+# pyasn1 is off that stream: 2.0.2 is a GA and is what the floor names, so
+# nothing here resolves pyasn1 to a prerelease. pysmi is the one floor left to
+# put back on a GA before cutting the 6.0.0 GA -- until then a released
+# pysnmplib lets an installer resolve a sibling release candidate.
 dependencies = [
     "pysnmp-pysmi >=3.1.0rc3,<4.0.0",
     "pycryptodomex >=3.11.0,<4.0.0",
-    "pysnmp-pyasn1 >=2.0.0rc2,<3.0.0",
+    "pysnmp-pyasn1 >=2.0.2,<3.0.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -888,11 +888,11 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pyasn1"
-version = "2.0.1"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/f8/9d17dff241c023116ab48bfa1e7180a9e9a3dbc8a63f3721d3b97ddb2d7e/pysnmp_pyasn1-2.0.1.tar.gz", hash = "sha256:776e624e83b6d8bdb30a0d03379b346bcfebbb752f6f02ad05287888c876483f", size = 229839, upload-time = "2026-09-06T02:48:23.616Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/c5/481b9576c830d55f09075aeaa86613922b13324cb82dc8d696430d77d604/pysnmp_pyasn1-2.0.2.tar.gz", hash = "sha256:0f412c1d12c3f78d707462f852cb75b47fe1794167d3ed9631acc0ce9b8300e2", size = 231127, upload-time = "2026-09-09T21:55:38.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/5b/56bf01541234545eff651c273f4ef7909e6be45a6b51ba1b2be0dec13631/pysnmp_pyasn1-2.0.1-py3-none-any.whl", hash = "sha256:9cf4b0db4ac03b7394f46f389cfb7d8947c9a0757e881d6a45e7eb2cbd6cd600", size = 108633, upload-time = "2026-09-06T02:48:22.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9b/35dd13e7220b8c7bf13e4c923fec4ecac2af4cab29d63fa94e196ae8d692/pysnmp_pyasn1-2.0.2-py3-none-any.whl", hash = "sha256:3e7988c303c09651a01f8cf95c5061ab93ea9426004e536a9443062eef075a06", size = 108609, upload-time = "2026-09-09T21:55:36.805Z" },
 ]
 
 [[package]]
@@ -932,7 +932,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
-    { name = "pysnmp-pyasn1", specifier = ">=2.0.0rc2,<3.0.0" },
+    { name = "pysnmp-pyasn1", specifier = ">=2.0.2,<3.0.0" },
     { name = "pysnmp-pysmi", specifier = ">=3.1.0rc3,<4.0.0" },
 ]
 


### PR DESCRIPTION
`pysnmp-pyasn1` 2.0.2 is a GA on PyPI, so the floor no longer has to name a release
candidate to track the sibling stream.

## Why now

Cutting the 6.0.0 GA requires both sibling floors to name GAs — otherwise a released
`pysnmplib` lets an installer resolve a sibling release candidate. This clears the
pyasn1 half.

## What changed

- `pysnmp-pyasn1 >=2.0.0rc2` → `>=2.0.2`
- `uv.lock` resolves 2.0.1 → 2.0.2
- Rewrote the dependency comment: the two-floor rc explanation is now a one-floor one

The old floor was inert. It named the last rc of the line 2.0.0 was on, so it sorted
one hair below that GA and resolution picked the GA anyway. Naming 2.0.2 removes pyasn1
from the prerelease stream entirely.

## What is still blocked

pysmi. Its floor names `3.1.0rc3`, which outranks its newest GA (3.0.0) and is what
actually resolves — deliberately, because 3.0.0 lacks the behavior-fragment re-seed
(pysnmp/pysmi#236) that every `SnmpEngine()` start depends on. That floor cannot move
until pysmi publishes 3.1.0 GA.

## Verification

`1174 passed, 12 skipped` against pyasn1 2.0.2.

Refs #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported `pysnmp-pyasn1` version to the stable 2.0.2 release.
  * Revised dependency guidance to reflect the current stable and release-candidate version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->