### PR TITLE
docs: say what every module and package is for (D100/D104)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
+"""Sphinx configuration for the pysnmp documentation build."""
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,23 +211,21 @@ ignore = [
     "S509",     # snmp-weak-cryptography
 
     # The docstring family, adopted in stages -- see #186. What is on now is
-    # the shape of the docstrings that exist: summary line, section headings,
-    # punctuation. What is still off is the requirement that every public
-    # thing have one, which is ~790 items across the package and is a
-    # documentation project rather than a lint fix. Writing 347 method
-    # docstrings mechanically produces noise, not documentation.
+    # the shape of the docstrings that exist, plus D100/D104: every module and
+    # package says what it is for. What is still off is the requirement that
+    # every public class, function and method have one, which is ~690 items
+    # and is a documentation project rather than a lint fix. Writing 347
+    # method docstrings mechanically produces noise, not documentation.
     #
     # These come off one rule at a time, each its own reviewable change:
-    #   D100/D104  108 modules and packages
+    #   D100/D104  104 modules and packages -- done
     #   D101       183 classes
     #   D103/D107  104 functions and constructors
     #   D102       347 methods, probably by subpackage
     #   D105        55 magic methods
-    "D100",     # undocumented-public-module
     "D101",     # undocumented-public-class
     "D102",     # undocumented-public-method
     "D103",     # undocumented-public-function
-    "D104",     # undocumented-public-package
     "D105",     # undocumented-magic-method
     "D107",     # undocumented-public-init
 

--- a/pysnmp/__init__.py
+++ b/pysnmp/__init__.py
@@ -1,3 +1,11 @@
+"""A pure-Python SNMP v1/v2c/v3 engine.
+
+`pysnmp.hlapi` is the entry point for most callers. `pysnmp.entity` holds the
+engine those calls are built on, `pysnmp.proto` the message processing and
+security models, `pysnmp.smi` the MIB machinery, and `pysnmp.carrier` the
+transports.
+"""
+
 # http://www.python.org/dev/peps/pep-0396/
 __version__ = "6.0.0-rc.10"
 # another variable is required to prevent semantic release from updating version in more than one place

--- a/pysnmp/cache.py
+++ b/pysnmp/cache.py
@@ -5,10 +5,19 @@
 #
 # Limited-size dictionary-like class to use for caches
 #
+"""A bounded mapping that evicts the least-used entries when it fills up."""
 
 
 class Cache:
+    """A dictionary that never grows past a fixed number of entries.
+
+    Reads are counted. When the cache is full, the tenth of its entries with
+    the fewest reads is dropped to make room, so an entry earns its place by
+    being looked up rather than by being recent.
+    """
+
     def __init__(self, maxSize=256):
+        """Make a cache holding at most `maxSize` entries."""
         self.__maxSize = maxSize
         self.__size = 0
         self.__chopSize = maxSize // 10
@@ -17,16 +26,20 @@ class Cache:
         self.__usage = {}
 
     def __contains__(self, k):
+        """Whether `k` is cached, without counting it as a read."""
         return k in self.__cache
 
     def __getitem__(self, k):
+        """The value cached under `k`, counting the lookup against eviction."""
         self.__usage[k] += 1
         return self.__cache[k]
 
     def __len__(self):
+        """How many entries are cached."""
         return self.__size
 
     def __setitem__(self, k, v):
+        """Cache `v` under `k`, evicting the least-used entries if full."""
         if self.__size >= self.__maxSize:
             usageKeys = sorted(self.__usage, key=lambda x, d=self.__usage: d[x])
             for _k in usageKeys[: self.__chopSize]:
@@ -39,6 +52,7 @@ class Cache:
         self.__cache[k] = v
 
     def __delitem__(self, k):
+        """Drop `k` and forget how often it was read."""
         del self.__cache[k]
         del self.__usage[k]
         self.__size -= 1

--- a/pysnmp/carrier/__init__.py
+++ b/pysnmp/carrier/__init__.py
@@ -1,1 +1,6 @@
 # This file is necessary to make this directory a package.
+"""Transports: how an SNMP message reaches the network and comes back.
+
+`base` states what a transport and a dispatcher have to do; `asyncio` is the
+implementation the engine uses, over UDP, UDP/IPv6 and Unix domain sockets.
+"""

--- a/pysnmp/carrier/asyncio/__init__.py
+++ b/pysnmp/carrier/asyncio/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""Transports and a dispatcher built on `asyncio`."""

--- a/pysnmp/carrier/asyncio/base.py
+++ b/pysnmp/carrier/asyncio/base.py
@@ -29,6 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
+"""What every asyncio transport shares: the loop it runs on and its lifecycle."""
+
 from pysnmp.carrier.asyncio.dispatch import AsyncioDispatcher
 from pysnmp.carrier.base import AbstractTransport
 

--- a/pysnmp/carrier/asyncio/dgram/__init__.py
+++ b/pysnmp/carrier/asyncio/dgram/__init__.py
@@ -1,4 +1,6 @@
 # This file is necessary to make this directory a package.
+"""Connectionless transports -- UDP, UDP/IPv6 and Unix domain datagrams."""
+
 from pysnmp.carrier.asyncio.dgram import udp, udp6, unix
 
 __all__ = ["udp", "udp6", "unix"]

--- a/pysnmp/carrier/asyncio/dgram/base.py
+++ b/pysnmp/carrier/asyncio/dgram/base.py
@@ -29,6 +29,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
+"""The datagram protocol every connectionless asyncio transport is built on.
+
+Handles the parts that do not vary with address family: opening the socket,
+queueing sends until the loop connects it, and handing what arrives to the
+callback the dispatcher registered.
+"""
+
 import asyncio
 import socket
 import traceback

--- a/pysnmp/carrier/asyncio/dgram/udp.py
+++ b/pysnmp/carrier/asyncio/dgram/udp.py
@@ -29,6 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
+"""SNMP over UDP/IPv4, transport domain 1.3.6.1.6.1.1."""
+
 import socket
 
 from pysnmp.carrier.asyncio.dgram.base import DgramAsyncioProtocol

--- a/pysnmp/carrier/asyncio/dgram/udp6.py
+++ b/pysnmp/carrier/asyncio/dgram/udp6.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""SNMP over UDP/IPv6, transport domain 1.3.6.1.2.1.100.1.2."""
+
 import socket
 
 from pysnmp.carrier.asyncio.dgram.base import DgramAsyncioProtocol

--- a/pysnmp/carrier/asyncio/dgram/unix.py
+++ b/pysnmp/carrier/asyncio/dgram/unix.py
@@ -3,6 +3,11 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""SNMP over Unix domain datagram sockets, transport domain 1.3.6.1.2.1.100.1.13.
+
+Not available on Windows, which has no `AF_UNIX`.
+"""
+
 import os
 import socket
 import tempfile

--- a/pysnmp/carrier/asyncio/dispatch.py
+++ b/pysnmp/carrier/asyncio/dispatch.py
@@ -29,6 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
+"""The asyncio transport dispatcher: the loop the engine's I/O runs on."""
+
 import asyncio
 import traceback
 

--- a/pysnmp/carrier/base.py
+++ b/pysnmp/carrier/base.py
@@ -4,6 +4,13 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""What a transport and a transport dispatcher have to provide.
+
+A dispatcher owns the event loop, routes an inbound message to whoever
+registered for that transport domain, and runs timer callbacks. A transport
+moves bytes for one domain. Nothing here is asyncio-specific.
+"""
+
 import functools
 
 from pysnmp.carrier import error

--- a/pysnmp/carrier/error.py
+++ b/pysnmp/carrier/error.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Errors raised by transports and dispatchers."""
+
 from pysnmp import error
 
 

--- a/pysnmp/carrier/sockfix.py
+++ b/pysnmp/carrier/sockfix.py
@@ -3,6 +3,13 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Socket constants Python does not define on every platform.
+
+A few of the options `sockmsg` needs are missing from `socket` depending on
+the platform and Python build. This patches in the numeric values rather than
+letting an `AttributeError` surface far from the cause.
+"""
+
 import socket
 
 from pysnmp import debug

--- a/pysnmp/carrier/sockmsg.py
+++ b/pysnmp/carrier/sockmsg.py
@@ -14,6 +14,14 @@
 # Parts of the code below is taken from:
 # http://carnivore.it/2012/10/12/python3.3_sendmsg_and_recvmsg
 #
+"""`sendto`/`recvfrom` that also carry the local address.
+
+Built on POSIX `sendmsg()`/`recvmsg()`. Two things the plain calls cannot do:
+report which local address a datagram actually arrived on, which matters when
+listening on 0.0.0.0 or [::], and set the source address on the way out, which
+is what transparent proxying needs.
+"""
+
 import ctypes
 import ipaddress
 import socket

--- a/pysnmp/debug.py
+++ b/pysnmp/debug.py
@@ -3,6 +3,13 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Debug logging, switched on per subsystem.
+
+`setLogger(Debug('io', 'msgproc'))` turns on tracing for the named areas; the
+flags below are the areas. When debugging is off the calls go to `DebugOff`,
+which costs a bound-method lookup and nothing else.
+"""
+
 import logging
 
 # octs2ints replaced with list() (bytes is already iterable of ints in Python 3)

--- a/pysnmp/entity/__init__.py
+++ b/pysnmp/entity/__init__.py
@@ -1,1 +1,7 @@
 # This file is necessary to make this directory a package.
+"""The SNMP engine and the applications that run on it.
+
+`engine` holds the engine itself, `config` writes the local configuration
+datastore it reads, and `rfc3413` holds the standard applications: command
+generator and responder, notification originator and receiver.
+"""

--- a/pysnmp/entity/config.py
+++ b/pysnmp/entity/config.py
@@ -4,6 +4,14 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Writing the local configuration datastore the engine reads.
+
+Everything the engine needs to know -- transports, v1/v2c communities, USM
+users, targets, notification and access policy -- is stored in MIB tables.
+These functions are the supported way to write those tables, rather than
+setting the columns directly.
+"""
+
 import warnings
 from typing import Any
 
@@ -137,7 +145,8 @@ def __checkLegacyVersions(snmpEngine: Any) -> None:
     Args:
         snmpEngine: the engine being configured
 
-    Raises:
+    Raises
+    ------
         PySnmpError: the engine was built with v1/v2c disabled.
     """
     # getattr, because an engine is duck-typed in places and a caller may pass

--- a/pysnmp/entity/engine.py
+++ b/pysnmp/entity/engine.py
@@ -4,6 +4,13 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""The SNMP engine: what every application is built on.
+
+An `SnmpEngine` owns the engine ID, the message and PDU dispatcher, the
+message processing and security models, the MIB instrumentation, and the
+transport dispatcher. One engine can serve a manager, an agent, or both.
+"""
+
 import os
 import shutil
 import tempfile
@@ -45,7 +52,8 @@ def _legacyVersionsEnabledByDefault() -> bool:
     environment says now rather than what it said when this module was first
     imported.
 
-    Returns:
+    Returns
+    -------
         False only when the environment asks for v1/v2c to be off.
     """
     return os.environ.get(LEGACY_VERSIONS_ENV, "").strip().lower() not in _TRUTHY

--- a/pysnmp/entity/observer.py
+++ b/pysnmp/entity/observer.py
@@ -4,6 +4,13 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Watching the engine's internals from outside, at named points in its work.
+
+An observer registered for an execution point is called with the engine's
+state as it passes through, which is how an application reaches values that
+are not part of any public return.
+"""
+
 from collections.abc import Iterator, MutableMapping
 from contextlib import contextmanager
 from typing import Any

--- a/pysnmp/entity/rfc3413/__init__.py
+++ b/pysnmp/entity/rfc3413/__init__.py
@@ -1,1 +1,6 @@
 # This file is necessary to make this directory a package.
+"""The standard SNMP applications of RFC 3413.
+
+Command generator and responder, notification originator and receiver, plus
+the context and target configuration they read.
+"""

--- a/pysnmp/entity/rfc3413/cmdgen.py
+++ b/pysnmp/entity/rfc3413/cmdgen.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""The command generator: the manager side that sends requests and retries them."""
+
 from collections.abc import Callable
 from typing import Any
 

--- a/pysnmp/entity/rfc3413/cmdrsp.py
+++ b/pysnmp/entity/rfc3413/cmdrsp.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""The command responder: the agent side that answers requests from the MIB."""
+
 from pyasn1.type import tag
 
 import pysnmp.smi.error

--- a/pysnmp/entity/rfc3413/config.py
+++ b/pysnmp/entity/rfc3413/config.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Reading target, notification and filter configuration back out of the MIB."""
+
 from pysnmp.entity import config
 from pysnmp.smi.error import NoSuchInstanceError, SmiError
 

--- a/pysnmp/entity/rfc3413/context.py
+++ b/pysnmp/entity/rfc3413/context.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The SNMPv3 context: which engine and which named view a request applies to."""
+
 from pyasn1.type import univ
 
 from pysnmp import debug, error

--- a/pysnmp/entity/rfc3413/mibvar.py
+++ b/pysnmp/entity/rfc3413/mibvar.py
@@ -6,6 +6,12 @@
 # THESE FUNCTIONS ARE OBSOLETE AND MUST NOT BE USED!
 # USE pysnmp.entity.rfc3413.oneliner.mibvar INSTEAD
 #
+"""Obsolete MIB variable helpers.
+
+Superseded by `pysnmp.smi.rfc1902`. Kept so old code keeps importing; do not
+use for anything new.
+"""
+
 from pyasn1.type import univ
 
 from pysnmp.smi.error import NoSuchObjectError

--- a/pysnmp/entity/rfc3413/ntforg.py
+++ b/pysnmp/entity/rfc3413/ntforg.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""The notification originator: sending traps and informs to configured targets."""
+
 from collections.abc import Callable
 from typing import Any
 

--- a/pysnmp/entity/rfc3413/ntfrcv.py
+++ b/pysnmp/entity/rfc3413/ntfrcv.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""The notification receiver: accepting traps and informs and handing them on."""
+
 from pysnmp import debug
 from pysnmp.proto import error, rfc3411
 from pysnmp.proto.api import v1, v2c  # backend is always SMIv2 compliant

--- a/pysnmp/entity/rfc3413/oneliner/__init__.py
+++ b/pysnmp/entity/rfc3413/oneliner/__init__.py
@@ -1,1 +1,6 @@
 # This file is necessary to make this directory a package.
+"""Obsolete compatibility wrappers.
+
+Superseded by `pysnmp.hlapi`. Kept so old code keeps importing; do not use for
+anything new.
+"""

--- a/pysnmp/entity/rfc3413/oneliner/cmdgen.py
+++ b/pysnmp/entity/rfc3413/oneliner/cmdgen.py
@@ -6,6 +6,8 @@
 # All code in this file belongs to obsolete, compatibility wrappers.
 # Never use interfaces below for new applications!
 #
+"""Obsolete command generator wrappers. Use `pysnmp.hlapi` instead."""
+
 from pyasn1.type import univ
 
 from pysnmp.entity.engine import SnmpEngine

--- a/pysnmp/entity/rfc3413/oneliner/ntforg.py
+++ b/pysnmp/entity/rfc3413/oneliner/ntforg.py
@@ -6,6 +6,8 @@
 # All code in this file belongs to obsolete, compatibility wrappers.
 # Never use interfaces below for new applications!
 #
+"""Obsolete notification originator wrappers. Use `pysnmp.hlapi` instead."""
+
 from pysnmp.entity import config
 from pysnmp.entity.engine import SnmpEngine
 from pysnmp.entity.rfc3413 import context

--- a/pysnmp/error.py
+++ b/pysnmp/error.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The exception and warning types every other pysnmp module raises."""
 
 
 class PySnmpCryptoWarning(UserWarning):
@@ -48,6 +49,7 @@ class PySnmpError(Exception):
         return (type(cause), cause, cause.__traceback__)
 
     def __str__(self) -> str:
+        """The message, with the exception this was raised from appended."""
         msg = super().__str__()
         cause = self._chained
         if cause is None:

--- a/pysnmp/hlapi/__init__.py
+++ b/pysnmp/hlapi/__init__.py
@@ -3,6 +3,13 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The high-level API: what most callers should import.
+
+Re-exports the synchronous facade over the asyncio API, so `getCmd` and
+friends here block, while the same names under `pysnmp.hlapi.asyncio` are
+coroutines.
+"""
+
 from pysnmp.entity.engine import SnmpEngine
 from pysnmp.hlapi import auth
 from pysnmp.hlapi.asyncio.device import DeviceReport as DeviceReport

--- a/pysnmp/hlapi/asyncio/__init__.py
+++ b/pysnmp/hlapi/asyncio/__init__.py
@@ -3,6 +3,11 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The high-level API as coroutines.
+
+Same calls as `pysnmp.hlapi`, awaited rather than blocking.
+"""
+
 from pysnmp.entity.engine import SnmpEngine
 from pysnmp.hlapi.asyncio.cmdgen import bulkCmd, getCmd, isEndOfMib, nextCmd, setCmd
 from pysnmp.hlapi.asyncio.device import (

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+"""GET, GETNEXT, GETBULK and SET as coroutines."""
+
 import asyncio
 from typing import Any
 

--- a/pysnmp/hlapi/asyncio/ntforg.py
+++ b/pysnmp/hlapi/asyncio/ntforg.py
@@ -8,6 +8,8 @@
 #          Zachary Lorusso <zlorusso@gmail.com>
 #
 
+"""Sending traps and informs as a coroutine."""
+
 import asyncio
 from typing import Any
 

--- a/pysnmp/hlapi/asyncio/sync/__init__.py
+++ b/pysnmp/hlapi/asyncio/sync/__init__.py
@@ -1,3 +1,5 @@
+"""The synchronous facade: the same calls, run to completion on a private loop."""
+
 from pysnmp.hlapi.asyncio.sync.cmdgen import bulkCmd, getCmd, nextCmd, setCmd
 from pysnmp.hlapi.asyncio.sync.device import get_device_report, getDeviceReport
 from pysnmp.hlapi.asyncio.sync.ntforg import sendNotification

--- a/pysnmp/hlapi/asyncio/sync/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/sync/cmdgen.py
@@ -1,3 +1,10 @@
+"""Blocking GET, GETNEXT, GETBULK and SET.
+
+Each runs the asyncio call on a loop of its own, so these are usable from code
+that has no event loop. Calling one from inside a running loop raises rather
+than deadlocking.
+"""
+
 import asyncio
 from collections.abc import Iterator
 from typing import Any

--- a/pysnmp/hlapi/asyncio/sync/ntforg.py
+++ b/pysnmp/hlapi/asyncio/sync/ntforg.py
@@ -1,3 +1,5 @@
+"""Blocking trap and inform delivery."""
+
 import asyncio
 
 from pysnmp.hlapi.asyncio import ntforg

--- a/pysnmp/hlapi/asyncio/transport.py
+++ b/pysnmp/hlapi/asyncio/transport.py
@@ -4,6 +4,12 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Where to send a request: UDP, UDP/IPv6 and Unix domain targets.
+
+A target pairs a transport with an address, and resolves a hostname to one
+before the engine needs it.
+"""
+
 import socket
 from typing import cast
 

--- a/pysnmp/hlapi/auth.py
+++ b/pysnmp/hlapi/auth.py
@@ -4,6 +4,12 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Who the request claims to be: community strings and USM users.
+
+`CommunityData` carries a v1/v2c community, `UsmUserData` a v3 user with its
+authentication and privacy protocols and keys.
+"""
+
 from typing import Any, NoReturn
 
 from pysnmp import error

--- a/pysnmp/hlapi/context.py
+++ b/pysnmp/hlapi/context.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""The SNMPv3 context a request is asked in: engine ID and context name."""
+
 from dataclasses import dataclass
 from typing import Any
 

--- a/pysnmp/hlapi/lcd.py
+++ b/pysnmp/hlapi/lcd.py
@@ -3,6 +3,13 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Turning high-level credentials into the engine's own configuration.
+
+The local configuration datastore is what the engine actually reads. These
+configurators write `CommunityData` and `UsmUserData` into it, and cache what
+they wrote so repeating a call does not re-register anything.
+"""
+
 from typing import Any
 
 from pysnmp import error, nextid

--- a/pysnmp/hlapi/transport.py
+++ b/pysnmp/hlapi/transport.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""What a transport target has to provide, independent of address family."""
+
 from typing import Any, Generic, TypeVar
 
 from pysnmp import error

--- a/pysnmp/hlapi/varbinds.py
+++ b/pysnmp/hlapi/varbinds.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Resolving variable bindings against the MIB, in both directions."""
+
 from typing import Any
 
 from pysnmp.smi import view

--- a/pysnmp/nextid.py
+++ b/pysnmp/nextid.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Generators for the counters SNMP identifiers are drawn from."""
+
 import secrets
 
 
@@ -10,6 +12,11 @@ class Integer:
     """Return a next value in a reasonably MT-safe manner."""
 
     def __init__(self, maximum, increment=256):
+        """Draw from a bank of `increment` values, wrapping at `maximum`.
+
+        The first value is chosen at random rather than from zero, so two
+        engines started at the same moment do not issue the same identifiers.
+        """
         self.__maximum = maximum
         increment = min(maximum, increment)
         self.__increment = increment
@@ -18,9 +25,15 @@ class Integer:
         self.__bank = list(range(e, e + self.__increment))
 
     def __repr__(self):
+        """The constructor call that would rebuild this generator."""
         return f"{self.__class__.__name__}({self.__maximum}, {self.__increment})"
 
     def __call__(self):
+        """The next value, refilling the bank when it runs low.
+
+        Refilling is safe unless roughly `increment / 2` threads reach it at
+        once, which is the sense in which this is only reasonably MT-safe.
+        """
         v = self.__bank.pop(0)
         if v % self.__threshold:
             return v

--- a/pysnmp/proto/__init__.py
+++ b/pysnmp/proto/__init__.py
@@ -1,1 +1,7 @@
 # This file is necessary to make this directory a package.
+"""SNMP itself: the message formats, and the models that process and secure them.
+
+The `rfc*` modules are the wire types. `mpmod` prepares and parses messages
+per version, `secmod` authenticates and encrypts them, `acmod` decides who may
+see what, and `api` is a version-independent way to build and read a PDU.
+"""

--- a/pysnmp/proto/acmod/__init__.py
+++ b/pysnmp/proto/acmod/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""Access control: deciding whether a request may reach a given object."""

--- a/pysnmp/proto/acmod/rfc3415.py
+++ b/pysnmp/proto/acmod/rfc3415.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The View-based Access Control Model of RFC 3415."""
+
 from pysnmp import debug
 from pysnmp.proto import errind, error
 from pysnmp.smi.error import NoSuchInstanceError

--- a/pysnmp/proto/acmod/void.py
+++ b/pysnmp/proto/acmod/void.py
@@ -3,6 +3,12 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""An access control model that permits everything.
+
+For an engine that answers to anyone, or one where access is enforced
+somewhere else entirely.
+"""
+
 from pysnmp import debug
 from pysnmp.proto import errind, error
 

--- a/pysnmp/proto/api/__init__.py
+++ b/pysnmp/proto/api/__init__.py
@@ -3,6 +3,12 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Building and reading PDUs without hard-coding a protocol version.
+
+`protoModules[protoVersion2c]` gives the module for that version; the calls on
+it are the same shape whichever version you asked for.
+"""
+
 from pysnmp.proto.api import v1, v2c, verdec
 
 # Protocol versions

--- a/pysnmp/proto/api/v1.py
+++ b/pysnmp/proto/api/v1.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Building and reading SNMPv1 messages and PDUs."""
+
 from pyasn1.type import univ
 
 from pysnmp import nextid

--- a/pysnmp/proto/api/v2c.py
+++ b/pysnmp/proto/api/v2c.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Building and reading SNMPv2c messages and PDUs, including GETBULK."""
+
 from pyasn1.type import constraint, univ
 
 from pysnmp.proto import rfc1901, rfc1902, rfc1905

--- a/pysnmp/proto/api/verdec.py
+++ b/pysnmp/proto/api/verdec.py
@@ -3,6 +3,12 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Reading the version field out of a message without decoding the rest.
+
+Which version a message claims decides who parses it, so this has to run
+before any of them do.
+"""
+
 from pyasn1.codec.ber import decoder, eoo
 from pyasn1.error import PyAsn1Error
 from pyasn1.type import univ

--- a/pysnmp/proto/cache.py
+++ b/pysnmp/proto/cache.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The dispatcher's record of requests it has sent and not yet answered."""
+
 from pysnmp.proto import error
 
 

--- a/pysnmp/proto/errind.py
+++ b/pysnmp/proto/errind.py
@@ -4,6 +4,13 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Error indications: what went wrong, as values rather than status codes.
+
+An error indication is a local failure -- no response, wrong digest, unknown
+user -- as distinct from an error status, which is what a remote agent put in
+a response it did send.
+"""
+
 import functools
 
 

--- a/pysnmp/proto/error.py
+++ b/pysnmp/proto/error.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Errors raised while processing a message."""
+
 from pyasn1.error import PyAsn1Error
 
 from pysnmp import debug

--- a/pysnmp/proto/mpmod/__init__.py
+++ b/pysnmp/proto/mpmod/__init__.py
@@ -1,1 +1,5 @@
 # This file is necessary to make this directory a package.
+"""Message processing models: turning a PDU into bytes on the wire, and back.
+
+One model per protocol version, each named for the RFC that defines it.
+"""

--- a/pysnmp/proto/mpmod/base.py
+++ b/pysnmp/proto/mpmod/base.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""What a message processing model has to provide."""
+
 from typing import Any
 
 from pysnmp.proto import error

--- a/pysnmp/proto/mpmod/cache.py
+++ b/pysnmp/proto/mpmod/cache.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""State a message processing model keeps between a request and its response."""
+
 from pysnmp import nextid
 from pysnmp.proto import error
 

--- a/pysnmp/proto/mpmod/rfc2576.py
+++ b/pysnmp/proto/mpmod/rfc2576.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Message processing for SNMPv1 and SNMPv2c."""
+
 from typing import Any
 
 from pyasn1.codec.ber import decoder, eoo

--- a/pysnmp/proto/mpmod/rfc3412.py
+++ b/pysnmp/proto/mpmod/rfc3412.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Message processing for SNMPv3, including the scoped PDU and header data."""
+
 from typing import Any
 
 from pyasn1.codec.ber import decoder, eoo

--- a/pysnmp/proto/proxy/__init__.py
+++ b/pysnmp/proto/proxy/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""Translating PDUs between protocol versions."""

--- a/pysnmp/proto/proxy/rfc2576.py
+++ b/pysnmp/proto/proxy/rfc2576.py
@@ -3,6 +3,13 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Translating PDUs between SNMPv1 and SNMPv2c, per RFC 2576.
+
+The two directions are not symmetric: v2c has types and error statuses v1
+cannot express, and a v1 trap carries fields a v2c trap encodes as variable
+bindings instead.
+"""
+
 from pysnmp import debug
 from pysnmp.proto import error, rfc1905, rfc3411
 from pysnmp.proto.api import v1, v2c

--- a/pysnmp/proto/rfc1155.py
+++ b/pysnmp/proto/rfc1155.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The SMIv1 types: what an SNMPv1 value can be."""
+
 from pyasn1.error import PyAsn1Error
 from pyasn1.type import constraint, namedtype, tag, univ
 

--- a/pysnmp/proto/rfc1157.py
+++ b/pysnmp/proto/rfc1157.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The SNMPv1 message and its PDUs."""
+
 from pyasn1.type import namedtype, namedval, tag, univ
 
 from pysnmp.proto import rfc1155

--- a/pysnmp/proto/rfc1901.py
+++ b/pysnmp/proto/rfc1901.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The SNMPv2c message: a community string wrapped around an SMIv2 PDU."""
+
 from pyasn1.type import namedtype, namedval, univ
 
 from pysnmp.proto import rfc1905

--- a/pysnmp/proto/rfc1902.py
+++ b/pysnmp/proto/rfc1902.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The SMIv2 types: what an SNMPv2 value can be."""
+
 from pyasn1.type import constraint, namedtype, namedval, tag, univ
 
 from pysnmp.proto import error

--- a/pysnmp/proto/rfc1905.py
+++ b/pysnmp/proto/rfc1905.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The SNMPv2 PDUs, and the three exception values a response can carry."""
+
 from pyasn1.type import constraint, namedtype, namedval, tag, univ
 
 from pysnmp.proto import rfc1902

--- a/pysnmp/proto/rfc3411.py
+++ b/pysnmp/proto/rfc3411.py
@@ -4,6 +4,12 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Which PDUs read, which write, and which are confirmed.
+
+The dispatcher and the access control model both need to classify a PDU
+without caring which version it arrived as; these tables are how.
+"""
+
 from typing import Any
 
 from pysnmp.proto import rfc1157, rfc1905

--- a/pysnmp/proto/rfc3412.py
+++ b/pysnmp/proto/rfc3412.py
@@ -4,6 +4,13 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""The message and PDU dispatcher: the middle of the engine.
+
+Everything inbound and outbound passes through here. It picks the message
+processing model for the version, routes a PDU to whichever application
+registered for it, and matches responses to the requests waiting on them.
+"""
+
 from pyasn1.error import PyAsn1Error
 
 from pysnmp import debug, nextid

--- a/pysnmp/proto/secmod/__init__.py
+++ b/pysnmp/proto/secmod/__init__.py
@@ -1,1 +1,6 @@
 # This file is necessary to make this directory a package.
+"""Security models: authenticating a message and keeping its contents private.
+
+`rfc3414` is USM, the user-based model SNMPv3 uses; `rfc2576` is the community
+string standing in as a security model for v1 and v2c.
+"""

--- a/pysnmp/proto/secmod/base.py
+++ b/pysnmp/proto/secmod/base.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""What a security model has to provide."""
+
 from pysnmp.proto import error
 from pysnmp.proto.secmod import cache
 

--- a/pysnmp/proto/secmod/cache.py
+++ b/pysnmp/proto/secmod/cache.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""State a security model keeps between a request and its response."""
+
 from pysnmp import nextid
 from pysnmp.proto import error
 

--- a/pysnmp/proto/secmod/eso/__init__.py
+++ b/pysnmp/proto/secmod/eso/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""Protocols that are widely implemented but not standards-track."""

--- a/pysnmp/proto/secmod/eso/priv/__init__.py
+++ b/pysnmp/proto/secmod/eso/priv/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""Non-standard privacy protocols: 3DES, and AES at 192 and 256 bits."""

--- a/pysnmp/proto/secmod/eso/priv/aes192.py
+++ b/pysnmp/proto/secmod/eso/priv/aes192.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""AES-192 privacy, in both the Blumenthal and Reeder key-extension variants."""
+
 from pysnmp.proto.secmod.eso.priv import aesbase
 
 

--- a/pysnmp/proto/secmod/eso/priv/aes256.py
+++ b/pysnmp/proto/secmod/eso/priv/aes256.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""AES-256 privacy, in both the Blumenthal and Reeder key-extension variants."""
+
 from pysnmp.proto.secmod.eso.priv import aesbase
 
 

--- a/pysnmp/proto/secmod/eso/priv/aesbase.py
+++ b/pysnmp/proto/secmod/eso/priv/aesbase.py
@@ -3,6 +3,13 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Extending a localized key to the length AES-192 and AES-256 need.
+
+RFC 3826 localizes a key to the digest length, which is shorter than these
+ciphers take. Blumenthal and Reeder each specified a way to stretch it, and
+they do not agree, so a peer has to be matched on which one it implements.
+"""
+
 from hashlib import md5, sha1
 from math import ceil
 

--- a/pysnmp/proto/secmod/eso/priv/des3.py
+++ b/pysnmp/proto/secmod/eso/priv/des3.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Triple DES privacy (Reeder), draft-reeder-snmpv3-usm-3desede."""
+
 import secrets
 from hashlib import md5, sha1
 

--- a/pysnmp/proto/secmod/rfc2576.py
+++ b/pysnmp/proto/secmod/rfc2576.py
@@ -4,6 +4,13 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""The community string as a security model, for SNMPv1 and SNMPv2c.
+
+A community string is not security, and this model does not pretend otherwise:
+it maps the community onto a security name and checks the transport it
+arrived on.
+"""
+
 from pyasn1.codec.ber import encoder
 from pyasn1.error import PyAsn1Error
 

--- a/pysnmp/proto/secmod/rfc3414/__init__.py
+++ b/pysnmp/proto/secmod/rfc3414/__init__.py
@@ -6,6 +6,8 @@
 
 # Lazy import to break circular dependency: service.py imports eso.priv
 # modules which import rfc3414.localkey/auth via this __init__.py
+"""The User-based Security Model of RFC 3414."""
+
 import importlib as _importlib
 
 

--- a/pysnmp/proto/secmod/rfc3414/auth/__init__.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""Authentication protocols: proving a message was not altered in transit."""

--- a/pysnmp/proto/secmod/rfc3414/auth/base.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/base.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""What an authentication service has to provide."""
+
 from pysnmp.proto import errind, error
 
 

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
@@ -3,6 +3,12 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""HMAC-MD5-96 authentication.
+
+MD5 is no longer considered safe; RFC 7860's SHA-2 protocols are the
+replacement. Configuring this raises `PySnmpWeakCryptoWarning`.
+"""
+
 from hashlib import md5
 
 from pyasn1.type import univ

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
@@ -3,6 +3,12 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""HMAC-SHA-96 authentication.
+
+SHA-1 is no longer considered safe; RFC 7860's SHA-2 protocols are the
+replacement. Configuring this raises `PySnmpWeakCryptoWarning`.
+"""
+
 from hashlib import sha1
 
 from pyasn1.type import univ

--- a/pysnmp/proto/secmod/rfc3414/auth/noauth.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/noauth.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The absence of authentication, as a service the model can call."""
+
 from pysnmp.proto import errind, error
 from pysnmp.proto.secmod.rfc3414.auth import base
 

--- a/pysnmp/proto/secmod/rfc3414/localkey.py
+++ b/pysnmp/proto/secmod/rfc3414/localkey.py
@@ -3,6 +3,13 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Turning a passphrase into a key, and a key into an engine-local one.
+
+Localizing binds a key to one engine ID, so the same passphrase configured
+against two agents yields two different keys and neither can be replayed at
+the other.
+"""
+
 from hashlib import md5, sha1
 
 from pyasn1.type import univ

--- a/pysnmp/proto/secmod/rfc3414/priv/__init__.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""Privacy protocols: keeping the contents of a message from being read."""

--- a/pysnmp/proto/secmod/rfc3414/priv/base.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/base.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""What an encryption service has to provide."""
+
 from pysnmp.proto import error
 
 

--- a/pysnmp/proto/secmod/rfc3414/priv/des.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/des.py
@@ -3,6 +3,12 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""CBC-DES privacy.
+
+DES is no longer considered safe; RFC 3826's AES is the replacement.
+Configuring this raises `PySnmpWeakCryptoWarning`.
+"""
+
 import secrets
 from hashlib import md5, sha1
 

--- a/pysnmp/proto/secmod/rfc3414/priv/nopriv.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/nopriv.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The absence of privacy, as a service the model can call."""
+
 from pysnmp.proto import errind, error
 from pysnmp.proto.secmod.rfc3414.priv import base
 

--- a/pysnmp/proto/secmod/rfc3414/service.py
+++ b/pysnmp/proto/secmod/rfc3414/service.py
@@ -3,6 +3,12 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""USM itself: authenticating, encrypting, and keeping engine time in step.
+
+Discovery, the time window that makes a replay stale, and the counters a peer
+reads to detect one, all live here.
+"""
+
 import time
 from collections.abc import Callable
 from typing import Any, NoReturn, TypeVar

--- a/pysnmp/proto/secmod/rfc3826/__init__.py
+++ b/pysnmp/proto/secmod/rfc3826/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""AES privacy for USM, per RFC 3826."""

--- a/pysnmp/proto/secmod/rfc3826/priv/__init__.py
+++ b/pysnmp/proto/secmod/rfc3826/priv/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""The AES-128 privacy protocol."""

--- a/pysnmp/proto/secmod/rfc3826/priv/aes.py
+++ b/pysnmp/proto/secmod/rfc3826/priv/aes.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""CFB128-AES-128 privacy, per RFC 3826."""
+
 import secrets
 from hashlib import md5, sha1
 

--- a/pysnmp/proto/secmod/rfc7860/__init__.py
+++ b/pysnmp/proto/secmod/rfc7860/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""The SHA-2 authentication protocols for USM, per RFC 7860."""

--- a/pysnmp/proto/secmod/rfc7860/auth/__init__.py
+++ b/pysnmp/proto/secmod/rfc7860/auth/__init__.py
@@ -1,1 +1,2 @@
 # This file is necessary to make this directory a package.
+"""HMAC-SHA-2 authentication protocols."""

--- a/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
+++ b/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2018, Olivier Verriest <verri@x25.pm>
 #
+"""HMAC-SHA-2 authentication at 224, 256, 384 and 512 bits, per RFC 7860."""
+
 import hmac
 from hashlib import sha224, sha256, sha384, sha512
 

--- a/pysnmp/smi/__init__.py
+++ b/pysnmp/smi/__init__.py
@@ -1,1 +1,7 @@
 # This file is necessary to make this directory a package.
+"""The MIB machinery: loading modules, resolving names and OIDs, serving values.
+
+`builder` loads MIB modules, `view` resolves names to OIDs and back, `instrum`
+serves values to the agent side, and `rfc1902` is the object-identity API the
+high-level calls take.
+"""

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -4,6 +4,14 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Loading MIB modules from wherever they are: a directory, a package, a corpus.
+
+`MibBuilder` finds a module by name, imports it, applies any hand-written
+runtime behavior from `pysnmp.smi.mibs.behavior`, and holds the symbols it
+defined. A source is a directory or an importable package; a module is Python
+rendered from ASN.1.
+"""
+
 import dis
 import importlib
 import importlib.machinery

--- a/pysnmp/smi/compiler.py
+++ b/pysnmp/smi/compiler.py
@@ -3,6 +3,12 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Compiling ASN.1 to loadable modules at run time, when pysmi is installed.
+
+pysmi is an optional dependency: install `pysnmplib[compile]` to get it.
+Without it `addMibCompiler` raises `SmiError` naming the missing import.
+"""
+
 import sys
 from pathlib import Path
 from typing import Any

--- a/pysnmp/smi/error.py
+++ b/pysnmp/smi/error.py
@@ -3,6 +3,12 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Errors raised while loading MIBs or serving managed objects.
+
+The `MibOperationError` subclasses map onto the SNMP error statuses an agent
+returns, so raising one is how instrumentation reports a failure.
+"""
+
 from pyasn1.error import PyAsn1Error
 
 from pysnmp.error import PySnmpError

--- a/pysnmp/smi/exval.py
+++ b/pysnmp/smi/exval.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""The three exception values a GETNEXT or GETBULK response can carry."""
+
 from pysnmp.proto import rfc1905
 
 noSuchObject = rfc1905.noSuchObject

--- a/pysnmp/smi/indices.py
+++ b/pysnmp/smi/indices.py
@@ -3,6 +3,13 @@
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
+"""Dictionaries that keep their keys in order, including OID order.
+
+GETNEXT has to find the successor of an OID, which a plain dict cannot do.
+`OidOrderedDict` sorts by OID component rather than lexically, so 1.3.6.1.10
+follows 1.3.6.1.9 rather than preceding it.
+"""
+
 from bisect import bisect
 
 

--- a/pysnmp/smi/instrum.py
+++ b/pysnmp/smi/instrum.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Serving managed objects: what the agent side calls to read and write values."""
+
 import traceback
 from typing import Any
 

--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -4,6 +4,13 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Naming a managed object, and pairing it with a value.
+
+`ObjectIdentity` is a MIB object by name, OID or index; `ObjectType` binds one
+to a value; `NotificationType` names a trap and the objects it carries. All
+three resolve against a MIB view before the engine sees them.
+"""
+
 import functools
 
 from pyasn1.error import PyAsn1Error

--- a/pysnmp/smi/view.py
+++ b/pysnmp/smi/view.py
@@ -4,6 +4,13 @@
 # Copyright (c) 2005-2019, Ilya Etingof deceased
 #
 
+"""Resolving MIB names to OIDs and OIDs back to names.
+
+`MibViewController` sits over a `MibBuilder` and indexes what it loaded, so a
+caller can ask for `sysDescr` and get 1.3.6.1.2.1.1.1, ask the other way
+round, or walk to the next object in OID order across every loaded module.
+"""
+
 from pysnmp import debug
 from pysnmp.smi import error
 from pysnmp.smi.indices import OidOrderedDict, OrderedDict

--- a/tools/regenerate_mibs.py
+++ b/tools/regenerate_mibs.py
@@ -162,6 +162,7 @@ def build(*modules: str) -> dict[str, str]:
 
 
 def main() -> int:
+    """Render the committed modules, or check them for drift under `--check`."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--check",


### PR DESCRIPTION
First of the stages #186 left behind. `D100` and `D104` come off the ignore list: 104 modules and packages that had no docstring now have one, and ruff holds the line on the next one added.

## What a module docstring is for here

Not "what is in this file" -- the class list already says that -- but "why would I open it".

- `carrier/sockmsg.py` exists because plain `sendto()`/`recvfrom()` cannot report which local address a datagram arrived on, which matters when listening on `0.0.0.0`.
- `smi/indices.py` says OID order is not lexical order, and that GETNEXT is why that matters.
- `proto/errind.py` draws the line between an error indication (local failure) and an error status (what a remote agent actually sent back).
- `secmod/eso/priv/aesbase.py` says Blumenthal and Reeder disagree on key extension, so a peer has to be matched on which one it implements.
- The four weak-crypto modules each name the protocol that replaced them.
- `rfc3413/mibvar.py` and everything under `rfc3413/oneliner/` say they are obsolete and what to use instead.

## Drive-by

Four `D406`/`D407` errors were failing on `next`. #219 landed docstring sections in Google style, #220 turned the numpy convention on, and they merged in an order where neither PR's CI saw the combination. Autofixed in `entity/config.py` and `entity/engine.py`.

## Shape of the diff

Docstrings go after the license header and before the first import, so the copyright blocks are untouched. 111 files, **438 insertions and 11 deletions** -- the 11 are the four autofixed section headers. Nothing else was changed or removed.

## What is still off

`D101` (183 classes), `D102` (347 methods), `D103`/`D107` (104 functions and constructors), `D105` (55 magic methods) -- ~690 items. The comment in `pyproject.toml` keeps the order they come off in.

## Verification

- `ruff check` clean, `ruff format --check` clean (216 files)
- `mypy pysnmp` clean (147 source files)
- 1258 passed, 12 skipped