### PR TITLE
style: turn on ruff's docstring rules, minus the ones that need prose

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,9 +138,8 @@ extend-exclude = [".eggs", ".git", ".hg", ".mypy_cache", ".tox", ".venv", "_buil
 
 [tool.ruff.lint]
 # The rule set pyasn1 and pysmi share, so a contributor moving between the
-# three repositories meets the same lint. The docstring family (D) is the one
-# deliberate gap: pysnmp has some 800 undocumented public classes and methods,
-# which is a documentation project rather than a lint fix. Tracked in #186.
+# three repositories meets the same lint -- the docstring family (D) included,
+# as of #186. Which parts of D are on is settled in the ignore list below.
 select = [
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
@@ -159,6 +158,7 @@ select = [
     "RUF",    # ruff-specific rules
     "PL",     # pylint
     "TRY",    # tryceratops
+    "D",      # pydocstyle
 ]
 ignore = [
     # Shared with pyasn1 and pysmi.
@@ -199,12 +199,56 @@ ignore = [
     # runtime where a weak one is configured (see pysnmp/error.py).
     "S508",     # snmp-insecure-version
     "S509",     # snmp-weak-cryptography
+
+    # The docstring family, adopted in stages -- see #186. What is on now is
+    # the shape of the docstrings that exist: summary line, section headings,
+    # punctuation. What is still off is the requirement that every public
+    # thing have one, which is ~790 items across the package and is a
+    # documentation project rather than a lint fix. Writing 347 method
+    # docstrings mechanically produces noise, not documentation.
+    #
+    # These come off one rule at a time, each its own reviewable change:
+    #   D100/D104  108 modules and packages
+    #   D101       183 classes
+    #   D103/D107  104 functions and constructors
+    #   D102       347 methods, probably by subpackage
+    #   D105        55 magic methods
+    "D100",     # undocumented-public-module
+    "D101",     # undocumented-public-class
+    "D102",     # undocumented-public-method
+    "D103",     # undocumented-public-function
+    "D104",     # undocumented-public-package
+    "D105",     # undocumented-magic-method
+    "D107",     # undocumented-public-init
+
+    # The one rule pyasn1 keeps that this does not, and the only place the two
+    # rule sets differ. Every third-person summary it caught -- "Returns the",
+    # "Adds a", "Creates a" -- has been fixed. What is left is 25 accessors
+    # and properties whose summary is a noun phrase naming what you get back:
+    # "The corpus this builder falls back to, or ``None``." Rewriting those as
+    # "Return the corpus..." is longer and says less, and for a property it
+    # describes a call that the reader does not make. D401 also misfires on an
+    # imperative that opens with an adverb ("Synchronously call ...").
+    "D401",     # non-imperative-mood
 ]
+
+[tool.ruff.lint.pydocstyle]
+# What pyasn1 uses, and what the Sphinx build already assumes -- conf.py sets
+# napoleon_numpy_docstring. Picking it here rather than leaving ruff on its
+# default also settles D203/D211 and D212/D213, which are mutually exclusive
+# pairs that ruff warns about when both are selected.
+convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
 # Generated MIB modules bind their names via mibBuilder.importSymbols() at
 # import time, so static analysis cannot see them.
-"pysnmp/smi/mibs/**" = ["F821"]
+# D: most modules here are generated, and their prose is the MIB's own
+# DESCRIPTION clauses rendered by pysmi's code generator -- nobody writes it
+# here and tools/regenerate_mibs.py would overwrite an edit made to satisfy a
+# lint. The hand-written ones in this directory (SNMPv2-SMI, SNMPv2-TC,
+# SNMPv2-CONF, the ASN1 modules) satisfy the enabled D rules anyway, so this
+# is not load-bearing for them.
+"pysnmp/smi/mibs/**" = ["F821", "D"]
 # Package __init__ modules re-export the public API.
 "**/__init__.py" = ["F401"]
 # Examples are documentation: star imports and binding every interface are
@@ -212,7 +256,12 @@ ignore = [
 # PLR2044: the `"""  #` that closes an example's prose block is not an empty
 # comment, it is the marker docs/source/examples/**.rst splits on -- the text
 # above it is included as prose, the code below it as a literal block.
-"examples/**" = ["F401", "F403", "F405", "F821", "S104", "PLR2044"]
+# D: an example's module docstring is reStructuredText that
+# docs/source/examples/**.rst includes verbatim, so its first two lines are a
+# title and its `+++++` underline -- not a summary line. Applying D400 to one
+# appends a period to the underline and breaks the title. pyasn1 exempts its
+# examples for the same reason.
+"examples/**" = ["F401", "F403", "F405", "F821", "S104", "PLR2044", "D"]
 # MD5 and SHA-1 are not a choice here: usmHMACMD5AuthProtocol and
 # usmHMACSHAAuthProtocol are what :RFC:`3414#section-6` and #section-7 define,
 # and pysnmp warns at runtime where either is configured.
@@ -223,9 +272,13 @@ ignore = [
 # implicit __context__ chaining is the thing under test.
 # S105/S108/S603: fixed passphrases, a fixed socket path and subprocess calls
 # with a literal argv are what a test harness is made of.
+# D: a test's docstring says what the test establishes and why it is worth
+# establishing, and a fixture's names what it hands back. Neither is an
+# imperative-mood summary of a public API, which is what D is shaped for.
+# pyasn1 exempts its tests the same way.
 "tests/**" = [
     "S101", "S102", "S104", "S105", "S108", "S603",
-    "B017", "B904", "BLE", "PL", "RUF", "TRY",
+    "B017", "B904", "BLE", "PL", "RUF", "TRY", "D",
 ]
 
 [tool.ruff.lint.isort]

--- a/pysnmp/carrier/asyncio/dgram/base.py
+++ b/pysnmp/carrier/asyncio/dgram/base.py
@@ -39,7 +39,7 @@ from pysnmp.carrier.asyncio.base import AbstractAsyncioTransport
 
 
 class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
-    """Base Asyncio datagram Transport, to be used with AsyncioDispatcher"""
+    """Base Asyncio datagram Transport, to be used with AsyncioDispatcher."""
 
     #: Address family this transport opens sockets in. None where the
     #: platform has no such family -- AF_UNIX on Windows, AF_INET6 on a build

--- a/pysnmp/carrier/asyncio/dispatch.py
+++ b/pysnmp/carrier/asyncio/dispatch.py
@@ -37,7 +37,7 @@ from pysnmp.error import PySnmpError
 
 
 class AsyncioDispatcher(AbstractTransportDispatcher):
-    """AsyncioDispatcher based on asyncio event loop"""
+    """AsyncioDispatcher based on asyncio event loop."""
 
     def __init__(self, *args, **kwargs):
         AbstractTransportDispatcher.__init__(self)

--- a/pysnmp/entity/observer.py
+++ b/pysnmp/entity/observer.py
@@ -30,7 +30,6 @@ def execution_context(
             ...
 
     """
-
     if variables is not None and context:
         raise TypeError(
             "execution context accepts either a mapping or keyword variables"
@@ -62,9 +61,10 @@ def execution_context(
 
 
 class MetaObserver:
-    """This is a simple facility for exposing internal SNMP Engine
-    working details to pysnmp applications. These details are
-    basically local scope variables at a fixed point of execution.
+    """Expose internal SNMP engine working details to pysnmp applications.
+
+    Those details are basically local scope variables at a fixed point of
+    execution.
 
     Two modes of operations are offered:
     1. Consumer: app can request an execution point context by execution point ID.

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -89,7 +89,7 @@ async def getCmd(
               the cost of slightly reduced performance. Default is `True`.
 
     Returns
-    ------
+    -------
     errorIndication : str
         True value indicates SNMP engine error.
     errorStatus : str
@@ -126,7 +126,6 @@ async def getCmd(
     >>> # asyncio.run(run())
 
     """
-
     __cbFun = make_callback(vbProcessor.unmakeVarBinds)
 
     addrName, paramsName = lcd.configure(
@@ -186,7 +185,7 @@ async def setCmd(
               the cost of slightly reduced performance. Default is `True`.
 
     Returns
-    ------
+    -------
     errorIndication : str
         True value indicates SNMP engine error.
     errorStatus : str
@@ -222,7 +221,6 @@ async def setCmd(
     >>> # asyncio.run(run())
 
     """
-
     __cbFun = make_callback(vbProcessor.unmakeVarBinds)
 
     addrName, paramsName = lcd.configure(
@@ -282,7 +280,7 @@ async def nextCmd(
               the cost of slightly reduced performance. Default is `True`.
 
     Returns
-    ------
+    -------
     errorIndication : str
         True value indicates SNMP engine error.
     errorStatus : str
@@ -322,7 +320,6 @@ async def nextCmd(
     >>> # asyncio.run(run())
 
     """
-
     __cbFun = make_callback(vbProcessor.unmakeVarBinds, multi_row=True)
 
     addrName, paramsName = lcd.configure(
@@ -454,7 +451,6 @@ async def bulkCmd(
     >>> # asyncio.run(run())
 
     """
-
     __cbFun = make_callback(vbProcessor.unmakeVarBinds, multi_row=True)
 
     addrName, paramsName = lcd.configure(

--- a/pysnmp/hlapi/asyncio/ntforg.py
+++ b/pysnmp/hlapi/asyncio/ntforg.py
@@ -106,7 +106,6 @@ async def sendNotification(
     >>> # asyncio.run(run())
 
     """
-
     __cbFun = make_callback(vbProcessor.unmakeVarBinds)
 
     notifyName = lcd.configure(

--- a/pysnmp/nextid.py
+++ b/pysnmp/nextid.py
@@ -7,7 +7,7 @@ import secrets
 
 
 class Integer:
-    """Return a next value in a reasonably MT-safe manner"""
+    """Return a next value in a reasonably MT-safe manner."""
 
     def __init__(self, maximum, increment=256):
         self.__maximum = maximum

--- a/pysnmp/proto/acmod/rfc3415.py
+++ b/pysnmp/proto/acmod/rfc3415.py
@@ -10,7 +10,7 @@ from pysnmp.smi.error import NoSuchInstanceError
 
 # 3.2
 class Vacm:
-    """View-based Access Control Model"""
+    """View-based Access Control Model."""
 
     accessModelID = 3
 

--- a/pysnmp/proto/acmod/void.py
+++ b/pysnmp/proto/acmod/void.py
@@ -10,7 +10,7 @@ from pysnmp.proto import errind, error
 # rfc3415 3.2
 # noinspection PyUnusedLocal
 class Vacm:
-    """Void Access Control Model"""
+    """Void Access Control Model."""
 
     accessModelID = 0
 

--- a/pysnmp/proto/errind.py
+++ b/pysnmp/proto/errind.py
@@ -9,7 +9,7 @@ import functools
 
 @functools.total_ordering
 class ErrorIndication(Exception):
-    """SNMPv3 error-indication values"""
+    """SNMPv3 error-indication values."""
 
     def __init__(self, descr=None):
         self.__value = self.__descr = (

--- a/pysnmp/proto/rfc1902.py
+++ b/pysnmp/proto/rfc1902.py
@@ -98,7 +98,7 @@ class Integer32(univ.Integer):
 
     @classmethod
     def withValues(cls, *values):
-        """Creates a subclass with discreet values constraint."""
+        """Create a subclass with discreet values constraint."""
 
         class X(cls):
             subtypeSpec = cls.subtypeSpec + constraint.SingleValueConstraint(*values)
@@ -108,7 +108,7 @@ class Integer32(univ.Integer):
 
     @classmethod
     def withRange(cls, minimum, maximum):
-        """Creates a subclass with value range constraint."""
+        """Create a subclass with value range constraint."""
 
         class X(cls):
             subtypeSpec = cls.subtypeSpec + constraint.ValueRangeConstraint(
@@ -195,7 +195,7 @@ class OctetString(univ.OctetString):
         Python string or :py:class:`~pysnmp.proto.rfc1902.OctetString`
         class instance.
 
-    Other parameters
+    Other Parameters
     ----------------
     hexValue : str
         Python string representing octets in a hexadecimal notation
@@ -258,7 +258,7 @@ class OctetString(univ.OctetString):
 
     @classmethod
     def withSize(cls, minimum, maximum):
-        """Creates a subclass with value size constraint."""
+        """Create a subclass with value size constraint."""
 
         class X(cls):
             subtypeSpec = cls.subtypeSpec + constraint.ValueSizeConstraint(
@@ -534,7 +534,7 @@ class Opaque(univ.OctetString):
         Python string or :py:class:`~pysnmp.proto.rfc1902.OctetString`-based
         class instance.
 
-    Other parameters
+    Other Parameters
     ----------------
     hexValue : str
         Python string representing octets in a hexadecimal notation
@@ -610,7 +610,7 @@ class Counter64(univ.Integer):
 
 
 class Bits(OctetString):
-    """Creates an instance of SNMP BITS class.
+    r"""Creates an instance of SNMP BITS class.
 
     The :py:class:`~pysnmp.proto.rfc1902.Bits` type represents
     an enumeration of named bits. This collection is assigned non-negative,
@@ -630,7 +630,7 @@ class Bits(OctetString):
         Sequence of bit names or a Python string (as a raw data) or
         :py:class:`~pysnmp.proto.rfc1902.OctetString` class instance.
 
-    Other parameters
+    Other Parameters
     ----------------
     hexValue : str
         Python string representing octets in a hexadecimal notation
@@ -699,7 +699,7 @@ class Bits(OctetString):
 
     @classmethod
     def withNamedBits(cls, **values):
-        """Creates a subclass with discreet named bits constraint.
+        """Create a subclass with discreet named bits constraint.
 
         Reduce fully duplicate enumerations along the way.
         """

--- a/pysnmp/proto/rfc3412.py
+++ b/pysnmp/proto/rfc3412.py
@@ -15,8 +15,10 @@ from pysnmp.smi import builder, instrum
 
 
 class MsgAndPduDispatcher:
-    """SNMP engine PDU & message dispatcher. Exchanges SNMP PDU's with
-    applications and serialized messages with transport level.
+    """SNMP engine PDU & message dispatcher.
+
+    Exchanges SNMP PDU's with applications and serialized messages with
+    transport level.
     """
 
     def __init__(self, mibInstrumController=None):
@@ -58,7 +60,7 @@ class MsgAndPduDispatcher:
 
     # 4.3.1
     def registerContextEngineId(self, contextEngineId, pduTypes, processPdu):
-        """Register application with dispatcher"""
+        """Register application with dispatcher."""
         # 4.3.2 -> no-op
 
         # 4.3.3
@@ -78,7 +80,7 @@ class MsgAndPduDispatcher:
 
     # 4.4.1
     def unregisterContextEngineId(self, contextEngineId, pduTypes):
-        """Unregister application with dispatcher"""
+        """Unregister application with dispatcher."""
         # 4.3.4
         if contextEngineId is None:
             # Default to local snmpEngineId
@@ -125,7 +127,7 @@ class MsgAndPduDispatcher:
         cbFun=None,
         cbCtx=None,
     ):
-        """PDU dispatcher -- prepare and serialize a request or notification"""
+        """PDU dispatcher -- prepare and serialize a request or notification."""
         # 4.1.1.2
         k = int(messageProcessingModel)
         if k in snmpEngine.messageProcessingSubsystems:
@@ -327,7 +329,7 @@ class MsgAndPduDispatcher:
 
     # 4.2.1
     def receiveMessage(self, snmpEngine, transportDomain, transportAddress, wholeMsg):
-        """Message dispatcher -- de-serialize message into PDU"""
+        """Message dispatcher -- de-serialize message into PDU."""
         # 4.2.1.1
         (snmpInPkts,) = self.mibInstrumController.mibBuilder.importSymbols(
             "__SNMPv2-MIB", "snmpInPkts"

--- a/pysnmp/proto/secmod/eso/priv/aes192.py
+++ b/pysnmp/proto/secmod/eso/priv/aes192.py
@@ -7,7 +7,7 @@ from pysnmp.proto.secmod.eso.priv import aesbase
 
 
 class AesBlumenthal192(aesbase.AbstractAesBlumenthal):
-    """AES 192 bit encryption (Internet draft)
+    """AES 192 bit encryption (Internet draft).
 
     Reeder AES encryption:
 
@@ -31,7 +31,7 @@ class AesBlumenthal192(aesbase.AbstractAesBlumenthal):
 
 
 class Aes192(aesbase.AbstractAesReeder):
-    """AES 192 bit encryption (Internet draft)
+    """AES 192 bit encryption (Internet draft).
 
     Reeder AES encryption with non-standard key localization algorithm
     borrowed from Reeder 3DES draft:

--- a/pysnmp/proto/secmod/eso/priv/aes256.py
+++ b/pysnmp/proto/secmod/eso/priv/aes256.py
@@ -7,7 +7,7 @@ from pysnmp.proto.secmod.eso.priv import aesbase
 
 
 class AesBlumenthal256(aesbase.AbstractAesBlumenthal):
-    """AES 256 bit encryption (Internet draft)
+    """AES 256 bit encryption (Internet draft).
 
     http://tools.ietf.org/html/draft-blumenthal-aes-usm-04
     """
@@ -29,7 +29,7 @@ class AesBlumenthal256(aesbase.AbstractAesBlumenthal):
 
 
 class Aes256(aesbase.AbstractAesReeder):
-    """AES 256 bit encryption (Internet draft)
+    """AES 256 bit encryption (Internet draft).
 
     Reeder AES encryption with non-standard key localization algorithm
     borrowed from Reeder 3DES draft:

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -192,7 +192,8 @@ class ZipMibSource(__AbstractMibSource):
         but without one a zip-installed MIB package cannot be enumerated at
         all, so it is read rather than done without.
 
-        Returns:
+        Returns
+        -------
             The mapping of member path to archive entry, or ``None`` for a
             loader that is not a zipimporter.
         """
@@ -370,7 +371,8 @@ def revisionOf(codeObj: Any) -> str | None:
     either -- ``dis`` reports what the module actually assigns, where a regex
     reports what its text looks like.
 
-    Returns:
+    Returns
+    -------
         The timestamp, or ``None`` for a module that states no revision --
         every SMIv1 module, and the SMI modules themselves.
     """
@@ -454,7 +456,8 @@ class MibBuilder:
     def getMibCorpus(self) -> Any:
         """The corpus this builder falls back to, or ``None``.
 
-        Returns:
+        Returns
+        -------
             The :py:class:`~pysnmp.smi.corpus.MibCorpus`, or ``None`` when
             none is configured -- which is the default and means this builder
             resolves exactly as it always has.
@@ -481,10 +484,12 @@ class MibBuilder:
                 :py:class:`~pysnmp.smi.corpus.MibCorpus`, or ``None`` to stop
                 using one
 
-        Returns:
+        Returns
+        -------
             This builder.
 
-        Raises:
+        Raises
+        ------
             SmiError: ``loadTexts`` is set and the corpus carries no prose.
                 Refused rather than silently satisfied: a caller that asked
                 for descriptions and got a module with none has no way to
@@ -507,7 +512,8 @@ class MibBuilder:
         Args:
             mibCorpus: the corpus about to be used, or ``None``
 
-        Raises:
+        Raises
+        ------
             SmiError: texts were asked for and the corpus has none.
         """
         if (
@@ -527,7 +533,8 @@ class MibBuilder:
         Args:
             modName: the module to build
 
-        Returns:
+        Returns
+        -------
             Whether it was built.
         """
         if self.__mibCorpus is None:
@@ -692,7 +699,7 @@ class MibBuilder:
         return [candidate for _, candidate in ordered]
 
     def loadModule(self, modName: str, **userCtx: Any) -> Any:
-        """Load and execute MIB modules as Python code"""
+        """Load and execute MIB modules as Python code."""
         if modName in self.__modSeen:
             # Already loaded, and loading is not idempotent: a MIB registers
             # its symbols as it runs, so executing a second copy over the first
@@ -767,7 +774,7 @@ class MibBuilder:
         return self
 
     def loadModules(self, *modNames: str, **userCtx: Any) -> Any:
-        """Load (optionally, compiling) pysnmp MIB modules"""
+        """Load (optionally, compiling) pysnmp MIB modules."""
         # Build a list of available modules. A dict rather than a set: it
         # de-duplicates across sources while keeping the order they were
         # searched in.

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -108,10 +108,12 @@ def oid_key(oid: Union[str, "tuple[int, ...]"]) -> bytes:
     Args:
         oid: dotted decimal, or arcs as integers
 
-    Returns:
+    Returns
+    -------
         The sort key.
 
-    Raises:
+    Raises
+    ------
         SmiError: the OID is not one, or an arc is out of range.
     """
     if isinstance(oid, str):
@@ -146,10 +148,12 @@ def oid_from_key(key: bytes) -> str:
     Args:
         key: the sort key
 
-    Returns:
+    Returns
+    -------
         The OID, dotted decimal.
 
-    Raises:
+    Raises
+    ------
         SmiError: the key is truncated.
     """
     arcs: list[str] = []
@@ -180,7 +184,8 @@ def subtree_bound(key: bytes) -> bytes:
     Args:
         key: an encoded OID
 
-    Returns:
+    Returns
+    -------
         The first key sorting above every descendant.
     """
     out = bytearray(key)
@@ -202,7 +207,8 @@ class MibCorpus:
     Args:
         path: the ``core.db`` to open
 
-    Raises:
+    Raises
+    ------
         SmiError: the file is missing, is not a corpus, or carries a schema
             version this pysnmp cannot read.
     """
@@ -354,7 +360,8 @@ class MibCorpus:
             key: ``schema_version``, ``corpus_version``, ``corpus_id``,
                 ``texts``, or one of the counts
 
-        Returns:
+        Returns
+        -------
             The value as a string, or ``None`` when the corpus carries none.
         """
         row = self._db.execute(self.QUERIES["meta"], (key,)).fetchone()
@@ -388,7 +395,8 @@ class MibCorpus:
         Args:
             name: the module's descriptor
 
-        Returns:
+        Returns
+        -------
             Its tier, MODULE-IDENTITY OID, revision, content hash and node
             count, or ``None`` when the corpus does not carry it.
         """
@@ -413,7 +421,8 @@ class MibCorpus:
         Args:
             identifier: ``type.id``, or ``None``
 
-        Returns:
+        Returns
+        -------
             The specification, or ``None``.
         """
         if identifier is None:
@@ -452,7 +461,8 @@ class MibCorpus:
         Args:
             oid: the OID to resolve
 
-        Returns:
+        Returns
+        -------
             The module name, or ``None`` when nothing claims a prefix of it.
             A miss is not an error: an unresolved OID still decodes
             structurally as far as the longest known prefix reaches.
@@ -481,7 +491,8 @@ class MibCorpus:
             module: which module's definition to take, where more than one
                 defines the OID. The first by name otherwise.
 
-        Returns:
+        Returns
+        -------
             The node, or ``None``.
         """
         key = oid_key(oid)
@@ -505,7 +516,8 @@ class MibCorpus:
             module: the module's descriptor
             name: the symbol's descriptor
 
-        Returns:
+        Returns
+        -------
             The node, or ``None``.
         """
         return self._node(
@@ -518,7 +530,8 @@ class MibCorpus:
         Args:
             oid: where to start, exclusive
 
-        Returns:
+        Returns
+        -------
             The next node, or ``None`` at the end of the corpus, which is
             ``endOfMibView`` and not an error.
         """
@@ -532,7 +545,8 @@ class MibCorpus:
         Args:
             oid: the subtree root
 
-        Returns:
+        Returns
+        -------
             The nodes, root first.
         """
         low = oid_key(oid)
@@ -550,7 +564,8 @@ class MibCorpus:
         Args:
             module: the module's descriptor
 
-        Returns:
+        Returns
+        -------
             The nodes.
         """
         return [
@@ -559,13 +574,15 @@ class MibCorpus:
         ]
 
     def symbols_of(self, module: str) -> list[dict[str, Any]]:
-        """Every type a module declares -- its TEXTUAL-CONVENTIONs and type
-        assignments -- in name order.
+        """Every type a module declares, in name order.
+
+        That is its TEXTUAL-CONVENTIONs and its type assignments.
 
         Args:
             module: the module's descriptor
 
-        Returns:
+        Returns
+        -------
             The symbols, each with its specification decoded.
         """
         return [
@@ -586,7 +603,8 @@ class MibCorpus:
             module: the module's descriptor
             name: the type's descriptor
 
-        Returns:
+        Returns
+        -------
             The symbol, or ``None``.
         """
         row = self._db.execute(self.QUERIES["symbol"], (module, name)).fetchone()
@@ -608,7 +626,8 @@ class MibCorpus:
         Args:
             module: the module's descriptor
 
-        Returns:
+        Returns
+        -------
             Symbol name to source module.
         """
         return dict(self._db.execute(self.QUERIES["imports_of"], (module,)))

--- a/pysnmp/smi/indices.py
+++ b/pysnmp/smi/indices.py
@@ -7,7 +7,7 @@ from bisect import bisect
 
 
 class OrderedDict(dict):
-    """Ordered dictionary used for indices"""
+    """Ordered dictionary used for indices."""
 
     def __init__(self, *args, **kwargs):
         self.__keys = []
@@ -104,7 +104,7 @@ class OrderedDict(dict):
 
 
 class OidOrderedDict(OrderedDict):
-    """OID-ordered dictionary used for indices"""
+    """OID-ordered dictionary used for indices."""
 
     def __init__(self, *args, **kwargs):
         self.__keysCache = {}

--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -430,7 +430,7 @@ class MibTree(ObjectType):
     #
 
     def getBranch(self, name, idx):
-        """Return a branch of this tree where the 'name' OID may reside"""
+        """Return a branch of this tree where the 'name' OID may reside."""
         for keyLen in self._vars.getKeysLens():
             subName = name[:keyLen]
             if subName in self._vars:
@@ -454,14 +454,14 @@ class MibTree(ObjectType):
                 raise error.NoSuchObjectError(idx=idx, name=name) from exc
 
     def getNode(self, name, idx=None):
-        """Return tree node found by name"""
+        """Return tree node found by name."""
         if name == self.name:
             return self
         else:
             return self.getBranch(name, idx).getNode(name, idx)
 
     def getNextNode(self, name, idx=None):
-        """Return tree node next to name"""
+        """Return tree node next to name."""
         try:
             nextNode = self.getBranch(name, idx)
         except (error.NoSuchInstanceError, error.NoSuchObjectError):
@@ -1119,8 +1119,9 @@ class MibTableColumn(MibScalar):
 
 
 class MibTableRow(MibTree):
-    """MIB table row (SMI 'Entry'). Manages a set of table columns.
-    Implements row creation/destruction.
+    """MIB table row (SMI 'Entry').
+
+    Manages a set of table columns and implements row creation/destruction.
     """
 
     def __init__(self, name):
@@ -1375,7 +1376,7 @@ class MibTableRow(MibTree):
     # Table index management
 
     def getIndicesFromInstId(self, instId):
-        """Return index values for instance identification"""
+        """Return index values for instance identification."""
         if instId in self.__idToIdxCache:
             return self.__idToIdxCache[instId]
 
@@ -1407,7 +1408,7 @@ class MibTableRow(MibTree):
         return indices
 
     def getInstIdFromIndices(self, *indices):
-        """Return column instance identification from indices"""
+        """Return column instance identification from indices."""
         try:
             return self.__idxToIdCache[indices]
         except TypeError:
@@ -1430,11 +1431,11 @@ class MibTableRow(MibTree):
     # Table access by index
 
     def getInstNameByIndex(self, colId, *indices):
-        """Build column instance name from components"""
+        """Build column instance name from components."""
         return self.name + (colId,) + self.getInstIdFromIndices(*indices)
 
     def getInstNamesByIndex(self, *indices):
-        """Build column instance names from indices"""
+        """Build column instance names from indices."""
         instNames = []
         for columnName in self._vars:
             instNames.append(self.getInstNameByIndex(*(columnName[-1],) + indices))
@@ -1513,7 +1514,7 @@ class MibTableRow(MibTree):
 
 
 class MibTable(MibTree):
-    """MIB table. Manages a set of TableRow's"""
+    """MIB table. Manages a set of TableRow's."""
 
     def __init__(self, name):
         MibTree.__init__(self, name)

--- a/pysnmp/smi/mibs/SNMPv2-TC.py
+++ b/pysnmp/smi/mibs/SNMPv2-TC.py
@@ -74,7 +74,7 @@ class TextualConvention:
         return self.clone(value)
 
     def prettyOut(self, value):  # override asn1 type method
-        """Implements DISPLAY-HINT evaluation"""
+        """Implements DISPLAY-HINT evaluation."""
         if self.displayHint and (
             self.__integer.isSuperTypeOf(self, matchConstraints=False)
             and not self.namedValues
@@ -215,7 +215,7 @@ class TextualConvention:
         raise SmiError("TEXTUAL-CONVENTION has no underlying SNMP base type")
 
     def prettyIn(self, value):  # override asn1 type method
-        """Implements DISPLAY-HINT parsing into base SNMP value
+        """Implements DISPLAY-HINT parsing into base SNMP value.
 
         Proper parsing seems impossible due to ambiguities.
         Here we are trying to do our best, but be prepared
@@ -542,8 +542,9 @@ class RowPointer(TextualConvention, ObjectIdentifier):
 
 
 class RowStatus(TextualConvention, Integer):
-    """A special kind of scalar MIB variable responsible for
-    MIB table row creation/destruction.
+    """A special kind of scalar MIB variable.
+
+    Responsible for MIB table row creation/destruction.
     """
 
     description = "The RowStatus textual convention is used to manage the creation and deletion of conceptual rows, and is used as the value of the SYNTAX clause for the status column of a conceptual row (as described in Section 7.7.1 of [2].)..."

--- a/pysnmp/smi/mibs/behavior/__init__.py
+++ b/pysnmp/smi/mibs/behavior/__init__.py
@@ -119,7 +119,8 @@ def apply(module: str, namespace: dict[str, Any]) -> bool:
         namespace: the loaded module's globals -- what its own symbols are
             bound in, which is what the fragment reads and writes
 
-    Returns:
+    Returns
+    -------
         Whether a fragment ran.
     """
     path = _fragments().get(module)

--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -50,7 +50,7 @@ class ObjectIdentity:
           :py:obj:`int` values representing MIB variable instance
           identification.
 
-    Other parameters
+    Other Parameters
     ----------------
     kwargs
         MIB resolution options(object):
@@ -95,7 +95,7 @@ class ObjectIdentity:
         self.__mibNode = None
 
     def getMibSymbol(self):
-        """Returns MIB variable symbolic identification.
+        """Return MIB variable symbolic identification.
 
         Returns
         -------
@@ -131,7 +131,7 @@ class ObjectIdentity:
             raise SmiError(f"{self.__class__.__name__} object not fully initialized")
 
     def getOid(self):
-        """Returns OID identifying MIB variable.
+        """Return OID identifying MIB variable.
 
         Returns
         -------
@@ -161,7 +161,7 @@ class ObjectIdentity:
             raise SmiError(f"{self.__class__.__name__} object not fully initialized")
 
     def getLabel(self):
-        """Returns symbolic path to this MIB variable.
+        """Return symbolic path to this MIB variable.
 
         Meaning a sequence of symbolic identifications for each of parent
         MIB objects in MIB tree.
@@ -213,7 +213,7 @@ class ObjectIdentity:
     #
 
     def addAsn1MibSource(self, *asn1Sources, **kwargs):
-        """Adds path to a repository to search ASN.1 MIB files.
+        """Add path to a repository to search ASN.1 MIB files.
 
         Parameters
         ----------
@@ -253,7 +253,7 @@ class ObjectIdentity:
         return self
 
     def addMibSource(self, *mibSources):
-        """Adds path to repository to search PySNMP MIB files.
+        """Add path to repository to search PySNMP MIB files.
 
         Parameters
         ----------
@@ -764,7 +764,7 @@ class ObjectType:
         return self.__state & self.stClean
 
     def addAsn1MibSource(self, *asn1Sources, **kwargs):
-        """Adds path to a repository to search ASN.1 MIB files.
+        """Add path to a repository to search ASN.1 MIB files.
 
         Parameters
         ----------
@@ -797,7 +797,7 @@ class ObjectType:
         return self
 
     def addMibSource(self, *mibSources):
-        """Adds path to repository to search PySNMP MIB files.
+        """Add path to repository to search PySNMP MIB files.
 
         Parameters
         ----------
@@ -962,7 +962,7 @@ class ObjectType:
         return self
 
     def getUnits(self):
-        """Returns UNITS clause value from the resolved MIB node.
+        """Return UNITS clause value from the resolved MIB node.
 
         Returns
         -------
@@ -1078,7 +1078,7 @@ class NotificationType:
         return f"{self.__class__.__name__}({self.__objectIdentity!r}, {self.__instanceIndex!r}, {self.__objects!r})"
 
     def addVarBinds(self, *varBinds):
-        """Appends variable-binding to notification.
+        """Append variable-binding to notification.
 
         Parameters
         ----------
@@ -1115,7 +1115,7 @@ class NotificationType:
         return self
 
     def addAsn1MibSource(self, *asn1Sources, **kwargs):
-        """Adds path to a repository to search ASN.1 MIB files.
+        """Add path to a repository to search ASN.1 MIB files.
 
         Parameters
         ----------
@@ -1148,7 +1148,7 @@ class NotificationType:
         return self
 
     def addMibSource(self, *mibSources):
-        """Adds path to repository to search PySNMP MIB files.
+        """Add path to repository to search PySNMP MIB files.
 
         Parameters
         ----------

--- a/pysnmp/smi/synthesis.py
+++ b/pysnmp/smi/synthesis.py
@@ -221,7 +221,7 @@ class _Resolver:
 
     @property
     def imports(self) -> dict[str, str]:
-        """This module's IMPORTS, as symbol to the module defining it."""
+        """The module's IMPORTS, as symbol to the module defining it."""
         return self._imports
 
     def declare(self, name: str, cls: Any) -> None:
@@ -248,10 +248,12 @@ class _Resolver:
         Args:
             name: the type name as the MIB declares it
 
-        Returns:
+        Returns
+        -------
             The class.
 
-        Raises:
+        Raises
+        ------
             SmiError: nothing defines the name. Loudly, rather than
                 substituting a base type: a column silently typed
                 ``OctetString`` instead of its TEXTUAL-CONVENTION renders
@@ -321,7 +323,8 @@ class _Resolver:
             module: where to look
             name: the symbol
 
-        Returns:
+        Returns
+        -------
             The symbol, or ``None``.
         """
         try:
@@ -344,7 +347,8 @@ class _Resolver:
         Args:
             spec: a corpus type specification
 
-        Returns:
+        Returns
+        -------
             A single constraint, or a union of several.
         """
         declared = spec.get("constraints") or {}
@@ -391,7 +395,8 @@ def synthesize_type(resolver: "_Resolver", spec: dict[str, Any]) -> Any:
         resolver: the module's resolver
         spec: a corpus type specification
 
-    Returns:
+    Returns
+    -------
         An instance ready to be handed to a ``MibScalar`` or a column.
     """
     if not spec.get("type"):
@@ -586,11 +591,13 @@ def load_module(builder: Any, corpus: Any, modName: str) -> bool:
         corpus: an open :py:class:`~pysnmp.smi.corpus.MibCorpus`
         modName: the module to build
 
-    Returns:
+    Returns
+    -------
         Whether the corpus carried the module. ``False`` leaves the builder
         untouched, so a caller can go on looking elsewhere.
 
-    Raises:
+    Raises
+    ------
         SmiError: the corpus carries the module but it could not be built --
             an unresolvable type, an OBJECT-TYPE the runtime has no class for.
             Loudly on purpose: a half-built module resolves some OIDs and not

--- a/pysnmp/smi/view.py
+++ b/pysnmp/smi/view.py
@@ -165,7 +165,7 @@ class MibViewController:
     # MIB tree node management
 
     def __getOidLabel(self, nodeName, oidToLabelIdx, labelToOidIdx):
-        """getOidLabel(nodeName) -> (oid, label, suffix)"""
+        """getOidLabel(nodeName) -> (oid, label, suffix)."""
         if not nodeName:
             return nodeName, nodeName, ()
         if nodeName in labelToOidIdx:

--- a/tools/iana_pen_to_mib.py
+++ b/tools/iana_pen_to_mib.py
@@ -16,7 +16,7 @@
 #
 # The generated MIB module can be loaded by MibBuilder.load_modules().
 #
-"""Parse IANA Private Enterprise Numbers and generate a pysnmp MIB module.
+r"""Parse IANA Private Enterprise Numbers and generate a pysnmp MIB module.
 
 The IANA PEN registry maps integer enterprise numbers to organization
 names.  This tool reads the registry (from a local file or the IANA

--- a/tools/regenerate_mibs.py
+++ b/tools/regenerate_mibs.py
@@ -47,7 +47,7 @@ OUTPUT_DIR = os.path.join(_ROOT, "pysnmp", "smi", "mibs")
 
 
 def _dependency_asn1() -> str:
-    """pysmi's bundled ASN.1, for the standard modules these import from."""
+    """Pysmi's bundled ASN.1, for the standard modules these import from."""
     return os.path.join(os.path.dirname(pysmi.__file__), "mibs", "asn1")
 
 
@@ -57,10 +57,12 @@ def render(*modules: str) -> dict[str, str]:
     Args:
         modules: module names; defaults to :py:data:`MODULES`
 
-    Returns:
+    Returns
+    -------
         Module name to rendered Python.
 
-    Raises:
+    Raises
+    ------
         RuntimeError: a module did not compile.
     """
     wanted = modules or MODULES


### PR DESCRIPTION
Refs #186. Stage 1 of the staged adoption the issue describes.

pysnmp now runs the same ruff rule set as pyasn1 and pysmi, `D` included, with
`convention = "numpy"` — what pyasn1 uses, and what the Sphinx build already assumes
(`conf.py` sets `napoleon_numpy_docstring = True`). Picking a convention also settles
D203/D211 and D212/D213, the mutually exclusive pairs ruff had been warning about on
every run.

**241 violations → 0.**

## What is on, and what is not

Enabled: the shape of the docstrings that already exist — summary line, section
headings, punctuation, mood.

Still ignored: `D100`–`D107`, the requirement that every public thing *have* a
docstring. That is ~790 items. Writing 347 method docstrings mechanically produces
noise, not documentation — the issue says this and it is right. The ignore list names
each rule with its count so they come off one at a time:

| rule | count | what it wants |
|---|---|---|
| D100/D104 | 108 | modules and packages |
| D101 | 183 | classes |
| D103/D107 | 104 | functions and constructors |
| D102 | 347 | methods — probably by subpackage |
| D105 | 55 | magic methods |

So the issue stays open, with the config now shaped so each remaining stage is a
one-line change plus its prose.

## Three things worth reviewing

**The D400 autofix broke 17 example titles.** It appends a period to a docstring's last
line. In `examples/` that line is the `+++++` underline of an RST title that
`docs/source/examples/**.rst` includes verbatim:

```
SNMPv1 TRAP with defaults
+++++++++++++++++++++++++.
```

Caught by the D205 that the corruption then triggered. Reverted, and `examples/` now
ignores `D` — which is what pyasn1 does with its own examples, for this reason.

**Three modules were writing Google-style sections that Sphinx never parsed.**
`smi/corpus.py`, `smi/synthesis.py` and `smi/builder.py` use `Args:`/`Returns:`, and
`conf.py` sets `napoleon_google_docstring = False`. Converted to numpy. To be accurate
about the benefit: this is consistency, not a rendering fix — of the three only
`MibBuilder` is autodocumented, and not on the members that carried those sections. The
rendered section count is identical before and after.

**D401 is the one rule pyasn1 keeps that this does not**, and the only difference
between the two rule sets. Every third-person summary it caught was fixed — 15 of them,
`Returns the`, `Adds a`, `Creates a`. What is left is 25 accessors and properties whose
summary is a noun phrase naming what you get back:

> `"The corpus this builder falls back to, or ``None``."`

Rewriting that as *"Return the corpus…"* is longer, says less, and for a property
describes a call the reader does not make. D401 also misfires on an imperative opening
with an adverb (`"Synchronously call …"`). Happy to fix all 25 instead if you would
rather have parity with pyasn1 than the shorter summaries.

## Also

- `tests/**` ignores `D` — a test docstring says what the test establishes, a fixture's
  names what it hands back; neither is an imperative summary of a public API. pyasn1
  does the same.
- `pysnmp/smi/mibs/**` ignores `D` — mostly generated, and `regenerate_mibs.py` would
  overwrite any edit made to satisfy a lint. The hand-written modules in that directory
  satisfy the enabled rules anyway, checked with the ignore lifted, so it is not
  load-bearing for them.

## Verification

- `ruff check` clean, and no more D203/D211 conflict warnings
- `1174 passed, 12 skipped`
- `mypy` clean
- `sphinx-build -n -W --keep-going` clean
- No `^[+=~-]{4,}\.$` anywhere in the tree — the corrupted-underline check