### PR TITLE
docs: say what every proto method is for (D102, part 1)

### DIFF
--- a/pysnmp/proto/acmod/rfc3415.py
+++ b/pysnmp/proto/acmod/rfc3415.py
@@ -46,6 +46,7 @@ class Vacm:
         writeView,
         notifyView,
     ):
+        """Remember one row of `vacmAccessTable` in the lookup this model reads."""
         if not groupName:
             return
 
@@ -91,6 +92,14 @@ class Vacm:
     def _getFamilyViewName(
         self, groupName, contextName, securityModel, securityLevel, viewType
     ):
+        """The view that applies to a group in a context at a security level.
+
+        :RFC:`3415#section-3.2` does not pick the first row that fits. An exact match
+        on context and security model short-circuits; otherwise the candidates are
+        narrowed to this security model rather than `any`, then to prefix matches on
+        the context, and among those the longest prefix at the highest permitted
+        security level wins. That ordering is why this cannot be a dictionary lookup.
+        """
         groups = self._accessMap
 
         try:
@@ -160,7 +169,15 @@ class Vacm:
         contextName,
         variableName,
     ):
+        """Whether one OID may be read, written or notified on, per :RFC:`3415`.
 
+        The context, security-to-group, access and view-tree tables are consulted in
+        that order, and a miss in any of them is a denial with its own error, so a
+        misconfiguration can be told apart from a deliberate refusal.
+
+        Each table is cached against its `branchVersionId`, since every varbind of
+        every request comes through here.
+        """
         mibInstrumController = snmpEngine.msgAndPduDsp.mibInstrumController
 
         debug.logger & debug.flagACL and debug.logger(

--- a/pysnmp/proto/acmod/void.py
+++ b/pysnmp/proto/acmod/void.py
@@ -30,6 +30,7 @@ class Vacm:
         contextName,
         variableName,
     ):
+        """Allows everything. This is the model to register when nothing is to be checked."""
         debug.logger & debug.flagACL and debug.logger(
             f"isAccessAllowed: viewType {viewType} for variableName {variableName} - OK"
         )

--- a/pysnmp/proto/api/v1.py
+++ b/pysnmp/proto/api/v1.py
@@ -39,6 +39,12 @@ class VarBindAPI:
 
     @staticmethod
     def setOIDVal(varBind, oidVal):
+        """Set both halves of a binding, treating `None` as the v1 null value.
+
+        The value goes in with tag and constraint checks off, because the binding's
+        CHOICE is what decides the type and re-checking it here would reject a
+        perfectly legal value that this API was handed deliberately.
+        """
         oid, val = oidVal[0], oidVal[1]
         varBind.setComponentByPosition(0, oid)
         if val is None:
@@ -55,6 +61,7 @@ class VarBindAPI:
 
     @staticmethod
     def getOIDVal(varBind):
+        """The OID and the value, with the binding's CHOICE already unwrapped."""
         return varBind[0], varBind[1].getComponent(1)
 
 
@@ -70,6 +77,7 @@ class PDUAPI:
     _errorIndex = Integer(0)
 
     def setDefaults(self, pdu):
+        """Stamp a fresh request ID and clear the error fields."""
         pdu.setComponentByPosition(
             0,
             getNextRequestID(),
@@ -96,22 +104,32 @@ class PDUAPI:
 
     @staticmethod
     def getRequestID(pdu):
+        """The request ID a response is matched back by."""
         return pdu.getComponentByPosition(0)
 
     @staticmethod
     def setRequestID(pdu, value):
+        """Set the request ID."""
         pdu.setComponentByPosition(0, value)
 
     @staticmethod
     def getErrorStatus(pdu):
+        """The error status, as the small integer set of :RFC:`1157#section-4.1`."""
         return pdu.getComponentByPosition(1)
 
     @staticmethod
     def setErrorStatus(pdu, value):
+        """Set the error status."""
         pdu.setComponentByPosition(1, value)
 
     @staticmethod
     def getErrorIndex(pdu, muteErrors=False):
+        """The 1-based binding the error refers to, checked against the bindings present.
+
+        An index past the end of the list is a malformed response, and agents do send
+        them. `muteErrors` clamps to the last binding instead of raising, for callers
+        that would rather carry on with a peer that is not quite right.
+        """
         errorIndex = pdu.getComponentByPosition(2)
         if errorIndex > len(pdu[3]):
             if muteErrors:
@@ -123,31 +141,43 @@ class PDUAPI:
 
     @staticmethod
     def setErrorIndex(pdu, value):
+        """Set the error index."""
         pdu.setComponentByPosition(2, value)
 
     def setEndOfMibError(self, pdu, errorIndex):
+        """Report the end of the MIB the only way v1 can, as `noSuchName`.
+
+        v1 has no `endOfMibView`: running off the end of the tree and asking for an
+        object that does not exist are the same answer, which is why a v1 walk has to
+        stop on an error rather than on a value.
+        """
         self.setErrorIndex(pdu, errorIndex)
         self.setErrorStatus(pdu, 2)
 
     def setNoSuchInstanceError(self, pdu, errorIndex):
+        """Report a missing instance, which in v1 is `noSuchName` as well."""
         self.setEndOfMibError(pdu, errorIndex)
 
     @staticmethod
     def getVarBindList(pdu):
+        """The binding list as the ASN.1 object, not as pairs."""
         return pdu.getComponentByPosition(3)
 
     @staticmethod
     def setVarBindList(pdu, varBindList):
+        """Set the binding list from an ASN.1 object."""
         pdu.setComponentByPosition(3, varBindList)
 
     @staticmethod
     def getVarBinds(pdu):
+        """The bindings as `(oid, value)` pairs."""
         return [
             apiVarBind.getOIDVal(varBind) for varBind in pdu.getComponentByPosition(3)
         ]
 
     @staticmethod
     def setVarBinds(pdu, varBinds):
+        """Set the bindings from `(oid, value)` pairs, or from ASN.1 bindings."""
         varBindList = pdu.setComponentByPosition(3).getComponentByPosition(3)
         varBindList.clear()
         for idx, varBind in enumerate(varBinds):
@@ -158,12 +188,20 @@ class PDUAPI:
                 apiVarBind.setOIDVal(varBindList.getComponentByPosition(idx), varBind)
 
     def getResponse(self, reqPDU):
+        """An empty response PDU carrying the request's ID."""
         rspPDU = GetResponsePDU()
         self.setDefaults(rspPDU)
         self.setRequestID(rspPDU, self.getRequestID(reqPDU))
         return rspPDU
 
     def getVarBindTable(self, reqPDU, rspPDU):
+        """The response's bindings as a table of one row.
+
+        GETBULK is what makes this a table rather than a list, and v1 has no GETBULK,
+        so the row count here is always one. A `noSuchName` response comes back as the
+        requested OIDs paired with nulls, since v1 leaves the bindings of an error
+        response unspecified and the caller still needs to know which OIDs ended.
+        """
         if apiPDU.getErrorStatus(rspPDU) == 2:
             varBindRow = []
             for varBind in apiPDU.getVarBinds(reqPDU):
@@ -186,6 +224,13 @@ class TrapPDUAPI:
     _zeroTime = TimeTicks(0)
 
     def setDefaults(self, pdu):
+        """Fill in the trap fields, resolving this host's address once and caching it.
+
+        A v1 trap states where it came from in a dedicated field, so the address has
+        to be found before one can be built. Where the host cannot resolve its own
+        name the unspecified address stands in, which :RFC:`1157` allows for an
+        agent that does not know its own address.
+        """
         if self._networkAddress is None:
             try:
                 import socket
@@ -237,56 +282,69 @@ class TrapPDUAPI:
 
     @staticmethod
     def getEnterprise(pdu):
+        """The OID naming what kind of device sent the trap."""
         return pdu.getComponentByPosition(0)
 
     @staticmethod
     def setEnterprise(pdu, value):
+        """Set the enterprise OID."""
         pdu.setComponentByPosition(0, value)
 
     @staticmethod
     def getAgentAddr(pdu):
+        """The IPv4 address the trap claims to come from."""
         return pdu.getComponentByPosition(1).getComponentByPosition(0)
 
     @staticmethod
     def setAgentAddr(pdu, value):
+        """Set the agent address, which v1 can only express as IPv4."""
         pdu.setComponentByPosition(1).getComponentByPosition(1).setComponentByPosition(
             0, value
         )
 
     @staticmethod
     def getGenericTrap(pdu):
+        """Which of the six predefined traps this is, or `enterpriseSpecific`."""
         return pdu.getComponentByPosition(2)
 
     @staticmethod
     def setGenericTrap(pdu, value):
+        """Set the generic trap number."""
         pdu.setComponentByPosition(2, value)
 
     @staticmethod
     def getSpecificTrap(pdu):
+        """The vendor's own trap number, meaningful only alongside the enterprise OID."""
         return pdu.getComponentByPosition(3)
 
     @staticmethod
     def setSpecificTrap(pdu, value):
+        """Set the specific trap number."""
         pdu.setComponentByPosition(3, value)
 
     @staticmethod
     def getTimeStamp(pdu):
+        """How long the sending agent had been up when the trap fired."""
         return pdu.getComponentByPosition(4)
 
     @staticmethod
     def setTimeStamp(pdu, value):
+        """Set the uptime stamp."""
         pdu.setComponentByPosition(4, value)
 
     @staticmethod
     def getVarBindList(pdu):
+        """The binding list as the ASN.1 object, not as pairs."""
         return pdu.getComponentByPosition(5)
 
     @staticmethod
     def setVarBindList(pdu, varBindList):
+        """Set the binding list from an ASN.1 object."""
         pdu.setComponentByPosition(5, varBindList)
 
     @staticmethod
     def getVarBinds(pdu):
+        """The bindings as `(oid, value)` pairs."""
         varBinds = []
         for varBind in pdu.getComponentByPosition(5):
             varBinds.append(apiVarBind.getOIDVal(varBind))
@@ -294,6 +352,7 @@ class TrapPDUAPI:
 
     @staticmethod
     def setVarBinds(pdu, varBinds):
+        """Set the bindings from `(oid, value)` pairs, or from ASN.1 bindings."""
         varBindList = pdu.setComponentByPosition(5).getComponentByPosition(5)
         varBindList.clear()
         for idx, varBind in enumerate(varBinds):
@@ -314,6 +373,7 @@ class MessageAPI:
     _community = univ.OctetString("public")
 
     def setDefaults(self, msg):
+        """Stamp version 1 and the default community."""
         msg.setComponentByPosition(
             0,
             self._version,
@@ -332,26 +392,32 @@ class MessageAPI:
 
     @staticmethod
     def getVersion(msg):
+        """The version field, which the dispatcher reads before anything else."""
         return msg.getComponentByPosition(0)
 
     @staticmethod
     def setVersion(msg, value):
+        """Set the version field."""
         msg.setComponentByPosition(0, value)
 
     @staticmethod
     def getCommunity(msg):
+        """The community, which in v1 is both the credential and the whole of the security."""
         return msg.getComponentByPosition(1)
 
     @staticmethod
     def setCommunity(msg, value):
+        """Set the community."""
         msg.setComponentByPosition(1, value)
 
     @staticmethod
     def getPDU(msg):
+        """The PDU carried inside the message."""
         return msg.getComponentByPosition(2).getComponent()
 
     @staticmethod
     def setPDU(msg, value):
+        """Set the PDU carried inside the message."""
         msg.setComponentByPosition(2).getComponentByPosition(2).setComponentByType(
             value.tagSet,
             value,
@@ -362,6 +428,7 @@ class MessageAPI:
         )
 
     def getResponse(self, reqMsg):
+        """A response message echoing the request's version, community and request ID."""
         rspMsg = Message()
         self.setDefaults(rspMsg)
         self.setVersion(rspMsg, self.getVersion(reqMsg))

--- a/pysnmp/proto/api/v2c.py
+++ b/pysnmp/proto/api/v2c.py
@@ -62,15 +62,28 @@ class PDUAPI(v1.PDUAPI):
     )
 
     def getResponse(self, reqPDU):
+        """An empty response PDU carrying the request's ID."""
         rspPDU = ResponsePDU()
         self.setDefaults(rspPDU)
         self.setRequestID(rspPDU, self.getRequestID(reqPDU))
         return rspPDU
 
     def getVarBindTable(self, reqPDU, rspPDU):
+        """The response's bindings as a table of one row.
+
+        Unlike v1 there is no error case to fold in: v2c reports a finished walk as an
+        `endOfMibView` value in the binding itself, so an error response has nothing
+        the caller wants and the bindings come back as they arrived.
+        """
         return [apiPDU.getVarBinds(rspPDU)]
 
     def setEndOfMibError(self, pdu, errorIndex):
+        """Mark one binding as past the end of the MIB.
+
+        v2c says this with a value rather than an error status, which is what lets a
+        single response finish some bindings and carry data for the rest -- the thing
+        v1 cannot express.
+        """
         varBindList = self.getVarBindList(pdu)
         varBindList[errorIndex - 1].setComponentByPosition(
             1,
@@ -81,6 +94,7 @@ class PDUAPI(v1.PDUAPI):
         )
 
     def setNoSuchInstanceError(self, pdu, errorIndex):
+        """Mark one binding as naming an object that exists with no instance."""
         varBindList = self.getVarBindList(pdu)
         varBindList[errorIndex - 1].setComponentByPosition(
             1,
@@ -101,6 +115,7 @@ class BulkPDUAPI(PDUAPI):
     _maxRepetitions = rfc1905.maxRepetitions.clone(10)
 
     def setDefaults(self, pdu):
+        """Stamp a request ID and the repetition counts, defaulting to 10 repetitions."""
         PDUAPI.setDefaults(self, pdu)
         pdu.setComponentByPosition(
             0,
@@ -128,21 +143,32 @@ class BulkPDUAPI(PDUAPI):
 
     @staticmethod
     def getNonRepeaters(pdu):
+        """How many leading bindings are fetched once rather than repeatedly."""
         return pdu.getComponentByPosition(1)
 
     @staticmethod
     def setNonRepeaters(pdu, value):
+        """Set the non-repeater count."""
         pdu.setComponentByPosition(1, value)
 
     @staticmethod
     def getMaxRepetitions(pdu):
+        """How many times the remaining bindings are walked."""
         return pdu.getComponentByPosition(2)
 
     @staticmethod
     def setMaxRepetitions(pdu, value):
+        """Set the repetition count."""
         pdu.setComponentByPosition(2, value)
 
     def getVarBindTable(self, reqPDU, rspPDU):
+        """The response's bindings cut back into rows, one per repetition.
+
+        GETBULK returns the non-repeaters once and then the repeaters over and over,
+        flattened into one list; this is what turns that back into rows. An agent may
+        return fewer repetitions than asked for, and a short final row is dropped
+        rather than padded, since a partial row is not a row of the table.
+        """
         nonRepeaters = self.getNonRepeaters(reqPDU)
 
         reqVarBinds = self.getVarBinds(reqPDU)
@@ -185,6 +211,11 @@ class TrapPDUAPI(v1.PDUAPI):
     _genTrap = ObjectIdentifier((1, 3, 6, 1, 6, 3, 1, 1, 5, 1))
 
     def setDefaults(self, pdu):
+        """Stamp the two bindings :RFC:`3416#section-4.2.6` requires of every v2c trap.
+
+        A v2c trap has none of v1's dedicated fields; the uptime and the trap OID are
+        ordinary bindings, and they have to be the first two.
+        """
         v1.PDUAPI.setDefaults(self, pdu)
         varBinds = [
             (self.sysUpTime, self._zeroTime),
@@ -203,6 +234,7 @@ class MessageAPI(v1.MessageAPI):
     _version = rfc1901.version.clone(1)
 
     def setDefaults(self, msg):
+        """Stamp version 2c and the default community."""
         msg.setComponentByPosition(
             0,
             self._version,
@@ -220,6 +252,7 @@ class MessageAPI(v1.MessageAPI):
         return msg
 
     def getResponse(self, reqMsg):
+        """A response message echoing the request's version, community and request ID."""
         rspMsg = Message()
         self.setDefaults(rspMsg)
         self.setVersion(rspMsg, self.getVersion(reqMsg))

--- a/pysnmp/proto/cache.py
+++ b/pysnmp/proto/cache.py
@@ -20,10 +20,16 @@ class Cache:
         self.__cacheRepository = {}
 
     def add(self, index, **kwargs):
+        """Remember a request under a handle, returning the handle back."""
         self.__cacheRepository[index] = kwargs
         return index
 
     def pop(self, index):
+        """Take a request back out, removing it. `None` where the handle is unknown.
+
+        A late response and a second response to the same request look identical here,
+        and both get `None` rather than an error -- neither is worth failing over.
+        """
         if index in self.__cacheRepository:
             cachedParams = self.__cacheRepository[index]
         else:
@@ -32,11 +38,17 @@ class Cache:
         return cachedParams
 
     def update(self, index, **kwargs):
+        """Add to what is remembered for a request, which must already be there."""
         if index not in self.__cacheRepository:
             raise error.ProtocolError(f"Cache miss on update for {kwargs}")
         self.__cacheRepository[index].update(kwargs)
 
     def expire(self, cbFun, cbCtx):
+        """Sweep requests the callback says are past due.
+
+        The callback decides, not a fixed age, because what counts as expired differs
+        by message processing model. Called with no callback this does nothing.
+        """
         for index, cachedParams in list(self.__cacheRepository.items()):
             if cbFun:
                 if cbFun(index, cachedParams, cbCtx):

--- a/pysnmp/proto/error.py
+++ b/pysnmp/proto/error.py
@@ -52,6 +52,7 @@ class StatusInformation(SnmpV3Error):
         return key in self.__errorIndication
 
     def get(self, key, defVal=None):
+        """One detail off the status, or `defVal` where it was not set."""
         return self.__errorIndication.get(key, defVal)
 
 

--- a/pysnmp/proto/mpmod/base.py
+++ b/pysnmp/proto/mpmod/base.py
@@ -48,6 +48,7 @@ class AbstractMessageProcessingModel:
         expectResponse,
         sendPduHandle,
     ):
+        """Serialize a request. Concrete models implement this."""
         raise error.ProtocolError("method not implemented")
 
     def prepareResponseMessage(
@@ -65,18 +66,22 @@ class AbstractMessageProcessingModel:
         stateReference,
         statusInformation,
     ):
+        """Serialize a response. Concrete models implement this."""
         raise error.ProtocolError("method not implemented")
 
     def prepareDataElements(
         self, snmpEngine, transportDomain, transportAddress, wholeMsg
     ):
+        """Parse an inbound message. Concrete models implement this."""
         raise error.ProtocolError("method not implemented")
 
     def releaseStateInformation(self, sendPduHandle):
+        """Drop what was held for one exchange."""
         try:
             self._cache.popBySendPduHandle(sendPduHandle)
         except error.ProtocolError:
             pass  # XXX maybe these should all follow some scheme?
 
     def receiveTimerTick(self, snmpEngine, timeNow):
+        """Called on the dispatcher's timer; drives cache expiry."""
         self._cache.expireCaches()

--- a/pysnmp/proto/mpmod/cache.py
+++ b/pysnmp/proto/mpmod/cache.py
@@ -37,9 +37,16 @@ class Cache:
     # Server mode cache handling
 
     def newStateReference(self):
+        """A fresh handle for a request being served, for the agent side."""
         return self.__stateReference()
 
     def pushByStateRef(self, stateReference, **msgInfo):
+        """Remember what answering a request will need, under its state reference.
+
+        A duplicate reference is a bug rather than a race, so it raises. The entry is
+        put on the expiry queue at the same time -- 600 ticks out -- because an
+        application that never answers must not hold the entry forever.
+        """
         if stateReference in self.__stateReferenceIndex:
             raise error.ProtocolError(
                 f"Cache dup for stateReference={stateReference} at {self}"
@@ -55,6 +62,12 @@ class Cache:
         self.__expirationQueue[expireAt]["stateReference"][stateReference] = 1
 
     def popByStateRef(self, stateReference):
+        """Take back what was remembered for a request being served.
+
+        A miss raises: the engine only asks for a reference it was given, so a missing
+        one means the request was already answered or has expired, and either way the
+        response being built has nowhere to go.
+        """
         if stateReference in self.__stateReferenceIndex:
             cacheInfo = self.__stateReferenceIndex[stateReference]
         else:
@@ -69,9 +82,16 @@ class Cache:
     # Client mode cache handling
 
     def newMsgID(self):
+        """A fresh message ID for a request being sent, for the manager side."""
         return self.__msgID()
 
     def pushByMsgId(self, msgId, **msgInfo):
+        """Remember a request under its message ID, and under its PDU handle too.
+
+        Two indices because the two directions ask differently: a response arrives
+        naming the message ID, while the application cancels or times out naming the
+        handle it was given.
+        """
         if msgId in self.__msgIdIndex:
             raise error.ProtocolError(f"Cache dup for msgId={msgId} at {self}")
         expireAt = self.__expirationTimer + 600
@@ -87,6 +107,7 @@ class Cache:
         self.__expirationQueue[expireAt]["msgId"][msgId] = 1
 
     def popByMsgId(self, msgId):
+        """Take back a sent request by the message ID a response quoted."""
         if msgId in self.__msgIdIndex:
             cacheInfo = self.__msgIdIndex[msgId]
         else:
@@ -99,11 +120,22 @@ class Cache:
         return cacheEntry
 
     def popBySendPduHandle(self, sendPduHandle):
+        """Take back a sent request by the handle the application holds.
+
+        Unlike the message-ID path a miss is silent, since the application may release
+        a request that has already been answered or expired.
+        """
         if sendPduHandle in self.__sendPduHandleIdx:
             self.popByMsgId(self.__sendPduHandleIdx[sendPduHandle])
 
     def expireCaches(self):
         # Uses internal clock to expire pending messages
+        """Drop everything scheduled to expire on this tick, and advance the clock.
+
+        The clock is the number of timer ticks, not wall time, so expiry follows the
+        dispatcher's timer rather than the system clock -- which is what keeps it
+        stable across a clock step.
+        """
         if self.__expirationTimer in self.__expirationQueue:
             cacheInfo = self.__expirationQueue[self.__expirationTimer]
             if "stateReference" in cacheInfo:

--- a/pysnmp/proto/mpmod/rfc2576.py
+++ b/pysnmp/proto/mpmod/rfc2576.py
@@ -45,6 +45,7 @@ class SnmpV1MessageProcessingModel(AbstractMessageProcessingModel):
         expectResponse,
         sendPduHandle,
     ):
+        """Serialize a v1 or v2c request: community, PDU, and nothing else."""
         mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
 
         (snmpEngineId,) = mibBuilder.importSymbols(
@@ -180,6 +181,7 @@ class SnmpV1MessageProcessingModel(AbstractMessageProcessingModel):
         stateReference,
         statusInformation,
     ):
+        """Serialize a v1 or v2c response, echoing the request's community."""
         mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
 
         (snmpEngineId,) = mibBuilder.importSymbols(
@@ -297,6 +299,12 @@ class SnmpV1MessageProcessingModel(AbstractMessageProcessingModel):
     def prepareDataElements(
         self, snmpEngine, transportDomain, transportAddress, wholeMsg
     ):
+        """Parse a v1 or v2c message and hand it to the security model.
+
+        With no message header to speak of, most of what the engine needs -- security
+        name, level, context -- comes back out of the community lookup rather than off
+        the wire.
+        """
         mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
 
         # rfc3412: 7.2.2

--- a/pysnmp/proto/mpmod/rfc3412.py
+++ b/pysnmp/proto/mpmod/rfc3412.py
@@ -252,6 +252,7 @@ class SnmpV3MessageProcessingModel(AbstractMessageProcessingModel):
         return msg, snmpEngineMaxMessageSize
 
     def getPeerEngineInfo(self, transportDomain, transportAddress):
+        """What discovery learned about the engine at an address, or three `None`s."""
         k = transportDomain, transportAddress
         if k in self.__engineIdCache:
             return (
@@ -279,6 +280,13 @@ class SnmpV3MessageProcessingModel(AbstractMessageProcessingModel):
         expectResponse,
         sendPduHandle,
     ):
+        """Serialize a v3 request, discovering the peer's engine ID first if need be.
+
+        A request to an engine this one has not talked to cannot be authenticated,
+        because the keys are localized to an engine ID that is not yet known. So the
+        first message to a new peer goes out as an unauthenticated discovery probe and
+        the real request follows once the report comes back.
+        """
         (snmpEngineID,) = (
             snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder.importSymbols(
                 "__SNMP-FRAMEWORK-MIB", "snmpEngineID"
@@ -423,6 +431,12 @@ class SnmpV3MessageProcessingModel(AbstractMessageProcessingModel):
         stateReference,
         statusInformation,
     ):
+        """Serialize a v3 response, or a report where the request could not be served.
+
+        A report is how v3 says what went wrong without an application ever seeing the
+        request, and it is also half of discovery -- which is why this is reached with
+        no cached state on the first exchange with a peer.
+        """
         (snmpEngineID,) = (
             snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder.importSymbols(
                 "__SNMP-FRAMEWORK-MIB", "snmpEngineID"
@@ -589,6 +603,14 @@ class SnmpV3MessageProcessingModel(AbstractMessageProcessingModel):
         self, snmpEngine, transportDomain, transportAddress, wholeMsg
     ):
         # 7.2.2
+        """Parse a v3 message: header, security, and then the scoped PDU.
+
+        The header has to be parsed before the security model can be chosen, and the
+        security model has to run before the scoped PDU can be read, since it may be
+        encrypted. A failure at any of those steps is answered with a report rather
+        than silence, because the sender may simply be missing what discovery would
+        tell it.
+        """
         msg, restOfwholeMsg = decoder.decode(wholeMsg, asn1Spec=self._snmpMsgSpec)
 
         debug.logger & debug.flagMP and debug.logger(
@@ -1029,5 +1051,10 @@ class SnmpV3MessageProcessingModel(AbstractMessageProcessingModel):
         self.__expirationTimer += 1
 
     def receiveTimerTick(self, snmpEngine, timeNow):
+        """Expire what discovery learned, then let the base class expire the caches.
+
+        Engine IDs are not remembered forever: a peer that reboots gets a new one, and
+        a stale entry would make every message to it fail authentication.
+        """
         self.__expireEnginesInfo()
         AbstractMessageProcessingModel.receiveTimerTick(self, snmpEngine, timeNow)

--- a/pysnmp/proto/rfc1155.py
+++ b/pysnmp/proto/rfc1155.py
@@ -35,6 +35,7 @@ class IpAddress(univ.OctetString):
     subtypeSpec = univ.OctetString.subtypeSpec + constraint.ValueSizeConstraint(4, 4)
 
     def prettyIn(self, value):
+        """Accept an address as dotted quad, four octets, or another `IpAddress`."""
         if isinstance(value, str) and len(value) != 4:
             try:
                 value = [int(x) for x in value.split(".")]
@@ -45,6 +46,7 @@ class IpAddress(univ.OctetString):
         return univ.OctetString.prettyIn(self, value)
 
     def prettyOut(self, value):
+        """Render as a dotted quad."""
         if value:
             return ".".join([str(x) for x in self.__class__(value).asNumbers()])
         else:
@@ -103,6 +105,11 @@ class NetworkAddress(univ.Choice):
     #          indicates an IpAddress);"
 
     def cloneFromName(self, value, impliedFlag, parentRow, parentIndices):
+        """Read a network address out of an OID being used as a table index.
+
+        The leading sub-identifier is the address family, and `internet` is the only
+        one :RFC:`1155` defines, so anything else is refused rather than guessed at.
+        """
         kind = value[0]
         clone = self.clone()
         if kind == 1:
@@ -112,6 +119,7 @@ class NetworkAddress(univ.Choice):
             raise SmiError(f"unknown NetworkAddress type {kind!r}")
 
     def cloneAsName(self, impliedFlag, parentRow, parentIndices):
+        """Render this address as OID sub-identifiers, for use as a table index."""
         kind = self.getName()
         component = self.getComponent()
         if kind == "internet":

--- a/pysnmp/proto/rfc1902.py
+++ b/pysnmp/proto/rfc1902.py
@@ -239,21 +239,35 @@ class OctetString(univ.OctetString):
     fixedLength: int | None = None
 
     def setFixedLength(self, value):
+        """Pin this string to an exact length, and return it for chaining.
+
+        A fixed length is not a constraint pyasn1 carries: it is what tells the table
+        index code how many sub-identifiers to take for this column, which it cannot
+        work out from the value alone.
+        """
         self.fixedLength = value
         return self
 
     def isFixedLength(self):
+        """Whether a fixed length has been pinned."""
         return self.fixedLength is not None
 
     def getFixedLength(self):
+        """The pinned length, or `None`."""
         return self.fixedLength
 
     def clone(self, *args, **kwargs):
+        """Clone, carrying the fixed length across.
+
+        pyasn1's clone knows nothing about the fixed length, so a plain clone would
+        silently drop it and break indexing on the copy.
+        """
         return univ.OctetString.clone(self, *args, **kwargs).setFixedLength(
             self.getFixedLength()
         )
 
     def subtype(self, *args, **kwargs):
+        """Subtype, carrying the fixed length across, for the same reason as `clone`."""
         return univ.OctetString.subtype(self, *args, **kwargs).setFixedLength(
             self.getFixedLength()
         )
@@ -346,6 +360,7 @@ class IpAddress(OctetString):
     fixedLength = 4
 
     def prettyIn(self, value):
+        """Accept an address as dotted quad, four octets, or another `IpAddress`."""
         if isinstance(value, str) and len(value) != 4:
             try:
                 value = [int(x) for x in value.split(".")]
@@ -357,6 +372,7 @@ class IpAddress(OctetString):
         return value
 
     def prettyOut(self, value):
+        """Render as a dotted quad."""
         if value:
             return ".".join([str(x) for x in self.__class__(value).asNumbers()])
         else:
@@ -664,6 +680,7 @@ class Bits(OctetString):
     namedValues = namedval.NamedValues()
 
     def __new__(cls, *args, **kwargs):
+        """Build a subclass on the fly when named bits are given to the constructor."""
         if "namedValues" in kwargs:
             Bits = cls.withNamedBits(**dict(kwargs.pop("namedValues")))
             return Bits(*args, **kwargs)
@@ -671,6 +688,11 @@ class Bits(OctetString):
         return OctetString.__new__(cls)
 
     def prettyIn(self, bits):
+        """Accept either bit names or the raw octets they pack into.
+
+        Bit 0 is the high bit of the first octet, not the low bit -- :RFC:`1902` numbers
+        them the other way round from how they would fall out of a shift.
+        """
         if not isinstance(bits, (tuple, list)):
             return OctetString.prettyIn(self, bits)  # raw bitstring
         octets = []
@@ -685,6 +707,7 @@ class Bits(OctetString):
         return OctetString.prettyIn(self, octets)
 
     def prettyOut(self, value):
+        """Render as the names of the bits that are set, in bit order."""
         names = []
         ints = self.__class__(value).asNumbers()
         for i, v in enumerate(ints):

--- a/pysnmp/proto/rfc1905.py
+++ b/pysnmp/proto/rfc1905.py
@@ -46,6 +46,7 @@ class NoSuchObject(univ.Null):
     )
 
     def prettyPrint(self, scope=0):
+        """Say that no such object exists, rather than printing an empty null."""
         return "No Such Object currently exists at this OID"
 
 
@@ -60,6 +61,7 @@ class NoSuchInstance(univ.Null):
     )
 
     def prettyPrint(self, scope=0):
+        """Say that the object exists but this instance does not."""
         return "No Such Instance currently exists at this OID"
 
 
@@ -74,6 +76,7 @@ class EndOfMibView(univ.Null):
     )
 
     def prettyPrint(self, scope=0):
+        """Say that the walk has run past the end of the view."""
         return "No more variables left in this MIB View"
 
 

--- a/pysnmp/proto/rfc3412.py
+++ b/pysnmp/proto/rfc3412.py
@@ -64,6 +64,7 @@ class MsgAndPduDispatcher:
 
     # legacy
     def getTransportInfo(self, stateReference):
+        """Where a request came from, so a response can be sent back to it."""
         if stateReference in self.__transportInfo:
             return self.__transportInfo[stateReference]
         else:
@@ -111,6 +112,12 @@ class MsgAndPduDispatcher:
         )
 
     def getRegisteredApp(self, contextEngineId, pduType):
+        """The application registered for a context and PDU type, wildcard included.
+
+        An exact registration wins; failing that the empty context engine ID matches
+        anything, which is how a notification receiver takes traps from engines it has
+        never heard of.
+        """
         k = (contextEngineId, pduType)
         if k in self.__appsRegistration:
             return self.__appsRegistration[k]
@@ -272,6 +279,7 @@ class MsgAndPduDispatcher:
         statusInformation,
     ):
         # Extract input values and initialize defaults
+        """Send an application's response back out through the model it arrived on."""
         k = int(messageProcessingModel)
         if k in snmpEngine.messageProcessingSubsystems:
             mpHandler = snmpEngine.messageProcessingSubsystems[k]
@@ -610,6 +618,7 @@ class MsgAndPduDispatcher:
     def releaseStateInformation(
         self, snmpEngine, sendPduHandle, messageProcessingModel
     ):
+        """Drop what was held for a request, in the dispatcher and the model both."""
         k = int(messageProcessingModel)
         if k in snmpEngine.messageProcessingSubsystems:
             mpHandler = snmpEngine.messageProcessingSubsystems[k]
@@ -665,4 +674,5 @@ class MsgAndPduDispatcher:
 
     # noinspection PyUnusedLocal
     def receiveTimerTick(self, snmpEngine, timeNow):
+        """Expire requests that were never answered, reporting a timeout for each."""
         self.__cache.expire(self.__expireRequest, snmpEngine)

--- a/pysnmp/proto/secmod/base.py
+++ b/pysnmp/proto/secmod/base.py
@@ -36,6 +36,7 @@ class AbstractSecurityModel:
         wholeMsg,
         msg,
     ):
+        """Verify and unwrap an inbound message. Concrete models implement this."""
         raise error.ProtocolError(f"Security model {self} not implemented")
 
     def generateRequestMsg(
@@ -50,6 +51,7 @@ class AbstractSecurityModel:
         securityLevel,
         scopedPDU,
     ):
+        """Wrap an outbound request. Concrete models implement this."""
         raise error.ProtocolError(f"Security model {self} not implemented")
 
     def generateResponseMsg(
@@ -65,11 +67,14 @@ class AbstractSecurityModel:
         scopedPDU,
         securityStateReference,
     ):
+        """Wrap an outbound response. Concrete models implement this."""
         raise error.ProtocolError(f"Security model {self} not implemented")
 
     def releaseStateInformation(self, stateReference):
+        """Drop what was cached for one exchange, once it can no longer be answered."""
         self._cache.pop(stateReference)
 
     def receiveTimerTick(self, snmpEngine, timeNow):
         # Security models without timers do not need to take action.
+        """Called on the dispatcher's timer; models that expire state override this."""
         pass

--- a/pysnmp/proto/secmod/cache.py
+++ b/pysnmp/proto/secmod/cache.py
@@ -19,11 +19,13 @@ class Cache:
         self.__cacheEntries = {}
 
     def push(self, **securityData):
+        """Stash what the response will need, returning the handle to fetch it back by."""
         stateReference = self.__stateReference()
         self.__cacheEntries[stateReference] = securityData
         return stateReference
 
     def pop(self, stateReference):
+        """Take back what was stashed, removing it -- a handle is good once."""
         if stateReference in self.__cacheEntries:
             securityData = self.__cacheEntries[stateReference]
         else:

--- a/pysnmp/proto/secmod/eso/priv/aesbase.py
+++ b/pysnmp/proto/secmod/eso/priv/aesbase.py
@@ -34,6 +34,13 @@ class AbstractAesBlumenthal(aes.Aes):
 
     # 3.1.2.1
     def localizeKey(self, authProtocol, privKey, snmpEngineID):
+        """Localize, then chain the hash over its own output until the key is long enough.
+
+        AES-192 and AES-256 need more key material than one localization produces.
+        Blumenthal's draft extends it by hashing the result again and appending, which
+        is what this does; Reeder's variant does something else, and the two do not
+        interoperate.
+        """
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             hashAlgo = md5
         elif authProtocol == hmacsha.HmacSha.serviceID:
@@ -75,6 +82,12 @@ class AbstractAesReeder(aes.Aes):
 
     # 2.1 of https://tools.itef.org/pdf/draft_bluementhal-aes-usm-04.txt
     def localizeKey(self, authProtocol, privKey, snmpEngineID):
+        """Localize by re-running the passphrase hash, as Reeder's draft has it.
+
+        The difference from Blumenthal is where the extension comes from: this repeats
+        the password-to-key step rather than hashing the localized key. Cisco and
+        others implement this one.
+        """
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             hashAlgo = md5
         elif authProtocol == hmacsha.HmacSha.serviceID:

--- a/pysnmp/proto/secmod/eso/priv/des3.py
+++ b/pysnmp/proto/secmod/eso/priv/des3.py
@@ -42,6 +42,12 @@ class Des3(base.AbstractEncryptionService):
     _localInt = secrets.randbits(32)
 
     def hashPassphrase(self, authProtocol, privKey):
+        """Hash the passphrase with whatever digest the authentication protocol uses.
+
+        Privacy has no digest of its own: :RFC:`3414#section-2.6` derives the privacy
+        key with the authentication protocol's hash, which is why the auth protocol has
+        to be passed in here at all.
+        """
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             hashAlgo = md5
         elif authProtocol == hmacsha.HmacSha.serviceID:
@@ -54,6 +60,12 @@ class Des3(base.AbstractEncryptionService):
 
     # 2.1
     def localizeKey(self, authProtocol, privKey, snmpEngineID):
+        """Localize the privacy key, extending it to the 32 octets 3DES-EDE needs.
+
+        One localization yields too little key material for three DES keys plus the
+        pre-IV, so the result is hashed and localized again and appended until it is
+        long enough -- the extension Reeder's draft specifies.
+        """
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             hashAlgo = md5
         elif authProtocol == hmacsha.HmacSha.serviceID:
@@ -116,6 +128,7 @@ class Des3(base.AbstractEncryptionService):
 
     # 5.1.1.2
     def encryptData(self, encryptKey, privParameters, dataToEncrypt):
+        """Encrypt with 3DES-EDE, returning the ciphertext and the salt to send with it."""
         DES3 = cipherbackend.getCipher("DES3")
         if DES3 is None:
             raise error.StatusInformation(errorIndication=errind.encryptionError)
@@ -138,6 +151,7 @@ class Des3(base.AbstractEncryptionService):
 
     # 5.1.1.3
     def decryptData(self, decryptKey, privParameters, encryptedData):
+        """Decrypt 3DES-EDE ciphertext, taking the IV from the salt the sender sent."""
         DES3 = cipherbackend.getCipher("DES3")
         if DES3 is None:
             raise error.StatusInformation(errorIndication=errind.decryptionError)

--- a/pysnmp/proto/secmod/rfc2576.py
+++ b/pysnmp/proto/secmod/rfc2576.py
@@ -51,6 +51,7 @@ class SnmpV1SecurityModel(base.AbstractSecurityModel):
         base.AbstractSecurityModel.__init__(self)
 
     def _sec2com(self, snmpEngine, securityName, contextEngineId, contextName):
+        """The community to put on the wire for a security name, from SNMP-COMMUNITY-MIB."""
         (snmpTargetParamsSecurityName,) = (
             snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder.importSymbols(
                 "SNMP-TARGET-MIB", "snmpTargetParamsSecurityName"
@@ -167,6 +168,12 @@ class SnmpV1SecurityModel(base.AbstractSecurityModel):
             ) from exc
 
     def _com2sec(self, snmpEngine, communityName, transportInformation):
+        """The security name a community maps to, given where the message came from.
+
+        The transport matters because a community may be tagged to a set of addresses;
+        a community that is right but arrives from an address it is not tagged for is
+        not accepted.
+        """
         (snmpTargetAddrTAddress,) = (
             snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder.importSymbols(
                 "SNMP-TARGET-MIB", "snmpTargetAddrTAddress"
@@ -443,6 +450,7 @@ class SnmpV1SecurityModel(base.AbstractSecurityModel):
         securityLevel,
         scopedPDU,
     ):
+        """Put the community on an outgoing request. There is nothing else to do."""
         (msg,) = globalData
         contextEngineId, contextName, pdu = scopedPDU
 
@@ -496,6 +504,7 @@ class SnmpV1SecurityModel(base.AbstractSecurityModel):
         securityStateReference,
     ):
         # rfc2576: 5.2.2
+        """Put the community on an outgoing response."""
         (msg,) = globalData
         contextEngineId, contextName, pdu = scopedPDU
         cachedSecurityData = self._cache.pop(securityStateReference)
@@ -542,6 +551,12 @@ class SnmpV1SecurityModel(base.AbstractSecurityModel):
         msg,
     ):
         # rfc2576: 5.2.1
+        """Map the community to a security name, counting a bad one in the MIB.
+
+        This is the whole of v1 and v2c security: the community is checked against the
+        configuration and nothing about the message is authenticated, so a message that
+        reaches here has already been trusted.
+        """
         communityName, transportInformation = securityParameters
 
         scope = {

--- a/pysnmp/proto/secmod/rfc3414/auth/base.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/base.py
@@ -21,19 +21,24 @@ class AbstractAuthenticationService:
     serviceID: tuple[int, ...] | None = None
 
     def hashPassphrase(self, authKey):
+        """Hash a passphrase into a master key. Concrete services implement this."""
         raise error.ProtocolError(errind.noAuthentication)
 
     def localizeKey(self, authKey, snmpEngineID):
+        """Bind a master key to one engine ID. Concrete services implement this."""
         raise error.ProtocolError(errind.noAuthentication)
 
     @property
     def digestLength(self):
+        """Octets of digest this service puts in the message."""
         raise error.ProtocolError(errind.noAuthentication)
 
     # 7.2.4.1
     def authenticateOutgoingMsg(self, authKey, wholeMsg):
+        """Fill in the digest placeholder. Concrete services implement this."""
         raise error.ProtocolError(errind.noAuthentication)
 
     # 7.2.4.2
     def authenticateIncomingMsg(self, authKey, authParameters, wholeMsg):
+        """Check the digest. Concrete services implement this."""
         raise error.ProtocolError(errind.noAuthentication)

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
@@ -43,13 +43,16 @@ class HmacMd5(base.AbstractAuthenticationService):
     __opad = [0x5C] * 64
 
     def hashPassphrase(self, authKey):
+        """Hash a passphrase into a master key with MD5."""
         return localkey.hashPassphraseMD5(authKey)
 
     def localizeKey(self, authKey, snmpEngineID):
+        """Bind a master key to one engine ID, so it cannot be replayed at another."""
         return localkey.localizeKeyMD5(authKey, snmpEngineID)
 
     @property
     def digestLength(self):
+        """12 -- HMAC-MD5-96 is truncated to 96 bits."""
         return 12
 
     # 6.3.1
@@ -58,6 +61,12 @@ class HmacMd5(base.AbstractAuthenticationService):
         # should be in the substrate. Also, it pre-sets digest placeholder
         # so we hash wholeMsg out of the box.
         # Yes, that's ugly but that's rfc...
+        """Compute HMAC-MD5-96 over the message and write it into the placeholder.
+
+        The caller has already serialized the message with twelve zero octets where
+        the digest goes, because the digest covers the whole message including its own
+        field. Finding that run of zeros is how the position is recovered.
+        """
         idx = wholeMsg.find(_twelveZeros)
         if idx == -1:
             raise error.ProtocolError("Cant locate digest placeholder")
@@ -94,6 +103,11 @@ class HmacMd5(base.AbstractAuthenticationService):
     # 6.3.2
     def authenticateIncomingMsg(self, authKey, authParameters, wholeMsg):
         # 6.3.2.1 & 2
+        """Check HMAC-MD5-96, zeroing the digest field before recomputing.
+
+        The sender hashed the message with zeros in the digest field, so the same
+        substitution has to be made here before the two can be compared.
+        """
         if len(authParameters) != 12:
             raise error.StatusInformation(errorIndication=errind.authenticationError)
 

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
@@ -43,13 +43,16 @@ class HmacSha(base.AbstractAuthenticationService):
     __opad = [0x5C] * 64
 
     def hashPassphrase(self, authKey):
+        """Hash a passphrase into a master key with SHA-1."""
         return localkey.hashPassphraseSHA(authKey)
 
     def localizeKey(self, authKey, snmpEngineID):
+        """Bind a master key to one engine ID, so it cannot be replayed at another."""
         return localkey.localizeKeySHA(authKey, snmpEngineID)
 
     @property
     def digestLength(self):
+        """12 -- HMAC-SHA-96 is truncated to 96 bits."""
         return 12
 
     # 7.3.1
@@ -59,6 +62,7 @@ class HmacSha(base.AbstractAuthenticationService):
         # should be in the substrate. Also, it pre-sets digest placeholder
         # so we hash wholeMsg out of the box.
         # Yes, that's ugly but that's rfc...
+        """Compute HMAC-SHA-96 over the message and write it into the placeholder."""
         idx = wholeMsg.find(_twelveZeros)
         if idx == -1:
             raise error.ProtocolError("Cant locate digest placeholder")
@@ -91,6 +95,7 @@ class HmacSha(base.AbstractAuthenticationService):
     # 7.3.2
     def authenticateIncomingMsg(self, authKey, authParameters, wholeMsg):
         # 7.3.2.1 & 2
+        """Check HMAC-SHA-96, zeroing the digest field before recomputing."""
         if len(authParameters) != 12:
             raise error.StatusInformation(errorIndication=errind.authenticationError)
 

--- a/pysnmp/proto/secmod/rfc3414/auth/noauth.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/noauth.py
@@ -15,14 +15,22 @@ class NoAuth(base.AbstractAuthenticationService):
     serviceID: tuple[int, ...] = (1, 3, 6, 1, 6, 3, 10, 1, 1, 1)  # usmNoAuthProtocol
 
     def hashPassphrase(self, authKey):
+        """Nothing to hash: there is no key at this security level."""
         return
 
     def localizeKey(self, authKey, snmpEngineID):
+        """Nothing to localize: there is no key at this security level."""
         return
 
     # 7.2.4.2
     def authenticateOutgoingMsg(self, authKey, wholeMsg):
+        """Always fails -- asking to authenticate with no authentication is a mistake.
+
+        Reached only where the security level and the protocol disagree, so it reports
+        rather than sending something the peer will reject.
+        """
         raise error.StatusInformation(errorIndication=errind.noAuthentication)
 
     def authenticateIncomingMsg(self, authKey, authParameters, wholeMsg):
+        """Always fails, for the same reason as the outgoing side."""
         raise error.StatusInformation(errorIndication=errind.noAuthentication)

--- a/pysnmp/proto/secmod/rfc3414/priv/base.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/base.py
@@ -22,13 +22,17 @@ class AbstractEncryptionService:
     keySize = 0
 
     def hashPassphrase(self, authProtocol, privKey):
+        """Hash a passphrase into a master privacy key. Concrete services implement this."""
         raise error.ProtocolError("no encryption")
 
     def localizeKey(self, authProtocol, privKey, snmpEngineID):
+        """Bind a privacy key to one engine ID. Concrete services implement this."""
         raise error.ProtocolError("no encryption")
 
     def encryptData(self, encryptKey, privParameters, dataToEncrypt):
+        """Encrypt a scoped PDU. Concrete services implement this."""
         raise error.ProtocolError("no encryption")
 
     def decryptData(self, decryptKey, privParameters, encryptedData):
+        """Decrypt a scoped PDU. Concrete services implement this."""
         raise error.ProtocolError("no encryption")

--- a/pysnmp/proto/secmod/rfc3414/priv/des.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/des.py
@@ -33,6 +33,7 @@ class Des(base.AbstractEncryptionService):
     _localInt = secrets.randbits(32)
 
     def hashPassphrase(self, authProtocol, privKey):
+        """Hash the passphrase with whatever digest the authentication protocol uses."""
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             hashAlgo = md5
         elif authProtocol == hmacsha.HmacSha.serviceID:
@@ -44,6 +45,11 @@ class Des(base.AbstractEncryptionService):
         return localkey.hashPassphrase(privKey, hashAlgo)
 
     def localizeKey(self, authProtocol, privKey, snmpEngineID):
+        """Localize the privacy key and keep the 16 octets DES needs.
+
+        Half of that is the DES key; the other half is the pre-IV, which is what makes
+        the salt on the wire enough to rebuild the IV at the far end.
+        """
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             hashAlgo = md5
         elif authProtocol == hmacsha.HmacSha.serviceID:
@@ -96,6 +102,12 @@ class Des(base.AbstractEncryptionService):
 
     # 8.2.4.1
     def encryptData(self, encryptKey, privParameters, dataToEncrypt):
+        """Encrypt with DES-CBC, returning the ciphertext and the salt to send with it.
+
+        The salt is the boot count and a counter, so no two messages from one engine
+        share an IV -- which is what DES-CBC needs and what the wire format has room
+        to carry.
+        """
         DES = cipherbackend.getCipher("DES")
         if DES is None:
             raise error.StatusInformation(errorIndication=errind.encryptionError)
@@ -121,6 +133,11 @@ class Des(base.AbstractEncryptionService):
 
     # 8.2.4.2
     def decryptData(self, decryptKey, privParameters, encryptedData):
+        """Decrypt DES-CBC ciphertext, rebuilding the IV from the salt and the pre-IV.
+
+        Ciphertext that is not a whole number of blocks is rejected rather than padded,
+        since a short final block means the message was truncated or is not ours.
+        """
         DES = cipherbackend.getCipher("DES")
         if DES is None:
             raise error.StatusInformation(errorIndication=errind.decryptionError)

--- a/pysnmp/proto/secmod/rfc3414/priv/nopriv.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/nopriv.py
@@ -15,13 +15,17 @@ class NoPriv(base.AbstractEncryptionService):
     serviceID: tuple[int, ...] = (1, 3, 6, 1, 6, 3, 10, 1, 2, 1)  # usmNoPrivProtocol
 
     def hashPassphrase(self, authProtocol, privKey):
+        """Nothing to hash: there is no privacy key at this security level."""
         return
 
     def localizeKey(self, authProtocol, privKey, snmpEngineID):
+        """Nothing to localize: there is no privacy key at this security level."""
         return
 
     def encryptData(self, encryptKey, privParameters, dataToEncrypt):
+        """Always fails -- asking to encrypt with no privacy is a mistake."""
         raise error.StatusInformation(errorIndication=errind.noEncryption)
 
     def decryptData(self, decryptKey, privParameters, encryptedData):
+        """Always fails, for the same reason as the outgoing side."""
         raise error.StatusInformation(errorIndication=errind.noEncryption)

--- a/pysnmp/proto/secmod/rfc3414/service.py
+++ b/pysnmp/proto/secmod/rfc3414/service.py
@@ -821,6 +821,7 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
         securityLevel,
         scopedPDU,
     ):
+        """Wrap a request in USM: authenticate, encrypt, and name the user."""
         return self.__generateRequestOrResponseMsg(
             snmpEngine,
             messageProcessingModel,
@@ -847,6 +848,7 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
         scopedPDU,
         securityStateReference,
     ):
+        """Wrap a response in USM, reusing what was cached from the request."""
         return self.__generateRequestOrResponseMsg(
             snmpEngine,
             messageProcessingModel,
@@ -872,6 +874,15 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
         wholeMsg,
         msg,
     ):
+        """Verify, decrypt, and answer with a report where discovery is what is wanted.
+
+        A message from an engine this one has not talked to is not a failure: the first
+        exchange with any peer is expected to come back as a report naming its engine
+        ID, boots and time, which is how the timeline needed for replay protection is
+        established. Every other failure is counted in the USM statistics and reported
+        the same way, so that a wrong key and an unknown user look alike to whoever
+        sent them.
+        """
         mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
 
         # 3.2.9 -- moved up here to be able to report
@@ -1414,6 +1425,7 @@ class SnmpUSMSecurityModel(AbstractSecurityModel):
         self.__expirationTimer += 1
 
     def receiveTimerTick(self, snmpEngine, timeNow):
+        """Expire what is remembered about peer engines' clocks."""
         self.__expireTimelineInfo()
 
 

--- a/pysnmp/proto/secmod/rfc3826/priv/aes.py
+++ b/pysnmp/proto/secmod/rfc3826/priv/aes.py
@@ -70,6 +70,7 @@ class Aes(base.AbstractEncryptionService):
         return privKey[: self.keySize].asOctets(), univ.OctetString(iv).asOctets()
 
     def hashPassphrase(self, authProtocol, privKey):
+        """Hash the passphrase with whatever digest the authentication protocol uses."""
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             hashAlgo = md5
         elif authProtocol == hmacsha.HmacSha.serviceID:
@@ -81,6 +82,7 @@ class Aes(base.AbstractEncryptionService):
         return localkey.hashPassphrase(privKey, hashAlgo)
 
     def localizeKey(self, authProtocol, privKey, snmpEngineID):
+        """Localize the privacy key and keep the 16 octets AES-128 needs."""
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             hashAlgo = md5
         elif authProtocol == hmacsha.HmacSha.serviceID:
@@ -94,6 +96,12 @@ class Aes(base.AbstractEncryptionService):
 
     # 3.2.4.1
     def encryptData(self, encryptKey, privParameters, dataToEncrypt):
+        """Encrypt with AES-128-CFB, returning the ciphertext and the salt.
+
+        The IV is the boot count, the engine time and a 64-bit counter, so it does not
+        repeat within a boot; only the counter half travels, since the receiver already
+        knows the other two.
+        """
         AES = cipherbackend.getCipher("AES")
         if AES is None:
             raise error.StatusInformation(errorIndication=errind.encryptionError)
@@ -121,6 +129,11 @@ class Aes(base.AbstractEncryptionService):
 
     # 3.2.4.2
     def decryptData(self, decryptKey, privParameters, encryptedData):
+        """Decrypt AES-128-CFB ciphertext, rebuilding the IV from boots, time and salt.
+
+        CFB is a stream mode, so unlike DES there is no block alignment to enforce and
+        ciphertext of any length decrypts.
+        """
         AES = cipherbackend.getCipher("AES")
         if AES is None:
             raise error.StatusInformation(errorIndication=errind.decryptionError)

--- a/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
+++ b/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
@@ -64,18 +64,26 @@ class HmacSha2(base.AbstractAuthenticationService):
         self.__placeHolder = univ.OctetString((0,) * self.__digestLength).asOctets()
 
     def hashPassphrase(self, authKey):
+        """Hash a passphrase into a master key with this instance's SHA-2 variant."""
         return localkey.hashPassphrase(authKey, self.__hashAlgo)
 
     def localizeKey(self, authKey, snmpEngineID):
+        """Bind a master key to one engine ID, so it cannot be replayed at another."""
         return localkey.localizeKey(authKey, snmpEngineID, self.__hashAlgo)
 
     @property
     def digestLength(self):
+        """Octets of digest, which differs per SHA-2 variant -- 16 for SHA-224 up to 48."""
         return self.__digestLength
 
     # 7.3.1
     def authenticateOutgoingMsg(self, authKey, wholeMsg):
         # 7.3.1.1
+        """Compute the HMAC and write it into the placeholder.
+
+        Unlike the :RFC:`3414` services the placeholder is not always twelve octets,
+        so its length comes from the variant in use.
+        """
         location = wholeMsg.find(self.__placeHolder)
         if location == -1:
             raise error.ProtocolError("Can't locate digest placeholder")
@@ -98,6 +106,7 @@ class HmacSha2(base.AbstractAuthenticationService):
     # 7.3.2
     def authenticateIncomingMsg(self, authKey, authParameters, wholeMsg):
         # 7.3.2.1 & 2
+        """Check the HMAC, zeroing the digest field before recomputing."""
         if len(authParameters) != self.__digestLength:
             raise error.StatusInformation(errorIndication=errind.authenticationError)
 


### PR DESCRIPTION
First half of the D102 stage of #186. 163 of 346 sites, all under `pysnmp/proto`.

`D102` stays on the ignore list until part 2 covers `smi`, `carrier`, `entity` and `hlapi` — splitting it keeps each half reviewable, and there is no useful intermediate state where the rule is half on.

## What got words and what did not

The wire-format accessors in `proto/api` are one line naming the field and its RFC meaning. There is nothing else true to say about `getRequestID()`, and inventing something would be the noise the staging comment in `pyproject.toml` warns about.

The words went where a signature actively misleads:

- **`getVarBindTable()` returns a table because GETBULK needs one.** In v1 and v2c it is always a single row. `BulkPDUAPI`'s version is the one that matters: it cuts the flattened response back into rows and drops a short final row rather than padding, since a partial row is not a row.
- **`setEndOfMibError()` means two different things per version.** v1 has no `endOfMibView`, so it sets `noSuchName` — which is why a v1 walk stops on an *error* rather than on a value. v2c sets a value in the binding, which is what lets one response finish some bindings and carry data for the rest.
- **The auth services locate their own digest by searching for the zero placeholder** the caller left in the serialized message, because the digest covers the message including its own field. Both directions substitute zeros before hashing.
- **Blumenthal and Reeder extend an AES key differently** — one hashes the localized key, the other repeats password-to-key. Peers on opposite drafts do not interoperate, and the docstrings now say so at both sites.
- **USM's `processIncomingMsg()` treats an unknown peer engine as expected, not as failure.** The first exchange with any peer comes back as a report; that is how the timeline for replay protection gets established.
- **VACM's `_getFamilyViewName()` cannot be a dictionary lookup.** RFC 3415 §3.2 narrows candidates by security model, then context prefix, then takes the longest prefix at the highest permitted security level.

## Corrections made while reading

Three claims I drafted did not survive checking the code, and were fixed before commit:

- `Cache.expire()` with no callback drops **nothing** — the `if cbFun` guard has no `else`. I had written that it drops everything.
- `Des3.localizeKey()` extends the key by hashing **and localizing again**, not by hashing alone.
- VACM consults four tables, not five.

## Verification

`ruff check` and `format`, `mypy` (147 files), 1258 passed / 12 skipped. Every modified file re-parsed with `ast` to confirm each docstring is the body's first statement (29 files, 0 misplaced). Diff is insertions only.

## Remaining under #186

183 D102 sites (`smi` 57, `entity` 61, `carrier` 53, `hlapi` 12), then D105 (48 magic methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)