### PR TITLE
docs: say what every class is for (D101)

### DIFF
--- a/docs/source/docs/api-internals.rst
+++ b/docs/source/docs/api-internals.rst
@@ -56,6 +56,8 @@ Transport
 
 .. autoclass:: pysnmp.hlapi.transport.AbstractTransportTarget
    :members:
+   :exclude-members: protoTransport
+
 
 MIB services
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,19 +211,19 @@ ignore = [
     "S509",     # snmp-weak-cryptography
 
     # The docstring family, adopted in stages -- see #186. What is on now is
-    # the shape of the docstrings that exist, plus D100/D104: every module and
-    # package says what it is for. What is still off is the requirement that
-    # every public class, function and method have one, which is ~690 items
-    # and is a documentation project rather than a lint fix. Writing 347
-    # method docstrings mechanically produces noise, not documentation.
+    # the shape of the docstrings that exist, plus D100/D104 and D101: every
+    # module, package and class says what it is for. What is still off is the
+    # requirement that every public function and method have one, which is
+    # ~506 items and is a documentation project rather than a lint fix.
+    # Writing 347 method docstrings mechanically produces noise, not
+    # documentation.
     #
     # These come off one rule at a time, each its own reviewable change:
     #   D100/D104  104 modules and packages -- done
-    #   D101       183 classes
+    #   D101       182 classes -- done
     #   D103/D107  104 functions and constructors
     #   D102       347 methods, probably by subpackage
     #   D105        55 magic methods
-    "D101",     # undocumented-public-class
     "D102",     # undocumented-public-method
     "D103",     # undocumented-public-function
     "D105",     # undocumented-magic-method

--- a/pysnmp/carrier/asyncio/base.py
+++ b/pysnmp/carrier/asyncio/base.py
@@ -36,5 +36,6 @@ from pysnmp.carrier.base import AbstractTransport
 
 
 class AbstractAsyncioTransport(AbstractTransport):
+    """What every asyncio transport shares, to be used with `AsyncioDispatcher`."""
+
     protoTransportDispatcher = AsyncioDispatcher
-    """Base Asyncio Transport, to be used with AsyncioDispatcher"""

--- a/pysnmp/carrier/asyncio/dgram/udp.py
+++ b/pysnmp/carrier/asyncio/dgram/udp.py
@@ -40,10 +40,14 @@ domainName = snmpUDPDomain = (1, 3, 6, 1, 6, 1, 1)
 
 
 class UdpTransportAddress(tuple, AbstractTransportAddress):
+    """An IPv4 endpoint, as the `(host, port)` pair `socket` uses."""
+
     pass
 
 
 class UdpAsyncioTransport(DgramAsyncioProtocol):
+    """SNMP over UDP/IPv4."""
+
     sockFamily = socket.AF_INET
     addressType = UdpTransportAddress
     # Not a bind: this is the address getsockname() reports for a socket that

--- a/pysnmp/carrier/asyncio/dgram/udp6.py
+++ b/pysnmp/carrier/asyncio/dgram/udp6.py
@@ -14,10 +14,18 @@ domainName = snmpUDP6Domain = (1, 3, 6, 1, 2, 1, 100, 1, 2)
 
 
 class Udp6TransportAddress(tuple, AbstractTransportAddress):
+    """An IPv6 endpoint, as the `(host, port, flowinfo, scopeid)` tuple `socket` uses."""
+
     pass
 
 
 class Udp6AsyncioTransport(DgramAsyncioProtocol):
+    """SNMP over UDP/IPv6.
+
+    Addresses are normalized so a scoped or IPv4-mapped form compares equal to the
+    plain one it means.
+    """
+
     sockFamily = socket.has_ipv6 and socket.AF_INET6 or None
     addressType = Udp6TransportAddress
     unboundLocalAddress = ("::", 0, 0, 0)

--- a/pysnmp/carrier/asyncio/dgram/unix.py
+++ b/pysnmp/carrier/asyncio/dgram/unix.py
@@ -25,10 +25,18 @@ domainName = snmpLocalDomain = (1, 3, 6, 1, 2, 1, 100, 1, 13)
 
 
 class UnixTransportAddress(str, AbstractTransportAddress):
+    """A Unix domain endpoint, which is a filesystem path."""
+
     pass
 
 
 class UnixAsyncioTransport(DgramAsyncioProtocol):
+    """SNMP over Unix domain datagram sockets.
+
+    Unavailable on Windows, where `AF_UNIX` does not exist and the constructor
+    raises.
+    """
+
     sockFamily = AF_UNIX
     addressType = UnixTransportAddress
 

--- a/pysnmp/carrier/base.py
+++ b/pysnmp/carrier/base.py
@@ -18,6 +18,12 @@ from pysnmp.carrier import error
 
 @functools.total_ordering
 class TimerCallable:
+    """A callback the dispatcher invokes on a fixed interval.
+
+    Compares equal to the bare function it wraps, so a caller can unregister the
+    callback it registered without holding on to the wrapper.
+    """
+
     def __init__(self, cbFun, callInterval):
         self.__cbFun = cbFun
         self.__nextCall = 0
@@ -45,6 +51,15 @@ class TimerCallable:
 
 
 class AbstractTransportDispatcher:
+    """Owns the transports and drives the I/O loop they run on.
+
+    Transports are registered against a transport domain, and an incoming message
+    is routed to the callback registered for whichever recipient the routing
+    function names. Jobs count what is still outstanding: the loop runs until
+    every job has released itself, which is what stops a dispatcher from exiting
+    while a request is still in flight.
+    """
+
     def __init__(self):
         self.__transports = {}
         self.__transportDomainMap = {}
@@ -201,6 +216,13 @@ class AbstractTransportDispatcher:
 
 
 class AbstractTransportAddress:
+    """An endpoint address, remembering which local address it was seen on.
+
+    The local address is what `sockmsg` recovers for a socket bound to a wildcard,
+    and it rides along on the address so a reply leaves by the interface the
+    request arrived on.
+    """
+
     _localAddress = None
 
     def setLocalAddress(self, s):
@@ -219,6 +241,12 @@ class AbstractTransportAddress:
 class AbstractTransport:
     #: Dispatcher this transport was written against; isCompatibleWithDispatcher()
     #: below checks candidates against it, and every concrete transport names one.
+    """One transport: a socket, opened either as a client or as a server.
+
+    A transport names the dispatcher it was written against, since the two share
+    an I/O model and pairing a transport with the wrong dispatcher would not work.
+    """
+
     protoTransportDispatcher: type[AbstractTransportDispatcher] | None = None
     addressType = AbstractTransportAddress
     _cbFun = None

--- a/pysnmp/carrier/base.py
+++ b/pysnmp/carrier/base.py
@@ -239,14 +239,14 @@ class AbstractTransportAddress:
 
 
 class AbstractTransport:
-    #: Dispatcher this transport was written against; isCompatibleWithDispatcher()
-    #: below checks candidates against it, and every concrete transport names one.
     """One transport: a socket, opened either as a client or as a server.
 
     A transport names the dispatcher it was written against, since the two share
     an I/O model and pairing a transport with the wrong dispatcher would not work.
     """
 
+    #: Dispatcher this transport was written against; isCompatibleWithDispatcher()
+    #: below checks candidates against it, and every concrete transport names one.
     protoTransportDispatcher: type[AbstractTransportDispatcher] | None = None
     addressType = AbstractTransportAddress
     _cbFun = None

--- a/pysnmp/carrier/error.py
+++ b/pysnmp/carrier/error.py
@@ -9,4 +9,6 @@ from pysnmp import error
 
 
 class CarrierError(error.PySnmpError):
+    """Raised when a transport or dispatcher cannot do what was asked of it."""
+
     pass

--- a/pysnmp/carrier/sockmsg.py
+++ b/pysnmp/carrier/sockmsg.py
@@ -33,10 +33,14 @@ in_addr_t = uint32_t
 
 
 class in_addr(ctypes.Structure):
+    """The C `struct in_addr`: one IPv4 address."""
+
     _fields_ = [("s_addr", in_addr_t)]
 
 
 class in6_addr_U(ctypes.Union):
+    """The union inside `struct in6_addr`, viewing the address at three widths."""
+
     _fields_ = [
         ("__u6_addr8", ctypes.c_uint8 * 16),
         ("__u6_addr16", ctypes.c_uint16 * 8),
@@ -45,12 +49,16 @@ class in6_addr_U(ctypes.Union):
 
 
 class in6_addr(ctypes.Structure):
+    """The C `struct in6_addr`: one IPv6 address."""
+
     _fields_ = [
         ("__in6_u", in6_addr_U),
     ]
 
 
 class in_pktinfo(ctypes.Structure):
+    """The C `struct in_pktinfo`: which interface and local address a datagram used."""
+
     _fields_ = [
         ("ipi_ifindex", ctypes.c_int),
         ("ipi_spec_dst", in_addr),
@@ -59,6 +67,8 @@ class in_pktinfo(ctypes.Structure):
 
 
 class in6_pktinfo(ctypes.Structure):
+    """The C `struct in6_pktinfo`: the IPv6 form of `in_pktinfo`."""
+
     _fields_ = [
         ("ipi6_addr", in6_addr),
         ("ipi6_ifindex", ctypes.c_uint),

--- a/pysnmp/debug.py
+++ b/pysnmp/debug.py
@@ -44,6 +44,8 @@ flagMap = {
 
 
 class Printer:
+    """Where debug output goes, defaulting to stderr through `logging`."""
+
     def __init__(self, logger=None, handler=None, formatter=None):
         if logger is None:
             logger = logging.getLogger("pysnmp")
@@ -68,6 +70,12 @@ NullHandler = logging.NullHandler
 
 
 class Debug:
+    """Debugging switched on for the named subsystems.
+
+    Truthiness is per flag: `debug.logger & flagIO` is what a caller tests before
+    building a message it would otherwise pay to format.
+    """
+
     defaultPrinter = None
 
     def __init__(self, *flags, **options):

--- a/pysnmp/entity/rfc3413/cmdgen.py
+++ b/pysnmp/entity/rfc3413/cmdgen.py
@@ -51,6 +51,13 @@ def getNextVarBinds(varBinds, origVarBinds=None):
 
 
 class CommandGenerator:
+    """Sends a request and matches the response back to it.
+
+    Handles what happens between those two: retries on timeout, and the SNMPv3
+    discovery exchange where the first request comes back as a report naming the
+    remote engine, and is then reissued against it.
+    """
+
     _null = univ.Null("")
 
     #: Deprecated pre-4.4 entry point, superseded by sendVarBinds(). The
@@ -312,6 +319,8 @@ CommandGeneratorBase = CommandGenerator
 
 
 class GetCommandGenerator(CommandGenerator):
+    """Sends GET: fetch exactly the objects named."""
+
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
@@ -354,6 +363,8 @@ class GetCommandGenerator(CommandGenerator):
 
 
 class SetCommandGenerator(CommandGenerator):
+    """Sends SET: write the values given."""
+
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
@@ -396,6 +407,8 @@ class SetCommandGenerator(CommandGenerator):
 
 
 class NextCommandGeneratorSingleRun(CommandGenerator):
+    """Sends one GETNEXT: the objects following those named, and no further."""
+
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
@@ -438,6 +451,13 @@ class NextCommandGeneratorSingleRun(CommandGenerator):
 
 
 class NextCommandGenerator(NextCommandGeneratorSingleRun):
+    """Walks with GETNEXT, reissuing until the subtree runs out.
+
+    Each response becomes the next request, so one call to `sendVarBinds` covers
+    the whole walk. `ignoreNonIncreasingOid` decides what to do about an agent
+    whose OIDs do not advance, which would otherwise loop forever.
+    """
+
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
@@ -505,6 +525,8 @@ class NextCommandGenerator(NextCommandGeneratorSingleRun):
 
 
 class BulkCommandGeneratorSingleRun(CommandGenerator):
+    """Sends one GETBULK: up to `maxRepetitions` rows, and no further."""
+
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
@@ -570,6 +592,8 @@ class BulkCommandGeneratorSingleRun(CommandGenerator):
 
 
 class BulkCommandGenerator(BulkCommandGeneratorSingleRun):
+    """Walks with GETBULK, reissuing until the subtree runs out."""
+
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):

--- a/pysnmp/entity/rfc3413/cmdrsp.py
+++ b/pysnmp/entity/rfc3413/cmdrsp.py
@@ -17,6 +17,14 @@ from pysnmp.proto.proxy import rfc2576
 
 # 3.2
 class CommandResponderBase:
+    """Answers a request out of the MIB, subject to access control.
+
+    A responder registers for the PDU types it handles, checks every variable
+    binding against the view the requester is allowed to see, and turns a MIB
+    error into the error status and index the version in use can express -- which
+    is not the same set for v1 as for v2c.
+    """
+
     acmID = 3  # default MIB access control method to use
     #: PDU tag sets this responder registers for; each subclass names its own.
     pduTypes: tuple[tag.TagSet, ...] = ()
@@ -350,6 +358,8 @@ class CommandResponderBase:
 
 
 class GetCommandResponder(CommandResponderBase):
+    """Answers GET."""
+
     pduTypes = (rfc1905.GetRequestPDU.tagSet,)
 
     # rfc1905: 4.2.1
@@ -368,6 +378,8 @@ class GetCommandResponder(CommandResponderBase):
 
 
 class NextCommandResponder(CommandResponderBase):
+    """Answers GETNEXT."""
+
     pduTypes = (rfc1905.GetNextRequestPDU.tagSet,)
 
     # rfc1905: 4.2.2
@@ -389,6 +401,12 @@ class NextCommandResponder(CommandResponderBase):
 
 
 class BulkCommandResponder(CommandResponderBase):
+    """Answers GETBULK.
+
+    `maxVarBinds` caps how many bindings one response may carry, since the
+    repetition count comes from the requester and is otherwise unbounded.
+    """
+
     pduTypes = (rfc1905.GetBulkRequestPDU.tagSet,)
     maxVarBinds = 64
 
@@ -434,6 +452,8 @@ class BulkCommandResponder(CommandResponderBase):
 
 
 class SetCommandResponder(CommandResponderBase):
+    """Answers SET."""
+
     pduTypes = (rfc1905.SetRequestPDU.tagSet,)
 
     # rfc1905: 4.2.5

--- a/pysnmp/entity/rfc3413/context.py
+++ b/pysnmp/entity/rfc3413/context.py
@@ -11,6 +11,13 @@ from pysnmp import debug, error
 
 
 class SnmpContext:
+    """Maps a context name to the MIB instrumentation that serves it.
+
+    A context is how one engine presents more than one set of managed objects --
+    per VRF, per virtual router, per tenant. The empty name is the default
+    context, which is what an agent with only one set of objects uses.
+    """
+
     def __init__(self, snmpEngine, contextEngineId=None):
         (snmpEngineId,) = (
             snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder.importSymbols(

--- a/pysnmp/entity/rfc3413/ntforg.py
+++ b/pysnmp/entity/rfc3413/ntforg.py
@@ -101,6 +101,12 @@ def _matchFilter(filterEntries, oid):
 
 
 class NotificationOriginator:
+    """Sends a notification to every target the configuration names.
+
+    A trap is sent and forgotten; an inform is acknowledged, so it is retried and
+    its response is matched back the way a request's is.
+    """
+
     acmID = 3  # default MIB access control method to use
 
     #: Deprecated pre-4.4 entry point, superseded by sendVarBinds(). The

--- a/pysnmp/entity/rfc3413/ntfrcv.py
+++ b/pysnmp/entity/rfc3413/ntfrcv.py
@@ -14,6 +14,12 @@ from pysnmp.proto.proxy import rfc2576
 
 # 3.4
 class NotificationReceiver:
+    """Receives traps and informs and hands them to a callback.
+
+    Acknowledges an inform itself, echoing the bindings back, so the callback does
+    not have to know which of the two it was given.
+    """
+
     pduTypes = (
         v1.TrapPDU.tagSet,
         v2c.SNMPv2TrapPDU.tagSet,

--- a/pysnmp/entity/rfc3413/oneliner/cmdgen.py
+++ b/pysnmp/entity/rfc3413/oneliner/cmdgen.py
@@ -24,6 +24,8 @@ MibVariable = ObjectIdentity
 
 
 class AsynCommandGenerator:
+    """Obsolete. Use `pysnmp.hlapi.asyncio`."""
+
     _null = univ.Null("")
 
     vbProcessor = CommandGeneratorVarBinds()
@@ -256,6 +258,8 @@ class AsynCommandGenerator:
 
 
 class CommandGenerator:
+    """Obsolete. Use `pysnmp.hlapi`."""
+
     _null = univ.Null("")
 
     def __init__(self, snmpEngine=None, asynCmdGen=None):

--- a/pysnmp/entity/rfc3413/oneliner/ntforg.py
+++ b/pysnmp/entity/rfc3413/oneliner/ntforg.py
@@ -38,6 +38,8 @@ class ErrorIndicationReturn:
 
 
 class AsynNotificationOriginator:
+    """Obsolete. Use `pysnmp.hlapi.asyncio`."""
+
     vbProcessor = NotificationOriginatorVarBinds()
     lcd = NotificationOriginatorLcdConfigurator()
 
@@ -150,6 +152,8 @@ class AsynNotificationOriginator:
 
 
 class NotificationOriginator:
+    """Obsolete. Use `pysnmp.hlapi`."""
+
     vbProcessor = NotificationOriginatorVarBinds()
 
     def __init__(self, snmpEngine=None, snmpContext=None, asynNtfOrg=None):

--- a/pysnmp/hlapi/asyncio/transport.py
+++ b/pysnmp/hlapi/asyncio/transport.py
@@ -155,6 +155,8 @@ class Udp6TransportTarget(AbstractTransportTarget[tuple[str, int]]):
 
 
 class UnixTransportTarget(AbstractTransportTarget[str]):
+    """A Unix domain socket to send to, named by its filesystem path."""
+
     transportDomain = unix.domainName
     protoTransport = unix.UnixAsyncioTransport
 

--- a/pysnmp/hlapi/lcd.py
+++ b/pysnmp/hlapi/lcd.py
@@ -42,6 +42,13 @@ class AbstractLcdConfigurator:
 
 
 class CommandGeneratorLcdConfigurator(AbstractLcdConfigurator):
+    """Configures the engine to send requests, and tears that down again.
+
+    Entries are reference-counted: configuring the same credentials twice adds a
+    user rather than a second set of rows, and the rows go away when the last user
+    unconfigures.
+    """
+
     cacheKeys = ["auth", "parm", "tran", "addr"]
 
     def configure(
@@ -209,6 +216,13 @@ class CommandGeneratorLcdConfigurator(AbstractLcdConfigurator):
 
 
 class NotificationOriginatorLcdConfigurator(AbstractLcdConfigurator):
+    """Configures the engine to send notifications, and tears that down again.
+
+    Builds on the command generator's configuration, since a notification still
+    needs a target and credentials, and adds the notification and filter rows on
+    top.
+    """
+
     cacheKeys = ["auth", "name"]
     _cmdGenLcdCfg = CommandGeneratorLcdConfigurator()
 

--- a/pysnmp/hlapi/varbinds.py
+++ b/pysnmp/hlapi/varbinds.py
@@ -25,6 +25,8 @@ class AbstractVarBinds:
 
 
 class CommandGeneratorVarBinds(AbstractVarBinds):
+    """Variable bindings for requests: resolves names to OIDs and back."""
+
     def makeVarBinds(self, snmpEngine: Any, varBinds: Any) -> list[Any]:
         mibViewController = self.getMibViewController(snmpEngine)
         __varBinds = []
@@ -61,6 +63,13 @@ class CommandGeneratorVarBinds(AbstractVarBinds):
 
 
 class NotificationOriginatorVarBinds(AbstractVarBinds):
+    """Variable bindings for notifications, which carry their own MIB lookups.
+
+    Unlike the command generator, this does not resolve replies by default: a
+    notification's bindings were built locally and are already what the caller
+    passed in.
+    """
+
     def makeVarBinds(self, snmpEngine: Any, varBinds: Any) -> list[Any]:
         mibViewController = self.getMibViewController(snmpEngine)
         if isinstance(varBinds, NotificationType):

--- a/pysnmp/proto/api/v1.py
+++ b/pysnmp/proto/api/v1.py
@@ -35,6 +35,8 @@ Message = rfc1157.Message
 
 
 class VarBindAPI:
+    """Reads and writes the two halves of a variable binding."""
+
     @staticmethod
     def setOIDVal(varBind, oidVal):
         oid, val = oidVal[0], oidVal[1]
@@ -62,6 +64,8 @@ getNextRequestID = nextid.Integer(0xFFFFFF)
 
 
 class PDUAPI:
+    """Reads and writes a v1 PDU without naming its fields directly."""
+
     _errorStatus = rfc1157.errorStatus.clone(0)
     _errorIndex = Integer(0)
 
@@ -173,6 +177,8 @@ apiPDU = PDUAPI()
 
 
 class TrapPDUAPI:
+    """Reads and writes a v1 trap, whose fields are unlike any other PDU's."""
+
     _networkAddress = None
     _entOid = ObjectIdentifier((1, 3, 6, 1, 4, 1, 20408))
     _genericTrap = rfc1157.genericTrap.clone("coldStart")
@@ -302,6 +308,8 @@ apiTrapPDU = TrapPDUAPI()
 
 
 class MessageAPI:
+    """Reads and writes a v1 message: version, community, and the PDU inside."""
+
     _version = rfc1157.version.clone(0)
     _community = univ.OctetString("public")
 

--- a/pysnmp/proto/api/v2c.py
+++ b/pysnmp/proto/api/v2c.py
@@ -50,6 +50,12 @@ apiVarBind = v1.apiVarBind
 
 
 class PDUAPI(v1.PDUAPI):
+    """Reads and writes a v2c PDU.
+
+    Adds what v1 has no way to say: an exception value in place of a variable's
+    value, rather than failing the whole response.
+    """
+
     _errorStatus = rfc1905.errorStatus.clone(0)
     _errorIndex = univ.Integer(0).subtype(
         subtypeSpec=constraint.ValueRangeConstraint(0, rfc1905.max_bindings)
@@ -89,6 +95,8 @@ apiPDU = PDUAPI()
 
 
 class BulkPDUAPI(PDUAPI):
+    """Reads and writes a GETBULK PDU's repetition counts."""
+
     _nonRepeaters = rfc1905.nonRepeaters.clone(0)
     _maxRepetitions = rfc1905.maxRepetitions.clone(10)
 
@@ -162,6 +170,12 @@ apiBulkPDU = BulkPDUAPI()
 
 
 class TrapPDUAPI(v1.PDUAPI):
+    """Reads and writes a v2c trap, which is an ordinary PDU.
+
+    What v1 carried in dedicated fields is here in the bindings: the uptime and
+    the trap OID are the first two, by definition.
+    """
+
     sysUpTime = (1, 3, 6, 1, 2, 1, 1, 3, 0)
     snmpTrapAddress = (1, 3, 6, 1, 6, 3, 18, 1, 3, 0)
     snmpTrapCommunity = (1, 3, 6, 1, 6, 3, 18, 1, 4, 0)
@@ -184,6 +198,8 @@ apiTrapPDU = TrapPDUAPI()
 
 
 class MessageAPI(v1.MessageAPI):
+    """Reads and writes a v2c message: version, community, and the PDU inside."""
+
     _version = rfc1901.version.clone(1)
 
     def setDefaults(self, msg):

--- a/pysnmp/proto/cache.py
+++ b/pysnmp/proto/cache.py
@@ -9,6 +9,12 @@ from pysnmp.proto import error
 
 
 class Cache:
+    """Holds a request until its response arrives, or until it expires.
+
+    Keyed by a handle the dispatcher hands out; `expire` is what the timer calls
+    to sweep the requests nothing ever answered.
+    """
+
     def __init__(self):
         self.__cacheRepository = {}
 

--- a/pysnmp/proto/errind.py
+++ b/pysnmp/proto/errind.py
@@ -39,6 +39,8 @@ class ErrorIndication(Exception):
 
 
 class SerializationError(ErrorIndication):
+    """The message could not be encoded."""
+
     pass
 
 
@@ -46,6 +48,8 @@ serializationError = SerializationError("SNMP message serialization error")
 
 
 class DeserializationError(ErrorIndication):
+    """The message could not be decoded."""
+
     pass
 
 
@@ -53,6 +57,8 @@ deserializationError = DeserializationError("SNMP message deserialization error"
 
 
 class ParseError(DeserializationError):
+    """The message is not well-formed ASN.1."""
+
     pass
 
 
@@ -60,6 +66,8 @@ parseError = ParseError("SNMP message deserialization error")
 
 
 class UnsupportedMsgProcessingModel(ErrorIndication):
+    """The message names a version this engine has no processing model for."""
+
     pass
 
 
@@ -69,6 +77,8 @@ unsupportedMsgProcessingModel = UnsupportedMsgProcessingModel(
 
 
 class UnknownPDUHandler(ErrorIndication):
+    """No application is registered for this PDU type."""
+
     pass
 
 
@@ -76,6 +86,8 @@ unknownPDUHandler = UnknownPDUHandler("Unhandled PDU type encountered")
 
 
 class UnsupportedPDUtype(ErrorIndication):
+    """The PDU type is not one this version defines."""
+
     pass
 
 
@@ -83,6 +95,8 @@ unsupportedPDUtype = UnsupportedPDUtype("Unsupported SNMP PDU type encountered")
 
 
 class RequestTimedOut(ErrorIndication):
+    """No response arrived before the last retry ran out."""
+
     pass
 
 
@@ -90,6 +104,8 @@ requestTimedOut = RequestTimedOut("No SNMP response received before timeout")
 
 
 class EmptyResponse(ErrorIndication):
+    """The response carried no PDU."""
+
     pass
 
 
@@ -97,6 +113,8 @@ emptyResponse = EmptyResponse("Empty SNMP response message")
 
 
 class NonReportable(ErrorIndication):
+    """The failure could not be reported back, so no report was sent."""
+
     pass
 
 
@@ -104,6 +122,8 @@ nonReportable = NonReportable("Report PDU generation not attempted")
 
 
 class DataMismatch(ErrorIndication):
+    """The response does not match the request it answers."""
+
     pass
 
 
@@ -111,6 +131,8 @@ dataMismatch = DataMismatch("SNMP request/response parameters mismatched")
 
 
 class EngineIDMismatch(ErrorIndication):
+    """The response came from a different engine than the request went to."""
+
     pass
 
 
@@ -118,6 +140,8 @@ engineIDMismatch = EngineIDMismatch("SNMP engine ID mismatch encountered")
 
 
 class UnknownEngineID(ErrorIndication):
+    """The engine ID is not one this engine knows."""
+
     pass
 
 
@@ -125,6 +149,8 @@ unknownEngineID = UnknownEngineID("Unknown SNMP engine ID encountered")
 
 
 class TooBig(ErrorIndication):
+    """The response would exceed what the transport can carry."""
+
     pass
 
 
@@ -132,6 +158,8 @@ tooBig = TooBig("SNMP message will be too big")
 
 
 class LoopTerminated(ErrorIndication):
+    """A walk was stopped because it was not making progress."""
+
     pass
 
 
@@ -139,6 +167,8 @@ loopTerminated = LoopTerminated("Infinite SNMP entities talk terminated")
 
 
 class InvalidMsg(ErrorIndication):
+    """The message header is malformed or self-inconsistent."""
+
     pass
 
 
@@ -149,6 +179,8 @@ invalidMsg = InvalidMsg("Invalid SNMP message header parameters encountered")
 
 
 class UnknownCommunityName(ErrorIndication):
+    """The community string is not one this engine is configured for."""
+
     pass
 
 
@@ -156,6 +188,8 @@ unknownCommunityName = UnknownCommunityName("Unknown SNMP community name encount
 
 
 class NoEncryption(ErrorIndication):
+    """Privacy was asked for, but no privacy protocol is configured."""
+
     pass
 
 
@@ -163,6 +197,8 @@ noEncryption = NoEncryption("No encryption services configured")
 
 
 class EncryptionError(ErrorIndication):
+    """The message could not be encrypted."""
+
     pass
 
 
@@ -170,6 +206,8 @@ encryptionError = EncryptionError("Ciphering services not available")
 
 
 class DecryptionError(ErrorIndication):
+    """The message could not be decrypted, or the ciphertext is damaged."""
+
     pass
 
 
@@ -179,6 +217,8 @@ decryptionError = DecryptionError(
 
 
 class NoAuthentication(ErrorIndication):
+    """Authentication was asked for, but no protocol is configured."""
+
     pass
 
 
@@ -186,6 +226,8 @@ noAuthentication = NoAuthentication("No authentication services configured")
 
 
 class AuthenticationError(ErrorIndication):
+    """The message could not be authenticated."""
+
     pass
 
 
@@ -195,6 +237,8 @@ authenticationError = AuthenticationError(
 
 
 class AuthenticationFailure(ErrorIndication):
+    """The digest does not match, so the message was altered or the key is wrong."""
+
     pass
 
 
@@ -202,6 +246,8 @@ authenticationFailure = AuthenticationFailure("Authenticator mismatched")
 
 
 class UnsupportedAuthProtocol(ErrorIndication):
+    """The authentication protocol is not one this build supports."""
+
     pass
 
 
@@ -211,6 +257,8 @@ unsupportedAuthProtocol = UnsupportedAuthProtocol(
 
 
 class UnsupportedPrivProtocol(ErrorIndication):
+    """The privacy protocol is not one this build supports."""
+
     pass
 
 
@@ -218,6 +266,8 @@ unsupportedPrivProtocol = UnsupportedPrivProtocol("Privacy protocol is not suppr
 
 
 class UnknownSecurityName(ErrorIndication):
+    """The security name is not one this engine is configured for."""
+
     pass
 
 
@@ -225,6 +275,8 @@ unknownSecurityName = UnknownSecurityName("Unknown SNMP security name encountere
 
 
 class UnsupportedSecurityModel(ErrorIndication):
+    """The message names a security model this engine does not have."""
+
     pass
 
 
@@ -232,6 +284,8 @@ unsupportedSecurityModel = UnsupportedSecurityModel("Unsupported SNMP security m
 
 
 class UnsupportedSecurityLevel(ErrorIndication):
+    """The security level asked for is not one this engine can provide."""
+
     pass
 
 
@@ -242,6 +296,12 @@ unsupportedSecurityLevel = UnsupportedSecurityLevel("Unsupported SNMP security l
 
 
 class NotInTimeWindow(ErrorIndication):
+    """The message's timestamp is outside the window this engine will accept.
+
+    What SNMPv3 uses instead of a nonce: a message too far from the remote
+    engine's clock is a replay, and is refused.
+    """
+
     pass
 
 
@@ -251,6 +311,8 @@ notInTimeWindow = NotInTimeWindow(
 
 
 class UnknownUserName(ErrorIndication):
+    """The USM user is not one this engine is configured for."""
+
     pass
 
 
@@ -258,6 +320,8 @@ unknownUserName = UnknownUserName("Unknown USM user")
 
 
 class WrongDigest(ErrorIndication):
+    """The PDU's digest does not match what was computed for it."""
+
     pass
 
 
@@ -265,6 +329,11 @@ wrongDigest = WrongDigest("Wrong SNMP PDU digest")
 
 
 class ReportPduReceived(ErrorIndication):
+    """The remote engine sent a report instead of a response.
+
+    Carries the report's own counter, which is what says why.
+    """
+
     pass
 
 
@@ -275,6 +344,8 @@ reportPduReceived = ReportPduReceived("Remote SNMP engine reported error")
 
 
 class NoSuchView(ErrorIndication):
+    """The MIB view named does not exist."""
+
     pass
 
 
@@ -282,6 +353,8 @@ noSuchView = NoSuchView("No such MIB view currently exists")
 
 
 class NoAccessEntry(ErrorIndication):
+    """No access entry matches this group, context and security level."""
+
     pass
 
 
@@ -289,6 +362,8 @@ noAccessEntry = NoAccessEntry("Access to MIB node denined")
 
 
 class NoGroupName(ErrorIndication):
+    """No VACM group is configured for this security name."""
+
     pass
 
 
@@ -296,6 +371,8 @@ noGroupName = NoGroupName("No such VACM group configured")
 
 
 class NoSuchContext(ErrorIndication):
+    """The context named does not exist."""
+
     pass
 
 
@@ -303,6 +380,8 @@ noSuchContext = NoSuchContext("SNMP context now found")
 
 
 class NotInView(ErrorIndication):
+    """The OID is outside the view this request is allowed to see."""
+
     pass
 
 
@@ -310,6 +389,8 @@ notInView = NotInView("Requested OID is out of MIB view")
 
 
 class AccessAllowed(ErrorIndication):
+    """Not an error: access control allowed the operation."""
+
     pass
 
 
@@ -317,6 +398,8 @@ accessAllowed = AccessAllowed()
 
 
 class OtherError(ErrorIndication):
+    """Something else went wrong inside the engine."""
+
     pass
 
 
@@ -327,6 +410,11 @@ otherError = OtherError("Unspecified SNMP engine error occurred")
 
 
 class OidNotIncreasing(ErrorIndication):
+    """The agent returned an OID no greater than the one asked about.
+
+    A walk driven off such a response would never end, so it stops here.
+    """
+
     pass
 
 

--- a/pysnmp/proto/error.py
+++ b/pysnmp/proto/error.py
@@ -12,6 +12,8 @@ from pysnmp.error import PySnmpError
 
 
 class ProtocolError(PySnmpError, PyAsn1Error):
+    """Raised when a message cannot be processed."""
+
     pass
 
 
@@ -19,10 +21,19 @@ class ProtocolError(PySnmpError, PyAsn1Error):
 
 
 class SnmpV3Error(ProtocolError):
+    """Raised by the SNMPv3 machinery: message processing, security, access control."""
+
     pass
 
 
 class StatusInformation(SnmpV3Error):
+    """Carries how a step failed, and what the next step needs to know.
+
+    Not always a failure the caller sees: the v3 discovery exchange reports back
+    through this, and the engine reads the details off it like a mapping to decide
+    whether to send a report, reissue the request, or give up.
+    """
+
     def __init__(self, **kwargs):
         SnmpV3Error.__init__(self)
         self.__errorIndication = kwargs
@@ -44,16 +55,24 @@ class StatusInformation(SnmpV3Error):
 
 
 class CacheExpiredError(SnmpV3Error):
+    """The state this message refers to is gone, so it can no longer be answered."""
+
     pass
 
 
 class InternalError(SnmpV3Error):
+    """Something the engine assumed about its own state did not hold."""
+
     pass
 
 
 class MessageProcessingError(SnmpV3Error):
+    """The message could not be prepared or parsed."""
+
     pass
 
 
 class RequestTimeout(SnmpV3Error):
+    """No response arrived in time."""
+
     pass

--- a/pysnmp/proto/mpmod/base.py
+++ b/pysnmp/proto/mpmod/base.py
@@ -15,6 +15,13 @@ class AbstractMessageProcessingModel:
     #: ASN.1 class of the message this model speaks; __init__ instantiates it.
     #: NotImplementedError stands in for a model that has not named one -- it is
     #: constructed, not raised, so the failure surfaces later rather than here.
+    """Turns a PDU into a message and back, for one SNMP version.
+
+    Which version is `messageProcessingModelID`. The model decides what the
+    header looks like and which security model handles it, and holds the state
+    linking an outgoing request to the response that answers it.
+    """
+
     snmpMsgSpec: type[Any] = NotImplementedError
 
     def __init__(self):

--- a/pysnmp/proto/mpmod/base.py
+++ b/pysnmp/proto/mpmod/base.py
@@ -12,9 +12,6 @@ from pysnmp.proto.mpmod import cache
 
 
 class AbstractMessageProcessingModel:
-    #: ASN.1 class of the message this model speaks; __init__ instantiates it.
-    #: NotImplementedError stands in for a model that has not named one -- it is
-    #: constructed, not raised, so the failure surfaces later rather than here.
     """Turns a PDU into a message and back, for one SNMP version.
 
     Which version is `messageProcessingModelID`. The model decides what the
@@ -22,6 +19,9 @@ class AbstractMessageProcessingModel:
     linking an outgoing request to the response that answers it.
     """
 
+    #: ASN.1 class of the message this model speaks; __init__ instantiates it.
+    #: NotImplementedError stands in for a model that has not named one -- it is
+    #: constructed, not raised, so the failure surfaces later rather than here.
     snmpMsgSpec: type[Any] = NotImplementedError
 
     def __init__(self):

--- a/pysnmp/proto/mpmod/cache.py
+++ b/pysnmp/proto/mpmod/cache.py
@@ -10,6 +10,12 @@ from pysnmp.proto import error
 
 
 class Cache:
+    """Holds what a message processing model needs when the response arrives.
+
+    Indexed two ways: by the message ID that goes on the wire, and by the state
+    reference the engine passes around internally.
+    """
+
     __stateReference = nextid.Integer(0xFFFFFF)
     __msgID = nextid.Integer(0xFFFFFF)
 

--- a/pysnmp/proto/mpmod/rfc2576.py
+++ b/pysnmp/proto/mpmod/rfc2576.py
@@ -23,6 +23,8 @@ from pysnmp.proto.mpmod.base import AbstractMessageProcessingModel
 
 
 class SnmpV1MessageProcessingModel(AbstractMessageProcessingModel):
+    """Message processing for SNMPv1."""
+
     messageProcessingModelID = univ.Integer(0)  # SNMPv1
     snmpMsgSpec: type[Any] = v1.Message
 
@@ -585,5 +587,11 @@ class SnmpV1MessageProcessingModel(AbstractMessageProcessingModel):
 
 
 class SnmpV2cMessageProcessingModel(SnmpV1MessageProcessingModel):
+    """Message processing for SNMPv2c.
+
+    The same as v1 apart from the version number and the message type, since the
+    community string works identically in both.
+    """
+
     messageProcessingModelID = univ.Integer(1)  # SNMPv2c
     snmpMsgSpec: type[Any] = v2c.Message

--- a/pysnmp/proto/mpmod/rfc3412.py
+++ b/pysnmp/proto/mpmod/rfc3412.py
@@ -24,6 +24,8 @@ pMod = api.protoModules[api.protoVersion2c]
 
 
 class ScopedPDU(univ.Sequence):
+    """A PDU together with the context it applies to."""
+
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("contextEngineId", univ.OctetString()),
         namedtype.NamedType("contextName", univ.OctetString()),
@@ -32,6 +34,8 @@ class ScopedPDU(univ.Sequence):
 
 
 class ScopedPduData(univ.Choice):
+    """The scoped PDU, either in the clear or encrypted."""
+
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("plaintext", ScopedPDU()),
         namedtype.NamedType("encryptedPDU", univ.OctetString()),
@@ -39,6 +43,13 @@ class ScopedPduData(univ.Choice):
 
 
 class HeaderData(univ.Sequence):
+    """The part of a v3 message every security model can read.
+
+    The message ID, the size the sender will accept, the flags saying whether it
+    is authenticated, encrypted and reportable, and which security model to hand
+    the rest to.
+    """
+
     componentType = namedtype.NamedTypes(
         namedtype.NamedType(
             "msgID",
@@ -71,6 +82,8 @@ class HeaderData(univ.Sequence):
 
 
 class SNMPv3Message(univ.Sequence):
+    """A v3 message: version, header, security parameters, and the scoped PDU."""
+
     componentType = namedtype.NamedTypes(
         namedtype.NamedType(
             "msgVersion",
@@ -96,6 +109,13 @@ _snmpErrors = {
 
 
 class SnmpV3MessageProcessingModel(AbstractMessageProcessingModel):
+    """Message processing for SNMPv3.
+
+    Separates the context from the security parameters, which is what lets v3 use
+    any security model: this handles the message, and USM or another model handles
+    authenticating and encrypting what is inside it.
+    """
+
     messageProcessingModelID = univ.Integer(3)  # SNMPv3
     snmpMsgSpec: type[Any] = SNMPv3Message
     _emptyStr = univ.OctetString("")

--- a/pysnmp/proto/rfc1155.py
+++ b/pysnmp/proto/rfc1155.py
@@ -23,6 +23,12 @@ __all__ = [
 
 
 class IpAddress(univ.OctetString):
+    """An IPv4 address, carried as four octets.
+
+    Accepts and prints the familiar dotted-quad form, which is not what goes on
+    the wire.
+    """
+
     tagSet = univ.OctetString.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassApplication, tag.tagFormatSimple, 0x00)
     )
@@ -46,6 +52,8 @@ class IpAddress(univ.OctetString):
 
 
 class Counter(univ.Integer):
+    """A 32-bit counter, which only ever increases and wraps at its maximum."""
+
     tagSet = univ.Integer.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassApplication, tag.tagFormatSimple, 0x01)
     )
@@ -55,6 +63,8 @@ class Counter(univ.Integer):
 
 
 class NetworkAddress(univ.Choice):
+    """An address in any protocol family SNMPv1 knows, which is only IP."""
+
     componentType = namedtype.NamedTypes(namedtype.NamedType("internet", IpAddress()))
 
     def clone(self, value=univ.noValue, **kwargs):
@@ -111,6 +121,8 @@ class NetworkAddress(univ.Choice):
 
 
 class Gauge(univ.Integer):
+    """A 32-bit gauge, which rises and falls and latches at its maximum."""
+
     tagSet = univ.Integer.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassApplication, tag.tagFormatSimple, 0x02)
     )
@@ -120,6 +132,8 @@ class Gauge(univ.Integer):
 
 
 class TimeTicks(univ.Integer):
+    """Hundredths of a second since some epoch the object's definition names."""
+
     tagSet = univ.Integer.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassApplication, tag.tagFormatSimple, 0x03)
     )
@@ -129,12 +143,16 @@ class TimeTicks(univ.Integer):
 
 
 class Opaque(univ.OctetString):
+    """Any other ASN.1 value, wrapped in octets so SNMPv1 can carry it."""
+
     tagSet = univ.OctetString.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassApplication, tag.tagFormatSimple, 0x04)
     )
 
 
 class ObjectName(univ.ObjectIdentifier):
+    """The name of a managed object: an OID."""
+
     pass
 
 

--- a/pysnmp/proto/rfc1157.py
+++ b/pysnmp/proto/rfc1157.py
@@ -51,24 +51,32 @@ class _RequestBase(univ.Sequence):
 
 
 class GetRequestPDU(_RequestBase):
+    """GET: fetch the objects named."""
+
     tagSet = _RequestBase.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0)
     )
 
 
 class GetNextRequestPDU(_RequestBase):
+    """GETNEXT: fetch the objects following those named."""
+
     tagSet = _RequestBase.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)
     )
 
 
 class GetResponsePDU(_RequestBase):
+    """The answer to a v1 request. Renamed `ResponsePDU` in v2c."""
+
     tagSet = _RequestBase.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 2)
     )
 
 
 class SetRequestPDU(_RequestBase):
+    """SET: write the values given."""
+
     tagSet = _RequestBase.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 3)
     )
@@ -88,6 +96,13 @@ genericTrap = univ.Integer().clone(
 
 
 class TrapPDU(univ.Sequence):
+    """A v1 trap, which is shaped unlike every other PDU.
+
+    It names the enterprise and agent that sent it and a generic and specific
+    trap number, where v2c and later carry the same information as ordinary
+    variable bindings.
+    """
+
     tagSet = univ.Sequence.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 4)
     )

--- a/pysnmp/proto/rfc1901.py
+++ b/pysnmp/proto/rfc1901.py
@@ -13,6 +13,8 @@ version = univ.Integer(namedValues=namedval.NamedValues(("version-2c", 1)))
 
 
 class Message(univ.Sequence):
+    """A v2c message: a version, a community string, and a PDU."""
+
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("version", version),
         namedtype.NamedType("community", univ.OctetString()),

--- a/pysnmp/proto/rfc1905.py
+++ b/pysnmp/proto/rfc1905.py
@@ -39,6 +39,8 @@ unSpecified = UnSpecified("")
 
 
 class NoSuchObject(univ.Null):
+    """Returned in place of a value when the object does not exist."""
+
     tagSet = univ.Null.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0x00)
     )
@@ -51,6 +53,8 @@ noSuchObject = NoSuchObject("")
 
 
 class NoSuchInstance(univ.Null):
+    """Returned in place of a value when the object exists but this instance does not."""
+
     tagSet = univ.Null.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0x01)
     )
@@ -63,6 +67,8 @@ noSuchInstance = NoSuchInstance("")
 
 
 class EndOfMibView(univ.Null):
+    """Returned by GETNEXT and GETBULK when there is nothing past this OID."""
+
     tagSet = univ.Null.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0x02)
     )
@@ -149,6 +155,13 @@ maxRepetitions = univ.Integer().subtype(
 
 # Base class for bulk PDU
 class BulkPDU(univ.Sequence):
+    """What GETBULK adds to a PDU: how many objects to fetch, and how many times.
+
+    The request-id and bindings are as in any PDU, but the two fields where a
+    response carries error status and index instead carry `non-repeaters` and
+    `max-repetitions`.
+    """
+
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("request-id", rfc1902.Integer32()),
         namedtype.NamedType("non-repeaters", nonRepeaters),
@@ -158,48 +171,69 @@ class BulkPDU(univ.Sequence):
 
 
 class GetRequestPDU(PDU):
+    """GET: fetch the objects named."""
+
     tagSet = PDU.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0)
     )
 
 
 class GetNextRequestPDU(PDU):
+    """GETNEXT: fetch the objects following those named."""
+
     tagSet = PDU.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)
     )
 
 
 class ResponsePDU(PDU):
+    """The answer to a request."""
+
     tagSet = PDU.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 2)
     )
 
 
 class SetRequestPDU(PDU):
+    """SET: write the values given."""
+
     tagSet = PDU.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 3)
     )
 
 
 class GetBulkRequestPDU(BulkPDU):
+    """GETBULK: walk several objects at once, in one round trip."""
+
     tagSet = PDU.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 5)
     )
 
 
 class InformRequestPDU(PDU):
+    """A notification that is acknowledged, so the sender knows it arrived."""
+
     tagSet = PDU.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 6)
     )
 
 
 class SNMPv2TrapPDU(PDU):
+    """A notification that is not acknowledged."""
+
     tagSet = PDU.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 7)
     )
 
 
 class ReportPDU(PDU):
+    """How the engine reports a problem with the message itself.
+
+    Sent instead of a response when the failure is below the application -- an
+    unknown engine ID, a wrong authentication digest, a timestamp outside the
+    window -- and carries the counter that says which.
+    """
+
     tagSet = PDU.tagSet.tagImplicitly(
         tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 8)
     )

--- a/pysnmp/proto/secmod/base.py
+++ b/pysnmp/proto/secmod/base.py
@@ -10,8 +10,6 @@ from pysnmp.proto.secmod import cache
 
 
 class AbstractSecurityModel:
-    #: securityModel value this model answers to (:RFC:`3411#section-4`), e.g. 3
-    #: for USM. None until a concrete model names one.
     """Authenticates and encrypts a message, and undoes both on the way in.
 
     Which model is `securityModelID`. Maps between the security name an
@@ -19,6 +17,8 @@ class AbstractSecurityModel:
     the state linking a request to the response that answers it.
     """
 
+    #: securityModel value this model answers to (:RFC:`3411#section-4`), e.g. 3
+    #: for USM. None until a concrete model names one.
     securityModelID: int | None = None
 
     def __init__(self):

--- a/pysnmp/proto/secmod/base.py
+++ b/pysnmp/proto/secmod/base.py
@@ -12,6 +12,13 @@ from pysnmp.proto.secmod import cache
 class AbstractSecurityModel:
     #: securityModel value this model answers to (:RFC:`3411#section-4`), e.g. 3
     #: for USM. None until a concrete model names one.
+    """Authenticates and encrypts a message, and undoes both on the way in.
+
+    Which model is `securityModelID`. Maps between the security name an
+    application uses and whatever credential the wire format carries, and holds
+    the state linking a request to the response that answers it.
+    """
+
     securityModelID: int | None = None
 
     def __init__(self):

--- a/pysnmp/proto/secmod/cache.py
+++ b/pysnmp/proto/secmod/cache.py
@@ -10,6 +10,8 @@ from pysnmp.proto import error
 
 
 class Cache:
+    """Holds what a security model needs when the response arrives."""
+
     __stateReference = nextid.Integer(0xFFFFFF)
 
     def __init__(self):

--- a/pysnmp/proto/secmod/eso/priv/aesbase.py
+++ b/pysnmp/proto/secmod/eso/priv/aesbase.py
@@ -21,6 +21,14 @@ from pysnmp.proto.secmod.rfc7860.auth import hmacsha2
 
 
 class AbstractAesBlumenthal(aes.Aes):
+    """AES with a key extended the way Blumenthal's draft says.
+
+    AES-192 and AES-256 need more key material than a localized key provides, and
+    the two drafts that extend it disagree. This one runs the localization
+    function again over the previous output, chaining until the key is long
+    enough. A peer implementing Reeder's variant will not interoperate.
+    """
+
     serviceID: tuple[int, ...] = ()
     keySize = 0
 

--- a/pysnmp/proto/secmod/rfc2576.py
+++ b/pysnmp/proto/secmod/rfc2576.py
@@ -23,6 +23,13 @@ from pysnmp.smi.error import NoSuchInstanceError
 
 
 class SnmpV1SecurityModel(base.AbstractSecurityModel):
+    """The community string as SNMPv1's security model.
+
+    No authentication and no encryption: the community string is the credential,
+    and it goes on the wire in the clear. Mapping it to a security name, and back,
+    is all this does.
+    """
+
     securityModelID = 1
 
     # According to rfc2576, community name <-> contextEngineId/contextName
@@ -609,6 +616,8 @@ class SnmpV1SecurityModel(base.AbstractSecurityModel):
 
 
 class SnmpV2cSecurityModel(SnmpV1SecurityModel):
+    """The community string as SNMPv2c's security model, identical but for its ID."""
+
     securityModelID = 2
 
 

--- a/pysnmp/proto/secmod/rfc3414/auth/base.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/base.py
@@ -9,8 +9,6 @@ from pysnmp.proto import errind, error
 
 
 class AbstractAuthenticationService:
-    #: OID naming the protocol this service implements, e.g. usmHMACMD5AuthProtocol.
-    #: Concrete services differ in length, so the arity cannot be pinned here.
     """Computes and checks the digest that authenticates a message.
 
     A passphrase is hashed once, then localized to each engine it is used with, so
@@ -18,6 +16,8 @@ class AbstractAuthenticationService:
     open another.
     """
 
+    #: OID naming the protocol this service implements, e.g. usmHMACMD5AuthProtocol.
+    #: Concrete services differ in length, so the arity cannot be pinned here.
     serviceID: tuple[int, ...] | None = None
 
     def hashPassphrase(self, authKey):

--- a/pysnmp/proto/secmod/rfc3414/auth/base.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/base.py
@@ -11,6 +11,13 @@ from pysnmp.proto import errind, error
 class AbstractAuthenticationService:
     #: OID naming the protocol this service implements, e.g. usmHMACMD5AuthProtocol.
     #: Concrete services differ in length, so the arity cannot be pinned here.
+    """Computes and checks the digest that authenticates a message.
+
+    A passphrase is hashed once, then localized to each engine it is used with, so
+    the key on the wire differs per engine and a key learned from one does not
+    open another.
+    """
+
     serviceID: tuple[int, ...] | None = None
 
     def hashPassphrase(self, authKey):

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
@@ -25,6 +25,8 @@ _fortyEightZeros = (0,) * 48
 
 
 class HmacMd5(base.AbstractAuthenticationService):
+    """HMAC-MD5-96. Broken; use `HmacSha2` instead."""
+
     serviceID: tuple[int, ...] = (
         1,
         3,

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
@@ -25,6 +25,8 @@ _fortyFourZeros = (0,) * 44
 
 
 class HmacSha(base.AbstractAuthenticationService):
+    """HMAC-SHA-96. Weak; use `HmacSha2` instead."""
+
     serviceID: tuple[int, ...] = (
         1,
         3,

--- a/pysnmp/proto/secmod/rfc3414/auth/noauth.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/noauth.py
@@ -10,6 +10,8 @@ from pysnmp.proto.secmod.rfc3414.auth import base
 
 
 class NoAuth(base.AbstractAuthenticationService):
+    """No authentication: computes no digest and accepts any message."""
+
     serviceID: tuple[int, ...] = (1, 3, 6, 1, 6, 3, 10, 1, 1, 1)  # usmNoAuthProtocol
 
     def hashPassphrase(self, authKey):

--- a/pysnmp/proto/secmod/rfc3414/priv/base.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/base.py
@@ -11,6 +11,13 @@ from pysnmp.proto import error
 class AbstractEncryptionService:
     #: OID naming the protocol this service implements, e.g. usmDESPrivProtocol.
     #: Concrete services differ in length, so the arity cannot be pinned here.
+    """Encrypts and decrypts the scoped PDU.
+
+    Keys are derived and localized as for authentication; `keySize` says how much
+    key material the cipher needs, which is what decides whether a localized key
+    has to be extended first.
+    """
+
     serviceID: tuple[int, ...] | None = None
     keySize = 0
 

--- a/pysnmp/proto/secmod/rfc3414/priv/base.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/base.py
@@ -9,8 +9,6 @@ from pysnmp.proto import error
 
 
 class AbstractEncryptionService:
-    #: OID naming the protocol this service implements, e.g. usmDESPrivProtocol.
-    #: Concrete services differ in length, so the arity cannot be pinned here.
     """Encrypts and decrypts the scoped PDU.
 
     Keys are derived and localized as for authentication; `keySize` says how much
@@ -18,6 +16,8 @@ class AbstractEncryptionService:
     has to be extended first.
     """
 
+    #: OID naming the protocol this service implements, e.g. usmDESPrivProtocol.
+    #: Concrete services differ in length, so the arity cannot be pinned here.
     serviceID: tuple[int, ...] | None = None
     keySize = 0
 

--- a/pysnmp/proto/secmod/rfc3414/priv/des.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/des.py
@@ -25,6 +25,8 @@ from pysnmp.proto.secmod.rfc7860.auth import hmacsha2
 
 
 class Des(base.AbstractEncryptionService):
+    """CBC-DES. Broken; use `Aes` or a stronger AES variant instead."""
+
     serviceID: tuple[int, ...] = (1, 3, 6, 1, 6, 3, 10, 1, 2, 2)  # usmDESPrivProtocol
     keySize = 16
 

--- a/pysnmp/proto/secmod/rfc3414/priv/nopriv.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/nopriv.py
@@ -10,6 +10,8 @@ from pysnmp.proto.secmod.rfc3414.priv import base
 
 
 class NoPriv(base.AbstractEncryptionService):
+    """No privacy: leaves the scoped PDU in the clear."""
+
     serviceID: tuple[int, ...] = (1, 3, 6, 1, 6, 3, 10, 1, 2, 1)  # usmNoPrivProtocol
 
     def hashPassphrase(self, authProtocol, privKey):

--- a/pysnmp/proto/secmod/rfc3414/service.py
+++ b/pysnmp/proto/secmod/rfc3414/service.py
@@ -62,6 +62,8 @@ def _run_or_raise_serialization_error(operation: Callable[[], _T], logLabel: str
 
 
 class UsmSecurityParameters(univ.Sequence):
+    """The USM header: whose engine, how far along its clock, which user, and the digest."""
+
     componentType = namedtype.NamedTypes(
         namedtype.NamedType("msgAuthoritativeEngineId", univ.OctetString()),
         namedtype.NamedType(
@@ -88,6 +90,14 @@ class UsmSecurityParameters(univ.Sequence):
 
 
 class SnmpUSMSecurityModel(AbstractSecurityModel):
+    """USM: per-user authentication and encryption for SNMPv3.
+
+    Keys are localized to the authoritative engine, so this first has to learn
+    which engine that is and how far along its clock is -- the discovery exchange,
+    where the first request comes back as a report. Messages outside the time
+    window are refused, which is what stops a replay.
+    """
+
     securityModelID = 3
     authServices = {
         hmacmd5.HmacMd5.serviceID: hmacmd5.HmacMd5(),

--- a/pysnmp/proto/secmod/rfc3826/priv/aes.py
+++ b/pysnmp/proto/secmod/rfc3826/priv/aes.py
@@ -21,6 +21,12 @@ from pysnmp.proto.secmod.rfc7860.auth import hmacsha2
 
 
 class Aes(base.AbstractEncryptionService):
+    """CFB128-AES-128.
+
+    The salt is a counter, not a random value, so no two messages from this engine
+    share an initialization vector.
+    """
+
     serviceID: tuple[int, ...] = (1, 3, 6, 1, 6, 3, 10, 1, 2, 4)  # usmAesCfb128Protocol
     keySize = 16
     _localInt = secrets.randbits(64)

--- a/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
+++ b/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
@@ -18,6 +18,12 @@ from pysnmp.proto.secmod.rfc3414.auth import base
 
 
 class HmacSha2(base.AbstractAuthenticationService):
+    """HMAC-SHA-2, at 224, 256, 384 or 512 bits.
+
+    One class for all four: `serviceID` picks which, and the hash, key length and
+    digest length follow from it.
+    """
+
     sha224ServiceID = (1, 3, 6, 1, 6, 3, 10, 1, 1, 4)  # usmHMAC128SHA224AuthProtocol
     sha256ServiceID = (1, 3, 6, 1, 6, 3, 10, 1, 1, 5)  # usmHMAC192SHA256AuthProtocol
     sha384ServiceID = (1, 3, 6, 1, 6, 3, 10, 1, 1, 6)  # usmHMAC256SHA384AuthProtocol

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -185,11 +185,11 @@ class __AbstractMibSource:
 
 
 class ZipMibSource(__AbstractMibSource):
+    """MIB modules loaded out of a zip archive, including an egg or a wheel."""
+
     # zipimport.zipimporter carries the archive directory privately, and
     # typeshed describes neither it nor the loader `__import__` hands back, so
     # there is nothing narrower to say here than what `_archiveFiles` checks.
-    """MIB modules loaded out of a zip archive, including an egg or a wheel."""
-
     __loader: Any
 
     @staticmethod

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -188,6 +188,8 @@ class ZipMibSource(__AbstractMibSource):
     # zipimport.zipimporter carries the archive directory privately, and
     # typeshed describes neither it nor the loader `__import__` hands back, so
     # there is nothing narrower to say here than what `_archiveFiles` checks.
+    """MIB modules loaded out of a zip archive, including an egg or a wheel."""
+
     __loader: Any
 
     @staticmethod
@@ -322,6 +324,8 @@ MibSource = __AbstractMibSource
 
 
 class DirMibSource(__AbstractMibSource):
+    """MIB modules loaded out of a filesystem directory."""
+
     def _init(self) -> Any:
         self._srcName = os.path.normpath(self._srcName)
         return self
@@ -400,6 +404,14 @@ def revisionOf(codeObj: Any) -> str | None:
 
 
 class MibBuilder:
+    """Loads MIB modules and holds the symbols they define.
+
+    A module is searched for across every registered source, and where more than
+    one source has it, the copy stating the newest MODULE-IDENTITY revision wins;
+    search order settles only what the revisions cannot. Loading a module loads
+    what it IMPORTS first, so asking for one symbol can pull in a graph of them.
+    """
+
     defaultCoreMibs = os.pathsep.join(("pysnmp.smi.mibs.instances", "pysnmp.smi.mibs"))
     defaultMiscMibs = "pysnmp_mibs"
 

--- a/pysnmp/smi/error.py
+++ b/pysnmp/smi/error.py
@@ -15,18 +15,31 @@ from pysnmp.error import PySnmpError
 
 
 class SmiError(PySnmpError, PyAsn1Error):
+    """Raised when a MIB cannot be loaded or a managed object cannot be served."""
+
     pass
 
 
 class MibLoadError(SmiError):
+    """Raised when a MIB module was found but could not be loaded."""
+
     pass
 
 
 class MibNotFoundError(MibLoadError):
+    """Raised when no source holds the MIB module that was asked for."""
+
     pass
 
 
 class MibOperationError(SmiError):
+    """Raised while serving a managed object, carrying named details.
+
+    The details are what the caller needs to build a response -- which binding
+    failed, what the old value was -- and are read off the exception like a
+    mapping. Subclasses are the SNMP error statuses of :RFC:`3416#section-3`.
+    """
+
     def __init__(self, **kwargs):
         self.__outArgs = kwargs
 
@@ -53,74 +66,110 @@ class MibOperationError(SmiError):
 
 
 class TooBigError(MibOperationError):
+    """The response would not fit in one message."""
+
     pass
 
 
 class NoSuchNameError(MibOperationError):
+    """No such object, as SNMPv1 reports it."""
+
     pass
 
 
 class BadValueError(MibOperationError):
+    """The value is not acceptable for the object, as SNMPv1 reports it."""
+
     pass
 
 
 class ReadOnlyError(MibOperationError):
+    """The object cannot be written, as SNMPv1 reports it."""
+
     pass
 
 
 class GenError(MibOperationError):
+    """Something else went wrong."""
+
     pass
 
 
 class NoAccessError(MibOperationError):
+    """The object is not accessible to this request."""
+
     pass
 
 
 class WrongTypeError(MibOperationError):
+    """The value is of the wrong type for the object."""
+
     pass
 
 
 class WrongLengthError(MibOperationError):
+    """The value is the right type but the wrong length."""
+
     pass
 
 
 class WrongEncodingError(MibOperationError):
+    """The value is not encoded the way its type requires."""
+
     pass
 
 
 class WrongValueError(MibOperationError):
+    """The value is well-formed but outside what the object accepts."""
+
     pass
 
 
 class NoCreationError(MibOperationError):
+    """The instance does not exist and cannot be created."""
+
     pass
 
 
 class InconsistentValueError(MibOperationError):
+    """The value is valid on its own but not against the rest of the state."""
+
     pass
 
 
 class ResourceUnavailableError(MibOperationError):
+    """The write needs a resource that is not available."""
+
     pass
 
 
 class CommitFailedError(MibOperationError):
+    """The write passed its checks but could not be committed."""
+
     pass
 
 
 class UndoFailedError(MibOperationError):
+    """A commit failed and undoing it failed too."""
+
     pass
 
 
 class AuthorizationError(MibOperationError):
+    """The request is not authorized."""
+
     pass
 
 
 class NotWritableError(MibOperationError):
+    """The object is not writable, as SNMPv2c and later report it."""
+
     pass
 
 
 class InconsistentNameError(MibOperationError):
+    """The instance name is inconsistent with the rest of the row."""
+
     pass
 
 
@@ -128,14 +177,20 @@ class InconsistentNameError(MibOperationError):
 
 
 class NoSuchObjectError(NoSuchNameError):
+    """No such object in this view, the SNMPv2c `noSuchObject` exception."""
+
     pass
 
 
 class NoSuchInstanceError(NoSuchNameError):
+    """The object exists but has no such instance, `noSuchInstance`."""
+
     pass
 
 
 class EndOfMibViewError(NoSuchNameError):
+    """There is nothing past this OID, the `endOfMibView` exception."""
+
     pass
 
 
@@ -143,12 +198,22 @@ class EndOfMibViewError(NoSuchNameError):
 
 
 class TableRowManagement(MibOperationError):
+    """Raised to ask the caller to create or destroy a conceptual row.
+
+    Not a failure: a write to a RowStatus column is how SNMP asks for a row to
+    appear or go away, and this is how the column tells the table about it.
+    """
+
     pass
 
 
 class RowCreationWanted(TableRowManagement):
+    """A row should be created."""
+
     pass
 
 
 class RowDestructionWanted(TableRowManagement):
+    """A row should be destroyed."""
+
     pass

--- a/pysnmp/smi/instrum.py
+++ b/pysnmp/smi/instrum.py
@@ -16,6 +16,13 @@ __all__ = ["AbstractMibInstrumController", "MibInstrumController"]
 
 
 class AbstractMibInstrumController:
+    """What the agent side needs from whatever serves its managed objects.
+
+    Three operations, matching the request types: read the objects named, read the
+    ones following them, and write. Implement this to serve objects from
+    something other than a loaded MIB.
+    """
+
     def readVars(
         self, varBinds: Any, acInfo: tuple[Any, Any] = (None, None)
     ) -> list[Any]:
@@ -33,6 +40,14 @@ class AbstractMibInstrumController:
 
 
 class MibInstrumController(AbstractMibInstrumController):
+    """Serves managed objects out of the MIB modules a builder loaded.
+
+    Each operation runs as a state machine over every variable binding at once,
+    which is what SNMP requires of a write: every binding is tested before any is
+    committed, and a failure anywhere rolls all of them back, so a SET either
+    happens completely or not at all.
+    """
+
     fsmReadVar: dict[tuple[str, str], str] = {
         # ( state, status ) -> newState
         ("start", "ok"): "readTest",

--- a/pysnmp/smi/view.py
+++ b/pysnmp/smi/view.py
@@ -21,6 +21,13 @@ classTypes = (type,)
 
 
 class MibViewController:
+    """Indexes what a builder loaded, and answers questions about names and OIDs.
+
+    Resolves a label to an OID and back, and walks to the next object in OID
+    order across every loaded module -- which is not the order the modules were
+    loaded in, nor lexical order on their names.
+    """
+
     def __init__(self, mibBuilder):
         self.mibBuilder = mibBuilder
         self.lastBuildId = -1


### PR DESCRIPTION
Second of the #186 stages. `D101` comes off the ignore list: 182 classes that had no docstring now have one, and ruff holds the line on the next one added.

## What a class docstring is for here

What the class is for, not what its methods are named. The ones worth writing are where SNMP itself is surprising:

- `NextCommandGenerator` walks by reissuing GETNEXT until the subtree runs out; `NextCommandGeneratorSingleRun` sends one and stops. The names do not say that.
- `MibInstrumController` runs each operation as a state machine over every binding at once, because SNMP requires a SET to test all of them before committing any, and to roll all of them back on one failure.
- `NotInTimeWindow` is what SNMPv3 has instead of a nonce.
- `AbstractAesBlumenthal` extends a localized key by chaining the localization function, and will not interoperate with a peer implementing Reeder's variant.
- `TableRowManagement` and its two subclasses are not failures -- they are how a RowStatus write asks a table for a row.
- `rfc1157.TrapPDU` is shaped unlike every other PDU; the docstring says what v2c carries instead.
- The weak-crypto classes -- `HmacMd5`, `HmacSha`, `Des` -- name their replacement in one line.

The 39 `errind` classes each carried a description string on the module-level instance below them and nothing on the class itself. Each now says what the condition actually is: `EngineIDMismatch` is "the response came from a different engine than the request went to", not "SNMP engine ID mismatch encountered".

## One deletion outside pyproject.toml

`AbstractAsyncioTransport` had a string literal sitting after its first assignment. That is an attribute docstring for `protoTransportDispatcher`, not documentation of the class, and nothing rendered it. Promoted to the class docstring it was meant to be.

## Shape of the diff

50 files, **591 insertions and 8 deletions** -- 7 of the 8 are the reworded `pyproject.toml` comment, the last is the literal above. Nothing else changed.

## What is still off

`D103`/`D107` (104 functions and constructors), `D102` (347 methods), `D105` (55 magic methods) -- ~506 items. The comment in `pyproject.toml` keeps the order.

## Verification

- `ruff check` clean, `ruff format --check` clean (216 files)
- `mypy pysnmp` clean (147 source files)
- 1258 passed, 12 skipped
- Every modified file re-parsed with `ast` to confirm each docstring is the class body's first statement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded public API documentation across transport, protocol, security, SMI, debugging, and SNMP operation components.
  - Added guidance for obsolete compatibility wrappers and recommendations to use modern APIs or stronger security algorithms where applicable.
  - Clarified transport address formats, MIB handling, notification behavior, request processing, and security model responsibilities.
  - Updated documentation coverage tracking to reflect improved class documentation and fewer remaining undocumented entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->