### PR TITLE
docs: say what every function and constructor is for (D103/D107)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,23 +211,21 @@ ignore = [
     "S509",     # snmp-weak-cryptography
 
     # The docstring family, adopted in stages -- see #186. What is on now is
-    # the shape of the docstrings that exist, plus D100/D104 and D101: every
-    # module, package and class says what it is for. What is still off is the
-    # requirement that every public function and method have one, which is
-    # ~506 items and is a documentation project rather than a lint fix.
-    # Writing 347 method docstrings mechanically produces noise, not
-    # documentation.
+    # the shape of the docstrings that exist, plus D100/D104, D101 and
+    # D103/D107: every module, package, class, function and constructor says
+    # what it is for. What is still off is the requirement that every method
+    # have one, which is 394 items and is a documentation project rather
+    # than a lint fix. Writing 346 method docstrings mechanically produces
+    # noise, not documentation.
     #
     # These come off one rule at a time, each its own reviewable change:
     #   D100/D104  104 modules and packages -- done
     #   D101       182 classes -- done
-    #   D103/D107  104 functions and constructors
-    #   D102       347 methods, probably by subpackage
-    #   D105        55 magic methods
+    #   D103/D107  102 functions and constructors -- done
+    #   D102       346 methods, probably by subpackage
+    #   D105        48 magic methods
     "D102",     # undocumented-public-method
-    "D103",     # undocumented-public-function
     "D105",     # undocumented-magic-method
-    "D107",     # undocumented-public-init
 
     # The one rule pyasn1 keeps that this does not, and the only place the two
     # rule sets differ. Every third-person summary it caught -- "Returns the",

--- a/pysnmp/carrier/asyncio/dgram/base.py
+++ b/pysnmp/carrier/asyncio/dgram/base.py
@@ -62,6 +62,12 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
     unboundLocalAddress: "tuple | str | None" = None
 
     def __init__(self, sock=None, sockMap=None, loop=None):
+        """Binds to an event loop now, creating one where there is no running loop.
+
+        Writes are queued rather than sent, because the transport does not exist until
+        asyncio has created the endpoint; socket options are queued for the same reason
+        and applied to the socket once there is one.
+        """
         self._writeQ = []
         self._lport = None
         self._pendingSocketOptions = []

--- a/pysnmp/carrier/asyncio/dgram/unix.py
+++ b/pysnmp/carrier/asyncio/dgram/unix.py
@@ -41,6 +41,11 @@ class UnixAsyncioTransport(DgramAsyncioProtocol):
     addressType = UnixTransportAddress
 
     def __init__(self, *args, **kwargs):
+        """Tracks the socket path, so a client-mode socket can be unlinked on close.
+
+        A Unix datagram client has to bind a path of its own to receive a reply, and
+        nothing else removes that file.
+        """
         DgramAsyncioProtocol.__init__(self, *args, **kwargs)
         self._iface = None
 

--- a/pysnmp/carrier/asyncio/dispatch.py
+++ b/pysnmp/carrier/asyncio/dispatch.py
@@ -42,6 +42,12 @@ class AsyncioDispatcher(AbstractTransportDispatcher):
     """AsyncioDispatcher based on asyncio event loop."""
 
     def __init__(self, *args, **kwargs):
+        """Binds to an event loop, creating one where there is no running loop.
+
+        The transport count is what decides whether the timer is running: the periodic
+        call is started when the first transport registers and stopped when the last
+        goes away, so an idle dispatcher does not keep the loop awake.
+        """
         AbstractTransportDispatcher.__init__(self)
         self.__transportCount = 0
         if "timeout" in kwargs:

--- a/pysnmp/carrier/base.py
+++ b/pysnmp/carrier/base.py
@@ -25,6 +25,7 @@ class TimerCallable:
     """
 
     def __init__(self, cbFun, callInterval):
+        """The first call is due immediately; the interval applies from then on."""
         self.__cbFun = cbFun
         self.__nextCall = 0
 
@@ -61,6 +62,11 @@ class AbstractTransportDispatcher:
     """
 
     def __init__(self):
+        """The timer resolution is what the whole timeout mechanism is built on.
+
+        It defaults to half a second, and the delta is the slack allowed around a tick
+        so a callback due fractionally early is not deferred a whole tick.
+        """
         self.__transports = {}
         self.__transportDomainMap = {}
         self.__jobs = {}

--- a/pysnmp/carrier/sockmsg.py
+++ b/pysnmp/carrier/sockmsg.py
@@ -76,6 +76,14 @@ class in6_pktinfo(ctypes.Structure):
 
 
 def getRecvFrom(addressType):
+    """Build a `recvfrom()` that also reports which local address a datagram reached.
+
+    A socket bound to the wildcard answers `getsockname()` with the wildcard, which
+    is no use for deciding where a reply should come from. The kernel does know,
+    and `IP_PKTINFO` or `IPV6_PKTINFO` is how it says so: the destination address
+    arrives as ancillary data alongside the datagram, and is attached to the
+    address the caller gets back.
+    """
 
     def recvfrom(s, sz):
         _to = None
@@ -106,6 +114,13 @@ def getRecvFrom(addressType):
 
 
 def getSendTo(addressType):
+    """Build a `sendto()` that sends from the address the request arrived on.
+
+    This is the other half of `getRecvFrom()`: the local address recorded on the
+    destination is passed back to the kernel as ancillary data, so a reply leaves
+    by the address the request was sent to rather than whichever one routing would
+    have picked.
+    """
 
     def sendto(s, _data, _to):
         ancdata = []

--- a/pysnmp/debug.py
+++ b/pysnmp/debug.py
@@ -47,6 +47,7 @@ class Printer:
     """Where debug output goes, defaulting to stderr through `logging`."""
 
     def __init__(self, logger=None, handler=None, formatter=None):
+        """Defaults to a stderr handler on the `pysnmp` logger at DEBUG level."""
         if logger is None:
             logger = logging.getLogger("pysnmp")
         logger.setLevel(logging.DEBUG)
@@ -79,6 +80,15 @@ class Debug:
     defaultPrinter = None
 
     def __init__(self, *flags, **options):
+        """Resolve where output goes, then turn on the flags named.
+
+        `printer` wins, then a class-wide default, then `loggerName` -- which attaches
+        to an existing logger with a null handler of its own, so output is routed by
+        whatever configured that logger rather than to stderr as well.
+
+        An unknown flag name is an error rather than a no-op: a misspelt flag would
+        otherwise silently turn nothing on.
+        """
         self._flags = flagNone
         if options.get("printer") is not None:
             self._printer = options.get("printer")
@@ -188,6 +198,7 @@ def prettify(value):
 
 
 def hexdump(octets):
+    """Octets as hexadecimal, sixteen to a line with the offset at the start."""
     return " ".join(
         [
             "{}{:02X}".format(n % 16 == 0 and f"\n{n:05d}: " or "", x)

--- a/pysnmp/entity/config.py
+++ b/pysnmp/entity/config.py
@@ -226,6 +226,17 @@ def addV1System(
     transportTag: Any | None = None,
     securityName: Any | None = None,
 ) -> None:
+    """Map a community name onto a security name, for v1 and v2c.
+
+    Writes a row of `snmpCommunityEntry` (:RFC:`3584#section-5`), which is what
+    gives a community-based message a `securityName` the access control model can
+    reason about. `securityName` defaults to `communityIndex` rather than to the
+    community itself, so the name VACM sees is not the secret on the wire.
+
+    `transportTag` is how a community is confined to a set of transport addresses:
+    it matches the tag on a `snmpTargetAddrEntry` row, and an empty tag means any
+    source is accepted.
+    """
     __checkLegacyVersions(snmpEngine)
     __warnAboutLegacyVersion(stacklevel=3)
 
@@ -268,6 +279,7 @@ def addV1System(
 
 
 def delV1System(snmpEngine: Any, communityIndex: str) -> None:
+    """Remove the community mapping `communityIndex` names."""
     (snmpCommunityEntry, tblIdx, snmpEngineID) = __cookV1SystemInfo(
         snmpEngine, communityIndex
     )
@@ -317,7 +329,21 @@ def addV3User(
     # deprecated parameter
     contextEngineId: Any | None = None,
 ) -> None:
+    """Configure a USM user, deriving localized keys from the passphrases.
 
+    This writes two tables. `usmUserEntry` (:RFC:`3414#section-5`) holds the user
+    and the protocols it uses; `pysnmpUsmSecretEntry` holds the passphrases, which
+    the standard table deliberately has nowhere to keep -- USM stores localized
+    keys, and a key localized to one engine ID cannot be relocalized to another.
+    Keeping the passphrase is what lets a user configured before the authoritative
+    engine ID is known be re-localized once it is.
+
+    `authKeyType` and `privKeyType` say whether the key given is a passphrase to be
+    localized or a key already localized to `securityEngineId`; passing an already
+    localized key for the wrong engine is not detectable here.
+
+    `contextEngineId` is deprecated and means `securityEngineId`.
+    """
     __checkPrivBackend(privProtocol)
     __warnAboutProtocol(authProtocol, stacklevel=3)
     __warnAboutProtocol(privProtocol, stacklevel=3)
@@ -460,6 +486,10 @@ def delV3User(
     # deprecated parameters follow
     contextEngineId: Any | None = None,
 ) -> None:
+    """Remove USM user `userName`, along with the passphrases kept for it.
+
+    `contextEngineId` is deprecated and means `securityEngineId`.
+    """
     if securityEngineId is None:  # backward compatibility
         securityEngineId = contextEngineId
     (securityEngineId, usmUserEntry, tblIdx1, pysnmpUsmSecretEntry, tblIdx2) = (
@@ -516,6 +546,13 @@ def addTargetParams(
     securityLevel: int,
     mpModel: int = 3,
 ) -> None:
+    """Name a (message processing model, security model, level) triple.
+
+    Writes `snmpTargetParamsEntry` (:RFC:`3413#section-4.2`). `mpModel` selects
+    both the message processing model and the security model that goes with it: 0
+    is SNMPv1, 1 and 2 are v2c, 3 is v3 with USM. The name this binds is what
+    `addTargetAddr()` refers to.
+    """
     if mpModel == 0:
         securityModel = 1
     elif mpModel in (1, 2):
@@ -543,6 +580,7 @@ def addTargetParams(
 
 
 def delTargetParams(snmpEngine: Any, name: str) -> None:
+    """Remove the target parameters named `name`."""
     snmpTargetParamsEntry, tblIdx = __cookTargetParamsInfo(snmpEngine, name)
     snmpEngine.msgAndPduDsp.mibInstrumController.writeVars(
         ((snmpTargetParamsEntry.name + (7,) + tblIdx, "destroy"),)
@@ -573,6 +611,16 @@ def addTargetAddr(
     tagList: Any = b"",
     sourceAddress: Any | None = None,
 ) -> None:
+    """Name a destination address, and the parameters to reach it with.
+
+    Writes `snmpTargetAddrEntry` (:RFC:`3413#section-4.1`), plus a row of
+    `pysnmpSourceAddrEntry` when `sourceAddress` is given -- the source address is
+    not something the standard table can express, and it is what lets a host with
+    several addresses choose which one a notification appears to come from.
+
+    `tagList` is what a notification profile and a community's `transportTag`
+    match against to find this address.
+    """
     mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
 
     (snmpTargetAddrEntry, snmpSourceAddrEntry, tblIdx) = __cookTargetAddrInfo(
@@ -614,6 +662,7 @@ def addTargetAddr(
 
 
 def delTargetAddr(snmpEngine: Any, addrName: str) -> None:
+    """Remove the target address named `addrName`."""
     (snmpTargetAddrEntry, snmpSourceAddrEntry, tblIdx) = __cookTargetAddrInfo(
         snmpEngine, addrName
     )
@@ -623,6 +672,14 @@ def delTargetAddr(snmpEngine: Any, addrName: str) -> None:
 
 
 def addTransport(snmpEngine: Any, transportDomain: Any, transport: Any) -> None:
+    """Bind a transport to a domain, creating a dispatcher if there is none.
+
+    A transport and a dispatcher share an I/O model, so a transport that does not
+    match the engine's existing dispatcher is refused rather than mixed in. Where
+    the engine has no dispatcher yet, one of the transport's own kind is created
+    and its loop taken from the transport; that dispatcher is reference-counted, so
+    `delTransport()` can shut down what was created implicitly.
+    """
     if snmpEngine.transportDispatcher:
         if not transport.isCompatibleWithDispatcher(snmpEngine.transportDispatcher):
             raise error.PySnmpError(
@@ -649,6 +706,7 @@ def addTransport(snmpEngine: Any, transportDomain: Any, transport: Any) -> None:
 
 
 def getTransport(snmpEngine: Any, transportDomain: Any) -> Any:
+    """The transport bound to `transportDomain`, or `None` if there is none."""
     if not snmpEngine.transportDispatcher:
         return
     try:
@@ -658,6 +716,12 @@ def getTransport(snmpEngine: Any, transportDomain: Any) -> Any:
 
 
 def delTransport(snmpEngine: Any, transportDomain: Any) -> Any:
+    """Unbind the transport at `transportDomain` and return it.
+
+    A dispatcher that `addTransport()` created implicitly is closed once the last
+    transport using it goes away. One the caller registered is left alone: it was
+    not this module's to create and is not this module's to close.
+    """
     if not snmpEngine.transportDispatcher:
         return
     transport = getTransport(snmpEngine, transportDomain)
@@ -768,6 +832,13 @@ def __cookVacmGroupInfo(
 def addVacmGroup(
     snmpEngine: Any, groupName: str, securityModel: int, securityName: Any
 ) -> None:
+    """Put a security name into a VACM group.
+
+    Writes `vacmSecurityToGroupEntry` (:RFC:`3415#section-4.1.2`). The pair that
+    identifies a row is (security model, security name), so the same name under
+    USM and under a community is two different rows and can land in two different
+    groups.
+    """
     (vacmSecurityToGroupEntry, tblIdx) = __cookVacmGroupInfo(
         snmpEngine, securityModel, securityName
     )
@@ -785,6 +856,7 @@ def addVacmGroup(
 
 
 def delVacmGroup(snmpEngine: Any, securityModel: int, securityName: Any) -> None:
+    """Remove the group membership of `securityName` under `securityModel`."""
     vacmSecurityToGroupEntry, tblIdx = __cookVacmGroupInfo(
         snmpEngine, securityModel, securityName
     )
@@ -822,6 +894,12 @@ def addVacmAccess(
     writeView: Any,
     notifyView: Any,
 ) -> None:
+    """Grant a group its read, write and notify views in a context.
+
+    Writes `vacmAccessEntry` (:RFC:`3415#section-4.1.4`). `contextMatch` is
+    ``exact`` or ``prefix``, and `securityLevel` is a floor rather than an
+    equality: a row written for `authNoPriv` also applies to `authPriv`.
+    """
     vacmAccessEntry, tblIdx = __cookVacmAccessInfo(
         snmpEngine, groupName, contextPrefix, securityModel, securityLevel
     )
@@ -850,6 +928,7 @@ def delVacmAccess(
     securityModel: int,
     securityLevel: int,
 ) -> None:
+    """Remove a group's access rights in a context."""
     vacmAccessEntry, tblIdx = __cookVacmAccessInfo(
         snmpEngine, groupName, contextPrefix, securityModel, securityLevel
     )
@@ -872,6 +951,16 @@ def __cookVacmViewInfo(snmpEngine: Any, viewName: str, subTree: Any) -> tuple[An
 def addVacmView(
     snmpEngine: Any, viewName: str, viewType: str, subTree: Any, subTreeMask: Any
 ) -> None:
+    """Include or exclude a subtree in a named view.
+
+    Writes `vacmViewTreeFamilyEntry` (:RFC:`3415#section-4.1.5`). `viewType` is
+    ``included`` or ``excluded``, and the most specific matching row wins, which is
+    what lets a view name a subtree and then carve a hole in it.
+
+    The mask may be given as an OID as well as an octet string -- a dotted string
+    is recognised by the separator in it and converted -- because writing a
+    bitmask as ``1.1.1.0.1`` is easier to check by eye than the octet it packs to.
+    """
     vacmViewTreeFamilyEntry, tblIdx = __cookVacmViewInfo(snmpEngine, viewName, subTree)
 
     # Allow bitmask specification in form of an OID
@@ -903,6 +992,7 @@ def addVacmView(
 
 
 def delVacmView(snmpEngine: Any, viewName: str, subTree: Any) -> None:
+    """Remove `subTree` from the view named `viewName`."""
     vacmViewTreeFamilyEntry, tblIdx = __cookVacmViewInfo(snmpEngine, viewName, subTree)
     snmpEngine.msgAndPduDsp.mibInstrumController.writeVars(
         ((vacmViewTreeFamilyEntry.name + (6,) + tblIdx, "destroy"),)
@@ -935,6 +1025,14 @@ def addVacmUser(
     notifySubTree: Any = (),
     contextName: Any = b"",
 ) -> None:
+    """Configure a user's access in one call: group, access and views.
+
+    VACM is three tables that have to agree, and each of the three is useless
+    without the other two. This derives a group name and view names from the
+    security name, then writes the context, the group membership, the access
+    rights and one view per subtree given. A subtree left empty means no view is
+    created, which denies that kind of access rather than granting all of it.
+    """
     (groupName, securityLevel, readView, writeView, notifyView) = __cookVacmUserInfo(
         snmpEngine, securityModel, securityName, securityLevel
     )
@@ -969,6 +1067,7 @@ def delVacmUser(
     notifySubTree: Any = (),
     contextName: Any = b"",
 ) -> None:
+    """Undo what `addVacmUser()` configured for this security name."""
     (groupName, securityLevel, readView, writeView, notifyView) = __cookVacmUserInfo(
         snmpEngine, securityModel, securityName, securityLevel
     )
@@ -994,6 +1093,11 @@ def addRoUser(
     subTree: Any,
     contextName: Any = b"",
 ) -> None:
+    """Grant read-only access to `subTree`.
+
+    Obsolete: `addVacmUser()` with a `readSubTree` says the same thing and can
+    grant the other kinds of access at the same time.
+    """
     addVacmUser(
         snmpEngine,
         securityModel,
@@ -1012,6 +1116,10 @@ def delRoUser(
     subTree: Any,
     contextName: Any = b"",
 ) -> None:
+    """Revoke the read-only access `addRoUser()` granted.
+
+    Obsolete: see `delVacmUser()`.
+    """
     delVacmUser(
         snmpEngine,
         securityModel,
@@ -1030,6 +1138,11 @@ def addRwUser(
     subTree: Any,
     contextName: Any = b"",
 ) -> None:
+    """Grant read and write access to `subTree`.
+
+    Obsolete: `addVacmUser()` with `readSubTree` and `writeSubTree` says the same
+    thing.
+    """
     addVacmUser(
         snmpEngine,
         securityModel,
@@ -1049,6 +1162,10 @@ def delRwUser(
     subTree: Any,
     contextName: Any = b"",
 ) -> None:
+    """Revoke the read-write access `addRwUser()` granted.
+
+    Obsolete: see `delVacmUser()`.
+    """
     delVacmUser(
         snmpEngine,
         securityModel,
@@ -1068,6 +1185,10 @@ def addTrapUser(
     subTree: Any,
     contextName: Any = b"",
 ) -> None:
+    """Grant the right to receive notifications about `subTree`.
+
+    Obsolete: `addVacmUser()` with a `notifySubTree` says the same thing.
+    """
     addVacmUser(
         snmpEngine,
         securityModel,
@@ -1088,6 +1209,10 @@ def delTrapUser(
     subTree: Any,
     contextName: Any = b"",
 ) -> None:
+    """Revoke the notify access `addTrapUser()` granted.
+
+    Obsolete: see `delVacmUser()`.
+    """
     delVacmUser(
         snmpEngine,
         securityModel,
@@ -1158,6 +1283,16 @@ def addNotificationTarget(
     filterType: Any | None = None,
     filterProfileName: Any | None = None,
 ) -> None:
+    """Say what to notify, where to send it, and what to leave out.
+
+    Writes `snmpNotifyEntry` (:RFC:`3413#section-4.3`), which binds a transport tag
+    to a notify type -- ``trap``, which is not acknowledged, or ``inform``, which
+    is. Where a filter subtree is given it also writes the filter profile and the
+    filter itself, so a target can be sent some notifications and not others.
+
+    The address is not named here: `transportTag` selects every `addTargetAddr()`
+    row carrying that tag, which is what lets one notification go to several.
+    """
     (
         snmpNotifyEntry,
         tblIdx1,
@@ -1218,6 +1353,7 @@ def delNotificationTarget(
     filterSubtree: Any | None = None,
     filterProfileName: Any | None = None,
 ) -> None:
+    """Remove a notification target, and its filter profile if it had one."""
     (
         snmpNotifyEntry,
         tblIdx1,
@@ -1255,6 +1391,13 @@ def setInitialVacmParameters(snmpEngine: Any) -> None:
     # rfc3415: A.1.1 --> initial-semi-security-configuration
 
     # rfc3415: A.1.2
+    """Write the initial VACM configuration from :RFC:`3415#appendix-A.1`.
+
+    This is the semi-secure configuration the RFC describes: an `initial` user
+    that can read the system group unauthenticated, and read or write more of the
+    tree once it authenticates. It exists so a freshly started engine can be
+    configured over SNMP rather than only out of band.
+    """
     addContext(snmpEngine, "")
 
     # rfc3415: A.1.3

--- a/pysnmp/entity/engine.py
+++ b/pysnmp/entity/engine.py
@@ -112,6 +112,18 @@ class SnmpEngine:
         msgAndPduDsp: Any = None,
         enableLegacyVersions: bool | None = None,
     ) -> None:
+        """Assemble the subsystems, and settle which SNMP versions this engine speaks.
+
+        `snmpEngineID` defaults to the one the MIB generated for this host, which is
+        derived from a MAC address where one can be found. `snmpEngineBoots` is
+        incremented here: :RFC:`3414#section-2.2` counts a boot as an engine coming up,
+        and USM's time window checks depend on it moving.
+
+        `enableLegacyVersions` decides whether the v1 and v2c message processing and
+        security models are registered at all. Leaving them out is the enforcement --
+        see the note in the body -- and `None` means take the default from the
+        environment.
+        """
         self.cache: dict[Any, Any] = {}
 
         self.observer = observer.MetaObserver()

--- a/pysnmp/entity/observer.py
+++ b/pysnmp/entity/observer.py
@@ -85,6 +85,12 @@ class MetaObserver:
     """
 
     def __init__(self):
+        """Observers, their contexts and the live execution points are kept apart.
+
+        A context exists only while execution is inside the point it belongs to; the
+        three dictionaries are separate so that registering an observer does not depend
+        on any point having been reached yet.
+        """
         self.__observers = {}
         self.__contexts = {}
         self.__execpoints = {}

--- a/pysnmp/entity/rfc3413/cmdgen.py
+++ b/pysnmp/entity/rfc3413/cmdgen.py
@@ -24,6 +24,17 @@ __null = univ.Null("")
 
 
 def getNextVarBinds(varBinds, origVarBinds=None):
+    """The bindings to ask for next, and why to stop if there are none.
+
+    A walk ends when every binding has run off the end of its subtree. Exception
+    values -- `noSuchObject`, `noSuchInstance`, `endOfMibView` -- are what say a
+    particular binding is finished, so they are counted rather than carried
+    forward, and when none are left the walk is over.
+
+    An agent answering a GETNEXT with an OID no greater than the one asked for
+    would loop forever, so `origVarBinds` is compared against the response and that
+    is reported as an error indication instead.
+    """
     errorIndication = None
     idx = nonNulls = len(varBinds)
     rspVarBinds = []
@@ -67,6 +78,7 @@ class CommandGenerator:
     sendReq: Callable[..., Any]
 
     def __init__(self, **options):
+        """Options are kept as given and read per request, not merged here."""
         self.__options = options
         self.__pendingReqs = {}
 

--- a/pysnmp/entity/rfc3413/cmdrsp.py
+++ b/pysnmp/entity/rfc3413/cmdrsp.py
@@ -30,6 +30,7 @@ class CommandResponderBase:
     pduTypes: tuple[tag.TagSet, ...] = ()
 
     def __init__(self, snmpEngine, snmpContext):
+        """Registers this responder for its PDU types under the context engine ID."""
         snmpEngine.msgAndPduDsp.registerContextEngineId(
             snmpContext.contextEngineId, self.pduTypes, self.processPdu
         )

--- a/pysnmp/entity/rfc3413/config.py
+++ b/pysnmp/entity/rfc3413/config.py
@@ -10,6 +10,13 @@ from pysnmp.smi.error import NoSuchInstanceError, SmiError
 
 
 def getTargetAddr(snmpEngine, snmpTargetAddrName):
+    """Read a target address row, memoised against the table's version.
+
+    Every outgoing notification looks this up, so it is cached in the engine's user
+    context rather than re-read. `branchVersionId` is what makes that safe: the MIB
+    bumps it on any write under the table, so a stale cache is discarded rather
+    than served.
+    """
     mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
 
     (snmpTargetAddrEntry,) = mibBuilder.importSymbols(
@@ -113,6 +120,11 @@ def getTargetAddr(snmpEngine, snmpTargetAddrName):
 
 
 def getTargetParams(snmpEngine, paramsName):
+    """Read a target parameters row, memoised the same way as the address.
+
+    The message processing model is mapped to a version the transport can name, and
+    an unsupported model is refused here rather than further down.
+    """
     mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
 
     (snmpTargetParamsEntry,) = mibBuilder.importSymbols(
@@ -175,6 +187,11 @@ def getTargetParams(snmpEngine, paramsName):
 
 def getTargetInfo(snmpEngine, snmpTargetAddrName):
     # Transport endpoint
+    """Everything needed to reach one target: where, how, and as whom.
+
+    Joins the address row to the parameters row it names, which is the pair a
+    notification originator needs and neither table holds alone.
+    """
     (
         snmpTargetAddrTDomain,
         snmpTargetAddrTAddress,
@@ -203,6 +220,11 @@ def getTargetInfo(snmpEngine, snmpTargetAddrName):
 
 
 def getNotificationInfo(snmpEngine, notificationTarget):
+    """The transport tag and notify type for a notification target.
+
+    The tag is not an address: it selects every target address row carrying it,
+    which is how one notification reaches several destinations.
+    """
     mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
 
     (snmpNotifyEntry,) = mibBuilder.importSymbols(
@@ -243,6 +265,12 @@ def getNotificationInfo(snmpEngine, notificationTarget):
 
 
 def getTargetNames(snmpEngine, tag):
+    """Every target address name tagged with `tag`.
+
+    The tag list on a row is whitespace-separated, so this is a membership test
+    across the table rather than a lookup, and it is memoised for the same reason
+    the row reads are.
+    """
     mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
 
     (snmpTargetAddrEntry,) = mibBuilder.importSymbols(

--- a/pysnmp/entity/rfc3413/context.py
+++ b/pysnmp/entity/rfc3413/context.py
@@ -19,6 +19,7 @@ class SnmpContext:
     """
 
     def __init__(self, snmpEngine, contextEngineId=None):
+        """Defaults the context engine ID to the local engine's own."""
         (snmpEngineId,) = (
             snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder.importSymbols(
                 "__SNMP-FRAMEWORK-MIB", "snmpEngineID"

--- a/pysnmp/entity/rfc3413/mibvar.py
+++ b/pysnmp/entity/rfc3413/mibvar.py
@@ -20,6 +20,11 @@ from pysnmp.smi.error import NoSuchObjectError
 
 
 def mibNameToOid(mibView, name):
+    """Resolve a (module, symbol) name and index suffix to an OID.
+
+    Obsolete: `pysnmp.smi.rfc1902.ObjectIdentity` does this and carries the result
+    with it.
+    """
     if isinstance(name[0], tuple):
         modName, symName = (tuple(name[0]) + ("", ""))[:2]
         if modName:  # load module if needed
@@ -51,6 +56,10 @@ __scalarSuffix = (univ.Integer(0),)
 
 
 def oidToMibName(mibView, oid):
+    """Resolve an OID back to the module, symbol and index that name it.
+
+    Obsolete: see `pysnmp.smi.rfc1902.ObjectIdentity`.
+    """
     if not isinstance(oid, tuple):
         oid = tuple(univ.ObjectIdentifier(oid))
     _oid, label, suffix = mibView.getNodeNameByOid(oid)
@@ -74,6 +83,13 @@ def oidToMibName(mibView, oid):
 
 
 def cloneFromMibValue(mibView, modName, symName, value):
+    """A value of the syntax the named object declares, or `None`.
+
+    Returns `None` for a node that has no syntax -- an OID assignment rather than
+    an object -- which is not an error, only nothing to clone.
+
+    Obsolete: see `pysnmp.smi.rfc1902.ObjectType`.
+    """
     (mibNode,) = mibView.mibBuilder.importSymbols(modName, symName)
     if hasattr(mibNode, "syntax"):  # scalar
         return mibNode.syntax.clone(value)

--- a/pysnmp/entity/rfc3413/ntforg.py
+++ b/pysnmp/entity/rfc3413/ntforg.py
@@ -116,6 +116,11 @@ class NotificationOriginator:
     sendNotification: Callable[..., Any]
 
     def __init__(self, **options):
+        """Traps and informs are tracked apart: only informs are awaited.
+
+        `snmpContext` is accepted for compatibility and is not used; the context comes
+        from the notification target configuration.
+        """
         self.__pendingReqs = {}
         self.__pendingNotifications = {}
         self.snmpContext = options.pop("snmpContext", None)  # this is deprecated

--- a/pysnmp/entity/rfc3413/ntfrcv.py
+++ b/pysnmp/entity/rfc3413/ntfrcv.py
@@ -27,6 +27,14 @@ class NotificationReceiver:
     )
 
     def __init__(self, snmpEngine, cbFun, cbCtx=None):
+        """Registers under the wildcard context engine ID, for any authoritative engine.
+
+        The community a v1 trap arrived with is not in the PDU by the time the callback
+        sees it, so an observer captures it during processing and it is passed on
+        separately. A callback written against the pre-4.4 signature is still called
+        correctly: the newer one is tried first and the `TypeError` it raises is what
+        selects the older.
+        """
         snmpEngine.msgAndPduDsp.registerContextEngineId(
             b"",
             self.pduTypes,

--- a/pysnmp/entity/rfc3413/oneliner/cmdgen.py
+++ b/pysnmp/entity/rfc3413/oneliner/cmdgen.py
@@ -32,6 +32,7 @@ class AsynCommandGenerator:
     lcd = CommandGeneratorLcdConfigurator()
 
     def __init__(self, snmpEngine=None):
+        """Creates an engine if none is given, and owns it for its lifetime."""
         if snmpEngine is None:
             self.snmpEngine = SnmpEngine()
         else:
@@ -264,6 +265,7 @@ class CommandGenerator:
 
     def __init__(self, snmpEngine=None, asynCmdGen=None):
         # compatibility attributes
+        """`asynCmdGen` is accepted for compatibility and ignored."""
         self.snmpEngine = snmpEngine or SnmpEngine()
 
     def getCmd(self, authData, transportTarget, *varNames, **kwargs):

--- a/pysnmp/entity/rfc3413/oneliner/ntforg.py
+++ b/pysnmp/entity/rfc3413/oneliner/ntforg.py
@@ -44,6 +44,11 @@ class AsynNotificationOriginator:
     lcd = NotificationOriginatorLcdConfigurator()
 
     def __init__(self, snmpEngine=None, snmpContext=None):
+        """Creates an engine and a default context if neither is given.
+
+        The default context it adds is never removed, which is one of the reasons this
+        class is obsolete.
+        """
         if snmpEngine is None:
             self.snmpEngine = snmpEngine = SnmpEngine()
         else:
@@ -158,6 +163,7 @@ class NotificationOriginator:
 
     def __init__(self, snmpEngine=None, snmpContext=None, asynNtfOrg=None):
         # compatibility attributes
+        """`asynNtfOrg` is accepted for compatibility and ignored."""
         self.snmpEngine = snmpEngine or SnmpEngine()
         self.mibViewController = self.vbProcessor.getMibViewController(self.snmpEngine)
 

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -49,6 +49,7 @@ lcd = CommandGeneratorLcdConfigurator()
 
 
 def isEndOfMib(x):
+    """Whether a walk has run off the end of every subtree it was following."""
     return not cmdgen.getNextVarBinds(x)[1]
 
 

--- a/pysnmp/hlapi/asyncio/sync/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/sync/cmdgen.py
@@ -79,6 +79,7 @@ def getCmd(
     *varBinds: Any,
     **options: Any,
 ) -> Iterator[tuple[Any, Any, Any, Any]]:
+    """Blocking GET. Yields one result, then whatever bindings are sent back in."""
     return _single(
         cmdgen.getCmd,
         snmpEngine,
@@ -98,6 +99,7 @@ def setCmd(
     *varBinds: Any,
     **options: Any,
 ) -> Iterator[tuple[Any, Any, Any, Any]]:
+    """Blocking SET. Yields one result, then whatever bindings are sent back in."""
     return _single(
         cmdgen.setCmd,
         snmpEngine,
@@ -117,6 +119,12 @@ def nextCmd(
     *varBinds: Any,
     **options: Any,
 ) -> Iterator[tuple[Any, Any, Any, Any]]:
+    """Blocking GETNEXT, walking until the end of the subtree.
+
+    `lexicographicMode` decides whether the walk stops at the end of the subtree it
+    started in or carries on to the end of the MIB; `maxRows` and `maxCalls` bound
+    it either way.
+    """
     loop = _loop()
     lexicographicMode = options.pop("lexicographicMode", True)
     ignoreNonIncreasingOid = options.pop("ignoreNonIncreasingOid", False)
@@ -202,6 +210,12 @@ def bulkCmd(
     *varBinds: Any,
     **options: Any,
 ) -> Iterator[tuple[Any, Any, Any, Any]]:
+    """Blocking GETBULK, walking until the end of the subtree.
+
+    `nonRepeaters` is how many of the bindings are fetched once rather than walked,
+    and `maxRepetitions` how many rows the agent should return per pass -- a value
+    larger than the response can hold is answered with fewer, not an error.
+    """
     loop = _loop()
     lexicographicMode = options.pop("lexicographicMode", True)
     ignoreNonIncreasingOid = options.pop("ignoreNonIncreasingOid", False)

--- a/pysnmp/hlapi/asyncio/sync/ntforg.py
+++ b/pysnmp/hlapi/asyncio/sync/ntforg.py
@@ -10,6 +10,11 @@ __all__ = ["sendNotification"]
 def sendNotification(
     snmpEngine, authData, transportTarget, contextData, notifyType, varBinds, **options
 ):
+    """Blocking trap or inform delivery.
+
+    Runs on an event loop of its own, so it is usable from code that has none;
+    calling it from inside a running loop raises rather than deadlocking.
+    """
     try:
         asyncio.get_running_loop()
     except RuntimeError:

--- a/pysnmp/hlapi/auth.py
+++ b/pysnmp/hlapi/auth.py
@@ -134,6 +134,17 @@ class CommunityData:
         tag: Any = None,
         securityName: str | None = None,
     ) -> None:
+        """Configure community-based access, deriving what was not given.
+
+        Called with one argument, that argument is the community name -- the older
+        two-argument form put the index first, and telling them apart is what the
+        swapping here is for.
+
+        The index defaults to a hash of everything that distinguishes this
+        configuration, so two different communities do not collide in the LCD, and the
+        security name tracks the index rather than the community, so the name VACM sees
+        is not the secret.
+        """
         if mpModel is not None:
             self.mpModel = mpModel
             self.securityModel = mpModel + 1
@@ -399,6 +410,16 @@ class UsmUserData:
         authKeyType: int = usmKeyTypePassphrase,
         privKeyType: int = usmKeyTypePassphrase,
     ) -> None:
+        """Configure a USM user, deriving the security level from the keys given.
+
+        The level is not passed in: a user with neither key is `noAuthNoPriv`, with an
+        authentication key `authNoPriv`, and with both `authPriv`. A privacy key
+        without an authentication key is refused, since :RFC:`3414` has no such level.
+
+        Where a key is given and its protocol is not, the protocol defaults to what
+        :RFC:`3414` specifies -- HMAC-MD5 and DES -- which are weak and are what the
+        run-time warnings are about.
+        """
         self.userName = userName
         if securityName is None:
             self.securityName = userName

--- a/pysnmp/proto/acmod/rfc3415.py
+++ b/pysnmp/proto/acmod/rfc3415.py
@@ -19,6 +19,12 @@ class Vacm:
     _powOfTwoSeq = (128, 64, 32, 16, 8, 4, 2, 1)
 
     def __init__(self):
+        """Four VACM tables, each cached against its own branch version.
+
+        Access control runs on every variable binding of every request, so the tables
+        are read once and kept. Each has its own version ID, so a write to one does not
+        discard the caches of the other three.
+        """
         self._contextBranchId = -1
         self._groupNameBranchId = -1
         self._accessBranchId = -1

--- a/pysnmp/proto/api/verdec.py
+++ b/pysnmp/proto/api/verdec.py
@@ -17,6 +17,14 @@ from pysnmp.proto.error import ProtocolError
 
 
 def decodeMessageVersion(wholeMsg):
+    """The version field of a message, read without decoding the rest.
+
+    The dispatcher has to know which message processing model to hand a message to
+    before it can be parsed, and the version is the second field of the outer
+    sequence. So this decodes only as far as that integer and leaves the remainder
+    alone, which also means a message for a model this engine does not have is
+    never fully parsed.
+    """
     try:
         seq, wholeMsg = decoder.decode(
             wholeMsg,

--- a/pysnmp/proto/cache.py
+++ b/pysnmp/proto/cache.py
@@ -16,6 +16,7 @@ class Cache:
     """
 
     def __init__(self):
+        """Nothing is cached until a request is added."""
         self.__cacheRepository = {}
 
     def add(self, index, **kwargs):

--- a/pysnmp/proto/errind.py
+++ b/pysnmp/proto/errind.py
@@ -19,6 +19,12 @@ class ErrorIndication(Exception):
     """SNMPv3 error-indication values."""
 
     def __init__(self, descr=None):
+        """The value is the class name with a lowercase first letter.
+
+        That is what makes an instance compare equal to the string the engine passes
+        around, so a caller can test against either. `descr` changes what is printed
+        without changing what it compares as.
+        """
         self.__value = self.__descr = (
             self.__class__.__name__[0].lower() + self.__class__.__name__[1:]
         )

--- a/pysnmp/proto/error.py
+++ b/pysnmp/proto/error.py
@@ -35,6 +35,7 @@ class StatusInformation(SnmpV3Error):
     """
 
     def __init__(self, **kwargs):
+        """Details are kept as given and read back like a mapping."""
         SnmpV3Error.__init__(self)
         self.__errorIndication = kwargs
         debug.logger & (

--- a/pysnmp/proto/mpmod/base.py
+++ b/pysnmp/proto/mpmod/base.py
@@ -25,6 +25,10 @@ class AbstractMessageProcessingModel:
     snmpMsgSpec: type[Any] = NotImplementedError
 
     def __init__(self):
+        """Each model instance gets its own message spec and cache.
+
+        The spec is instantiated rather than shared because decoding writes into it.
+        """
         self._snmpMsgSpec = self.snmpMsgSpec()  # local copy
         self._cache = cache.Cache()
 

--- a/pysnmp/proto/mpmod/cache.py
+++ b/pysnmp/proto/mpmod/cache.py
@@ -20,6 +20,13 @@ class Cache:
     __msgID = nextid.Integer(0xFFFFFF)
 
     def __init__(self):
+        """Three indices over the same entries, plus the expiration queue.
+
+        A message is looked up by the message ID that came back on the wire, by the
+        state reference the engine passes internally, and by the handle the application
+        holds -- three different questions about one exchange. The expiration queue is
+        what eventually drops an exchange nothing answered.
+        """
         self.__msgIdIndex = {}
         self.__stateReferenceIndex = {}
         self.__sendPduHandleIdx = {}

--- a/pysnmp/proto/mpmod/rfc3412.py
+++ b/pysnmp/proto/mpmod/rfc3412.py
@@ -129,6 +129,12 @@ class SnmpV3MessageProcessingModel(AbstractMessageProcessingModel):
     }
 
     def __init__(self):
+        """Adds the engine ID cache the v3 discovery exchange depends on.
+
+        Discovery is what learns a remote engine's ID, and it is expensive enough that
+        the answer is kept per transport address and expired on a timer rather than
+        repeated per request.
+        """
         AbstractMessageProcessingModel.__init__(self)
         self.__scopedPDU = ScopedPDU()
         self.__engineIdCache = {}

--- a/pysnmp/proto/proxy/rfc2576.py
+++ b/pysnmp/proto/proxy/rfc2576.py
@@ -104,6 +104,14 @@ __zeroInt = v1.Integer(0)
 
 
 def v1ToV2(v1Pdu, origV2Pdu=None, snmpTrapCommunity=""):
+    """Translate a v1 PDU into its v2c equivalent (:RFC:`2576#section-3.1`).
+
+    A trap is the awkward case: v1 carries enterprise, agent address and the
+    generic and specific trap numbers in the PDU itself, and v2c carries none of
+    them, so they become variable bindings and the trap number becomes an OID.
+    Where `snmpTrapCommunity` is given it is appended as a binding, since a v2c
+    trap has nowhere else to put it.
+    """
     pduType = v1Pdu.tagSet
     v2Pdu = __v1ToV2PduMap[pduType].clone()
 
@@ -187,6 +195,19 @@ def v1ToV2(v1Pdu, origV2Pdu=None, snmpTrapCommunity=""):
 
 
 def v2ToV1(v2Pdu, origV1Pdu=None):
+    """Translate a v2c PDU into its v1 equivalent (:RFC:`2576#section-4.1`).
+
+    The translation is lossy in the direction v1 cannot express. `Counter64`
+    has no v1 form at all, and what to do about it depends on what was asked:
+    a GET becomes a `noSuchName` error, a GETNEXT has to be reissued past the
+    offending object, and anything else is a protocol error -- which is why
+    `origV1Pdu` is needed rather than optional for a response. The exception
+    values v2c added become `noSuchName` as well.
+
+    On any error the bindings are echoed from `origV1Pdu`, since :RFC:`3416`
+    leaves them unspecified in an error response and v1 managers expect what
+    they sent.
+    """
     debug.logger & debug.flagPrx and debug.logger(
         f"v2ToV1: v2Pdu {v2Pdu.prettyPrint()}"
     )

--- a/pysnmp/proto/rfc3412.py
+++ b/pysnmp/proto/rfc3412.py
@@ -29,6 +29,12 @@ class MsgAndPduDispatcher:
     """
 
     def __init__(self, mibInstrumController=None):
+        """Creates MIB instrumentation if none is given, and loads what the engine needs.
+
+        The modules loaded here are the ones the engine itself reads and writes during
+        normal operation -- its counters, its USM and VACM tables -- so they are not
+        optional and are not left to the application to remember.
+        """
         if mibInstrumController is None:
             self.mibInstrumController = instrum.MibInstrumController(
                 builder.MibBuilder()

--- a/pysnmp/proto/secmod/base.py
+++ b/pysnmp/proto/secmod/base.py
@@ -22,6 +22,7 @@ class AbstractSecurityModel:
     securityModelID: int | None = None
 
     def __init__(self):
+        """Each model instance gets its own cache of in-flight requests."""
         self._cache = cache.Cache()
 
     def processIncomingMsg(

--- a/pysnmp/proto/secmod/cache.py
+++ b/pysnmp/proto/secmod/cache.py
@@ -15,6 +15,7 @@ class Cache:
     __stateReference = nextid.Integer(0xFFFFFF)
 
     def __init__(self):
+        """Nothing is cached until a request is pushed."""
         self.__cacheEntries = {}
 
     def push(self, **securityData):

--- a/pysnmp/proto/secmod/rfc2576.py
+++ b/pysnmp/proto/secmod/rfc2576.py
@@ -39,6 +39,12 @@ class SnmpV1SecurityModel(base.AbstractSecurityModel):
     # in here.
 
     def __init__(self):
+        """Four MIB caches, each invalidated by its own table's version.
+
+        Mapping a community to a security name and back reads several tables on every
+        message, so each is cached separately and only the one that was written is
+        discarded.
+        """
         self.__transportBranchId = self.__paramsBranchId = self.__communityBranchId = (
             self.__securityBranchId
         ) = -1

--- a/pysnmp/proto/secmod/rfc3414/localkey.py
+++ b/pysnmp/proto/secmod/rfc3414/localkey.py
@@ -16,6 +16,12 @@ from pyasn1.type import univ
 
 
 def hashPassphrase(passphrase, hashFunc):
+    """The password-to-key hash of :RFC:`3414#appendix-A.2`, not yet localized.
+
+    The passphrase is repeated into a ring buffer and exactly one megabyte of it is
+    hashed. The cost is the point: it is what makes a short passphrase expensive to
+    attack by brute force. The result is not usable as a key until localized.
+    """
     passphrase = univ.OctetString(passphrase).asOctets()
     # noinspection PyDeprecation,PyCallingNonCallable
     hasher = hashFunc()
@@ -40,10 +46,18 @@ def hashPassphrase(passphrase, hashFunc):
 
 
 def passwordToKey(passphrase, snmpEngineId, hashFunc):
+    """A passphrase hashed and then localized to `snmpEngineId`, in one step."""
     return localizeKey(hashPassphrase(passphrase, hashFunc), snmpEngineId, hashFunc)
 
 
 def localizeKey(passKey, snmpEngineId, hashFunc):
+    """Bind a key to one engine ID (:RFC:`3414#appendix-A.2`).
+
+    Hashes key, engine ID and key again, so the result cannot be used against any
+    other engine. This is what makes a key stolen from one agent useless at the
+    next, and also what means a key cannot be re-localized -- the passphrase is
+    needed for that.
+    """
     passKey = univ.OctetString(passKey).asOctets()
     # noinspection PyDeprecation,PyCallingNonCallable
     digest = hashFunc(passKey + snmpEngineId.asOctets() + passKey).digest()
@@ -52,25 +66,39 @@ def localizeKey(passKey, snmpEngineId, hashFunc):
 
 # RFC3414: A.2.1
 def hashPassphraseMD5(passphrase):
+    """The MD5 password-to-key hash of :RFC:`3414#appendix-A.2.1`."""
     return hashPassphrase(passphrase, md5)
 
 
 # RFC3414: A.2.2
 def hashPassphraseSHA(passphrase):
+    """The SHA-1 password-to-key hash of :RFC:`3414#appendix-A.2.2`."""
     return hashPassphrase(passphrase, sha1)
 
 
 def passwordToKeyMD5(passphrase, snmpEngineId):
+    """An MD5 passphrase hashed and localized to `snmpEngineId`."""
     return localizeKey(hashPassphraseMD5(passphrase), snmpEngineId, md5)
 
 
 def passwordToKeySHA(passphrase, snmpEngineId):
+    """A passphrase localized to `snmpEngineId` with SHA-1.
+
+    Does not implement :RFC:`3414#appendix-A.2.2`: the passphrase is hashed with
+    MD5 rather than SHA-1 before being localized, so the key this returns does not
+    match what another implementation derives from the same passphrase. Nothing in
+    pysnmp calls it -- the SHA-1 authentication service uses `hashPassphraseSHA()`
+    and `localizeKeySHA()`, which are correct -- and changing it would change the
+    keys of anyone who does.
+    """
     return localizeKey(hashPassphraseMD5(passphrase), snmpEngineId, sha1)
 
 
 def localizeKeyMD5(passKey, snmpEngineId):
+    """An already-hashed MD5 key bound to `snmpEngineId`."""
     return localizeKey(passKey, snmpEngineId, md5)
 
 
 def localizeKeySHA(passKey, snmpEngineId):
+    """An already-hashed SHA-1 key bound to `snmpEngineId`."""
     return localizeKey(passKey, snmpEngineId, sha1)

--- a/pysnmp/proto/secmod/rfc3414/service.py
+++ b/pysnmp/proto/secmod/rfc3414/service.py
@@ -127,6 +127,13 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
     wildcardSecurityEngineId = pMod.OctetString(hexValue="0000000000")
 
     def __init__(self):
+        """Adds the timeline USM needs to detect a replayed message.
+
+        :RFC:`3414#section-2.2.3` requires the engine boots and time of every remote
+        engine it talks to be tracked, since that is what the time window is checked
+        against. It is expired on a timer, so an engine no longer being talked to does
+        not be remembered forever.
+        """
         AbstractSecurityModel.__init__(self)
         self.__securityParametersSpec = UsmSecurityParameters()
         self.__timeline = {}

--- a/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
+++ b/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
@@ -48,6 +48,13 @@ class HmacSha2(base.AbstractAuthenticationService):
     }
 
     def __init__(self, oid):
+        """Selects the SHA-2 variant the protocol OID names.
+
+        The four variants differ in digest length and in how much of the digest goes on
+        the wire (:RFC:`7860#section-4`), so both are looked up here and an OID for a
+        variant this does not implement is refused at construction rather than at first
+        use.
+        """
         if oid not in self.hashAlgorithms:
             raise error.ProtocolError(
                 f"No SHA-2 authentication algorithm {oid} available"

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -448,6 +448,14 @@ class MibBuilder:
     loaderContract = (1, 0)
 
     def __init__(self) -> None:
+        """Assemble the search path, in the order modules are looked for.
+
+        The environment comes first (`PYSNMP_MIB_PKGS`, `PYSNMP_MIB_DIRS`,
+        `PYSNMP_MIB_DIR`), then the core modules, which are inserted at the front so
+        nothing overrides the ones the engine itself needs, then the generated ones.
+        That ordering is what lets a user's copy of a MIB shadow the bundled one
+        without being able to displace the framework modules.
+        """
         self.lastBuildId = self._autoName = 0
         sources = []
         for ev in "PYSNMP_MIB_PKGS", "PYSNMP_MIB_DIRS", "PYSNMP_MIB_DIR":

--- a/pysnmp/smi/compiler.py
+++ b/pysnmp/smi/compiler.py
@@ -37,6 +37,12 @@ except ImportError as e:
     from pysnmp.smi import error
 
     def addMibCompilerDecorator(errorMsg):
+        """Build the stand-in `addMibCompiler()` used when pysmi is not installed.
+
+        The import error is captured here so the failure names what was missing,
+        rather than reporting only that no compiler is configured.
+        """
+
         def addMibCompiler(mibBuilder, **kwargs):
             if not kwargs.get("ifAvailable"):
                 raise error.SmiError(f"MIB compiler not available: {errorMsg}")
@@ -48,6 +54,12 @@ except ImportError as e:
 else:
 
     def addMibCompiler(mibBuilder, **kwargs):
+        """Attach a MIB compiler to the builder, so ASN.1 can be compiled on demand.
+
+        Without pysmi installed this raises `SmiError` naming the missing import,
+        unless `ifAvailable` is set. `ifNotAdded` makes the call a no-op where a
+        compiler is already attached.
+        """
         if kwargs.get("ifNotAdded") and mibBuilder.getMibCompiler():
             return
 

--- a/pysnmp/smi/error.py
+++ b/pysnmp/smi/error.py
@@ -41,6 +41,7 @@ class MibOperationError(SmiError):
     """
 
     def __init__(self, **kwargs):
+        """Details are kept as given and read back like a mapping."""
         self.__outArgs = kwargs
 
     def __str__(self):

--- a/pysnmp/smi/indices.py
+++ b/pysnmp/smi/indices.py
@@ -17,6 +17,12 @@ class OrderedDict(dict):
     """Ordered dictionary used for indices."""
 
     def __init__(self, *args, **kwargs):
+        """Key order is tracked alongside the mapping and sorted lazily.
+
+        The dirty flag is what makes that lazy: keys are appended on insert and the
+        ordering is computed on the first read that needs it, so a load of many
+        objects sorts once rather than on every insert.
+        """
         self.__keys = []
         self.__dirty = True
         super().__init__()
@@ -114,6 +120,12 @@ class OidOrderedDict(OrderedDict):
     """OID-ordered dictionary used for indices."""
 
     def __init__(self, *args, **kwargs):
+        """Adds a cache of key to OID tuple on top of the ordered dictionary.
+
+        Keys arrive as tuples and as strings, and OID order is numeric per
+        sub-identifier rather than lexical, so the tuple each key sorts by is
+        converted once and kept.
+        """
         self.__keysCache = {}
         OrderedDict.__init__(self, *args, **kwargs)
 

--- a/pysnmp/smi/instrum.py
+++ b/pysnmp/smi/instrum.py
@@ -82,6 +82,12 @@ class MibInstrumController(AbstractMibInstrumController):
     }
 
     def __init__(self, mibBuilder: Any) -> None:
+        """Indexing is deferred: `lastBuildId` starts behind whatever the builder has.
+
+        The controller re-indexes when the builder's build ID has moved, so starting
+        behind means the first operation indexes and no module load has to remember to
+        trigger it.
+        """
         self.mibBuilder = mibBuilder
         self.lastBuildId = -1
         self.lastBuildSyms: dict[str, Any] = {}

--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -92,6 +92,12 @@ class ObjectIdentity:
     stDirty, stClean = 1, 2
 
     def __init__(self, *args, **kwargs):
+        """Arguments are kept unresolved; `resolveWithMib()` is what interprets them.
+
+        What was passed can be a name, an OID, a module and symbol, or a symbol and
+        index values, and telling those apart needs a MIB view that may not exist yet.
+        So this only records them, and the object stays dirty until resolved.
+        """
         self.__args = args
         self.__kwargs = kwargs
         self.__mibSourcesToAdd = self.__modNamesToLoad = None
@@ -745,6 +751,12 @@ class ObjectType:
     stDirty, stClean = 1, 2
 
     def __init__(self, objectIdentity, objectSyntax=rfc1905.unSpecified):
+        """Pairs an identity with a value, both unresolved until `resolveWithMib()`.
+
+        The syntax the value has to conform to comes from the MIB, so the value cannot
+        be checked or converted here. `unSpecified` is the value a GET carries, where
+        the caller is asking rather than telling.
+        """
         if not isinstance(objectIdentity, ObjectIdentity):
             raise SmiError(
                 f"initializer should be ObjectIdentity instance, not {objectIdentity!r}"
@@ -1064,6 +1076,12 @@ class NotificationType:
     stDirty, stClean = 1, 2
 
     def __init__(self, objectIdentity, instanceIndex=(), objects=None):
+        """Records the notification and the objects it will carry, unresolved.
+
+        Which objects a notification carries is what its MIB definition says, so the
+        list is filled in by `resolveWithMib()`; `objects` supplies values for those
+        the sender has to provide itself.
+        """
         if not isinstance(objectIdentity, ObjectIdentity):
             raise SmiError(
                 f"initializer should be ObjectIdentity instance, not {objectIdentity!r}"

--- a/pysnmp/smi/view.py
+++ b/pysnmp/smi/view.py
@@ -29,6 +29,7 @@ class MibViewController:
     """
 
     def __init__(self, mibBuilder):
+        """Indexing is deferred until the first lookup, as in the instrumentation."""
         self.mibBuilder = mibBuilder
         self.lastBuildId = -1
         self.__mibSymbolsIdx = OrderedDict()


### PR DESCRIPTION
Third stage of #186. 102 sites: 60 public functions, 42 constructors. `D103` and `D107` come off the ignore list, so ruff holds the line from here.

Follows #220 (convention), the D100/D104 module sweep, and #222 (D101 classes).

## What a constructor docstring says here

What the object is left holding and why -- not a restatement of the signature. The class docstring already says what the class is for.

```python
def __init__(self):
    """Three indices over the same entries, plus the expiration queue.

    A message is looked up by the message ID that came back on the wire, by
    the state reference the engine passes around internally, and by the
    handle the application holds -- three different questions about one
    exchange. The expiration queue is what eventually drops an exchange
    nothing answered.
    """
```

Where the answer is one line, it is one line -- `Cache.__init__` says "Nothing is cached until a request is pushed" and stops.

## entity/config.py

28 of the 102, and the public configuration API. Each now names the MIB table it writes and the RFC that defines it: which table a call lands in is what a reader cannot get from the signature, and those tables are what an operator inspects when a configuration does not behave.

Things worth stating plainly that came out of the reading:

- `addV1System()` defaults `securityName` to `communityIndex`, not to the community -- the name VACM sees is deliberately not the secret on the wire.
- `addV3User()` writes two tables because USM has nowhere to keep a passphrase. A key localized to one engine ID cannot be relocalized to another, so keeping the passphrase is what makes re-localization possible once the authoritative engine ID is known.
- `getRecvFrom()` / `getSendTo()` are two halves of one mechanism: a wildcard-bound socket cannot answer `getsockname()` usefully, so the kernel reports the datagram's destination as ancillary data and the reply goes back out from it.
- `v2ToV1()` needs `origV1Pdu` rather than merely accepting it -- what to do about a `Counter64` depends on which PDU type asked.

## One defect found, documented not fixed

`passwordToKeySHA()` hashes the passphrase with **MD5** and then localizes with SHA-1. That is not RFC 3414 A.2.2, and the key it returns will not match another implementation's for the same passphrase.

Nothing in pysnmp calls it -- the SHA-1 authentication service uses `hashPassphraseSHA()` and `localizeKeySHA()`, which are correct. Its only test asserts the digest length, which is 20 bytes either way, so the bug is invisible to the suite.

The docstring states the discrepancy rather than describing intended behavior. Fixing it changes the keys of anyone who does call it, which is a decision worth taking on its own rather than inside a documentation change.

## Remaining under #186

| rule | items |
|---|---|
| D102 | 346 methods |
| D105 | 48 magic methods |

## Verification

- `ruff check` clean, `ruff format --check` clean (216 files)
- `mypy pysnmp` clean (147 source files)
- `sphinx-build -n -W` builds clean
- 1258 passed, 12 skipped
- Every modified file re-parsed with `ast`: 45 files, 0 misplaced docstrings