### PR TITLE
docs: finish the docstring family (D102 part 2, D105) — closes #186

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,21 +210,16 @@ ignore = [
     "S508",     # snmp-insecure-version
     "S509",     # snmp-weak-cryptography
 
-    # The docstring family, adopted in stages -- see #186. What is on now is
-    # the shape of the docstrings that exist, plus D100/D104, D101 and
-    # D103/D107: every module, package, class, function and constructor says
-    # what it is for. What is still off is the requirement that every method
-    # have one, which is 394 items and is a documentation project rather
-    # than a lint fix. Writing 346 method docstrings mechanically produces
-    # noise, not documentation.
+    # The docstring family, adopted in stages -- see #186. Everything but
+    # D105 is on: every module, package, class, function, constructor and
+    # method says what it is for.
     #
-    # These come off one rule at a time, each its own reviewable change:
+    # These came off one rule at a time, each its own reviewable change:
     #   D100/D104  104 modules and packages -- done
     #   D101       182 classes -- done
     #   D103/D107  102 functions and constructors -- done
-    #   D102       346 methods, probably by subpackage
+    #   D102       346 methods, in two parts (proto, then the rest) -- done
     #   D105        48 magic methods
-    "D102",     # undocumented-public-method
     "D105",     # undocumented-magic-method
 
     # The one rule pyasn1 keeps that this does not, and the only place the two

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,17 +210,14 @@ ignore = [
     "S508",     # snmp-insecure-version
     "S509",     # snmp-weak-cryptography
 
-    # The docstring family, adopted in stages -- see #186. Everything but
-    # D105 is on: every module, package, class, function, constructor and
-    # method says what it is for.
-    #
-    # These came off one rule at a time, each its own reviewable change:
-    #   D100/D104  104 modules and packages -- done
-    #   D101       182 classes -- done
-    #   D103/D107  102 functions and constructors -- done
-    #   D102       346 methods, in two parts (proto, then the rest) -- done
-    #   D105        48 magic methods
-    "D105",     # undocumented-magic-method
+    # The docstring family is fully on -- see #186. Every module, package,
+    # class, function, constructor, method and magic method says what it is
+    # for. It came off one rule at a time, each its own reviewable change:
+    #   D100/D104  104 modules and packages
+    #   D101       182 classes
+    #   D103/D107  102 functions and constructors
+    #   D102       346 methods, in two parts: proto, then the rest
+    #   D105         7 magic methods the passes above had not already covered
 
     # The one rule pyasn1 keeps that this does not, and the only place the two
     # rule sets differ. Every third-person summary it caught -- "Returns the",

--- a/pysnmp/carrier/asyncio/dgram/base.py
+++ b/pysnmp/carrier/asyncio/dgram/base.py
@@ -80,12 +80,22 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
         self.loop = loop
 
     def datagram_received(self, datagram, transportAddress):
+        """Hand an arriving datagram to the dispatcher's callback, via the loop.
+
+        Delivery is deferred with `call_soon` rather than made here, so the callback
+        does not run inside asyncio's receive path.
+        """
         if self._cbFun is None:
             raise error.CarrierError("Unable to call cbFun")
         else:
             self.loop.call_soon(self._cbFun, self, transportAddress, datagram)
 
     def connection_made(self, transport):
+        """Take the socket, apply the options that were waiting, and flush the send queue.
+
+        Socket options and sends can both be asked for before the loop has a socket to
+        apply them to, so both are held until this point.
+        """
         self.transport = transport
         sock = transport.get_extra_info("socket")
         for configureSocket in self._pendingSocketOptions:
@@ -107,12 +117,14 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
                 ) from e
 
     def connection_lost(self, exc):
+        """Drop the transport. Sends after this queue again rather than failing."""
         self.transport = None
         debug.logger & debug.flagIO and debug.logger("connection_lost: invoked")
 
     # AbstractAsyncioTransport API
 
     def openClientMode(self, iface=None):
+        """Open a socket for sending, optionally bound to a local address."""
         try:
             c = self.loop.create_datagram_endpoint(
                 lambda: self, local_addr=iface, family=self.sockFamily
@@ -128,6 +140,7 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
         return self
 
     def openServerMode(self, iface):
+        """Bind a socket to receive on."""
         try:
             c = self.loop.create_datagram_endpoint(
                 lambda: self, local_addr=iface, family=self.sockFamily
@@ -143,6 +156,7 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
         return self
 
     def closeTransport(self):
+        """Cancel the pending endpoint, close the socket, and drop the callback."""
         if self._lport is not None:
             self._lport.cancel()
             if not self.loop.is_running():
@@ -155,6 +169,7 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
         AbstractAsyncioTransport.closeTransport(self)
 
     def sendMessage(self, outgoingMessage, transportAddress):
+        """Send a datagram, queueing it if the loop has not connected the socket yet."""
         debug.logger & debug.flagIO and debug.logger(
             "sendMessage: {} transportAddress {!r} outgoingMessage {}".format(
                 (self.transport is None and "queuing" or "sending"),
@@ -175,6 +190,13 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
                 ) from e
 
     def getLocalAddress(self):
+        """The address this socket is bound to, or the wildcard where it is unbound.
+
+        An unbound socket has no name POSIX and Windows agree on: one answers with the
+        family's wildcard, the other fails and asyncio reports no name at all. The
+        concrete transport's `unboundLocalAddress` stands in for the second case so
+        callers get an address of the right shape either way.
+        """
         if self.transport is None:
             return None
         localAddress = self.transport.get_extra_info("sockname")
@@ -183,6 +205,11 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
         return localAddress
 
     def normalizeAddress(self, transportAddress):
+        """Coerce to this transport's address type, noting the local address on it.
+
+        The local address rides along so a reply can leave by the interface the request
+        arrived on, which matters once a socket is bound to a wildcard.
+        """
         if not isinstance(transportAddress, self.addressType):
             transportAddress = self.addressType(transportAddress)
         if not transportAddress.getLocalAddress():
@@ -190,12 +217,15 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
         return transportAddress
 
     def _configureSocket(self, configureSocket):
+        """Apply a socket option now, or hold it until there is a socket to apply it to."""
         if self.transport is None:
             self._pendingSocketOptions.append(configureSocket)
             return
         configureSocket(self.transport.get_extra_info("socket"))
 
     def enableBroadcast(self, flag=1):
+        """Allow sending to a broadcast address."""
+
         def configureSocket(sock):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, flag)
 
@@ -208,12 +238,18 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
         return self
 
     def enablePktInfo(self, flag=1):
+        """Always fails: asyncio's datagram transport does not expose the ancillary data.
+
+        Recovering the address a datagram arrived on needs `recvmsg`, which asyncio's
+        datagram endpoint does not surface. A raw socket is the way to do this.
+        """
         raise error.CarrierError(
             "Packet-information source-address handling is unavailable with "
             "asyncio datagram transports; use a raw asyncio socket for this use case"
         )
 
     def enableTransparent(self, flag=1):
+        """Always fails, for the same reason as `enablePktInfo`."""
         if self.sockFamily == socket.AF_INET:
             option = socket.SOL_IP, socket.IP_TRANSPARENT
         elif self.sockFamily == socket.AF_INET6:

--- a/pysnmp/carrier/asyncio/dgram/udp6.py
+++ b/pysnmp/carrier/asyncio/dgram/udp6.py
@@ -31,6 +31,13 @@ class Udp6AsyncioTransport(DgramAsyncioProtocol):
     unboundLocalAddress = ("::", 0, 0, 0)
 
     def normalizeAddress(self, transportAddress):
+        """Coerce to a four-part IPv6 address, dropping the zone ID and scope.
+
+        A link-local address arrives carrying a zone (`fe80::1%eth0`) and asyncio
+        reports flowinfo and scope alongside it, none of which mean anything to the
+        peer. Two addresses that differ only in those parts are the same endpoint, so
+        they are stripped to make addresses comparable.
+        """
         localAddress = None
         if isinstance(transportAddress, AbstractTransportAddress):
             localAddress = transportAddress.getLocalAddress()

--- a/pysnmp/carrier/asyncio/dgram/unix.py
+++ b/pysnmp/carrier/asyncio/dgram/unix.py
@@ -50,6 +50,11 @@ class UnixAsyncioTransport(DgramAsyncioProtocol):
         self._iface = None
 
     def openClientMode(self, iface=None):
+        """Bind a path to send from, inventing a temporary one where none is given.
+
+        A unix datagram socket has no reply address unless it is bound, so even a
+        client needs a path of its own before it can be answered.
+        """
         if iface is None:
             fd, iface = tempfile.mkstemp(prefix="pysnmp-", dir=tempfile.gettempdir())
             os.close(fd)
@@ -59,12 +64,22 @@ class UnixAsyncioTransport(DgramAsyncioProtocol):
         return DgramAsyncioProtocol.openClientMode(self, iface)
 
     def openServerMode(self, iface):
+        """Bind a filesystem path to receive on, removing a stale file at that path.
+
+        A path left behind by a previous run is not reusable and would fail the bind,
+        so it is cleared rather than reported.
+        """
         if Path(iface).exists():
             Path(iface).unlink()
         self._iface = iface
         return DgramAsyncioProtocol.openServerMode(self, iface)
 
     def closeTransport(self):
+        """Close the socket and unlink the path it was bound to.
+
+        A unix socket outlives the process that made it, so this is what stops each
+        run leaving a file behind -- including the temporary path a client bound.
+        """
         DgramAsyncioProtocol.closeTransport(self)
         if self._iface:
             Path(self._iface).unlink(missing_ok=True)

--- a/pysnmp/carrier/asyncio/dispatch.py
+++ b/pysnmp/carrier/asyncio/dispatch.py
@@ -62,16 +62,24 @@ class AsyncioDispatcher(AbstractTransportDispatcher):
                 self.loop = asyncio.new_event_loop()
 
     async def handle_timeout(self):
+        """Tick the dispatcher's timers forever, one sleep per resolution."""
         while True:
             await asyncio.sleep(self.getTimerResolution())
             self.handleTimerTick(self.loop.time())
 
     def _start_timer(self):
+        """Start the ticking task, unless one is already running."""
         self._timerStartHandle = None
         if self.loopingcall is None:
             self.loopingcall = self.loop.create_task(self.handle_timeout())
 
     def runDispatcher(self, timeout=0.0):
+        """Run the loop until the outstanding work is done, or forever with none.
+
+        With jobs pending or writes still queued this returns once they have drained,
+        which is what a client wants. With nothing outstanding it runs forever instead
+        of returning immediately, since that is a server waiting to be asked something.
+        """
         if self.loop.is_running():
             return
 
@@ -94,12 +102,19 @@ class AsyncioDispatcher(AbstractTransportDispatcher):
             ) from e
 
     def transportsAreWorking(self):
+        """Whether any transport still has datagrams queued to send."""
         for transport in self._AbstractTransportDispatcher__transports.values():
             if getattr(transport, "_writeQ", None):
                 return True
         return False
 
     def registerTransport(self, tDomain, transport):
+        """Take a transport, adopting its event loop and starting the timer.
+
+        A server-mode transport is often built before the dispatcher and already holds
+        a loop; receiving only works if both are on the same one, so the dispatcher
+        moves rather than making the transport move.
+        """
         # If the transport already has an event loop (e.g. server-mode
         # transport created before the dispatcher), adopt its loop so
         # that datagram reception works on the same loop.
@@ -121,6 +136,7 @@ class AsyncioDispatcher(AbstractTransportDispatcher):
         self.__transportCount += 1
 
     def _cancel_timer(self):
+        """Stop the ticking task and wait for it where the loop is not running."""
         if self._timerStartHandle is not None:
             self._timerStartHandle.cancel()
             self._timerStartHandle = None
@@ -134,6 +150,7 @@ class AsyncioDispatcher(AbstractTransportDispatcher):
         self.loopingcall = None
 
     def unregisterTransport(self, tDomain):
+        """Release a transport, stopping the timer once the last one is gone."""
         t = AbstractTransportDispatcher.getTransport(self, tDomain)
         if t is not None:
             AbstractTransportDispatcher.unregisterTransport(self, tDomain)
@@ -146,6 +163,7 @@ class AsyncioDispatcher(AbstractTransportDispatcher):
             self._cancel_timer()
 
     def closeDispatcher(self):
+        """Close every transport and stop the timer."""
         AbstractTransportDispatcher.closeDispatcher(self)
         self._cancel_timer()
         self.__transportCount = 0

--- a/pysnmp/carrier/base.py
+++ b/pysnmp/carrier/base.py
@@ -32,18 +32,27 @@ class TimerCallable:
         self.__callInterval = callInterval
 
     def __call__(self, timeNow):
+        """Run the callback if its interval has elapsed, otherwise do nothing.
+
+        The dispatcher calls every timer on every tick and each one decides for itself
+        whether it is due, which is what lets callbacks on different intervals share a
+        single tick.
+        """
         if self.__nextCall <= timeNow:
             self.__cbFun(timeNow)
             self.__nextCall = timeNow + self.interval
 
     def __eq__(self, cbFun):
+        """Compare equal to the bare function, so it can be unregistered by function."""
         return self.__cbFun == cbFun
 
     def __lt__(self, cbFun):
+        """Order by the wrapped function, for `total_ordering`."""
         return self.__cbFun < cbFun
 
     @property
     def interval(self):
+        """Seconds between calls."""
         return self.__callInterval
 
     @interval.setter
@@ -79,6 +88,13 @@ class AbstractTransportDispatcher:
         self.__routingCbFun = None
 
     def _cbFun(self, incomingTransport, transportAddress, incomingMessage):
+        """Route one inbound message to whoever registered for it.
+
+        The routing function names a recipient; with none registered the message goes
+        to the default callback. A message that matches nothing raises rather than
+        being dropped quietly, since that is a configuration mistake and losing traffic
+        over it would be hard to notice.
+        """
         if incomingTransport in self.__transportDomainMap:
             transportDomain = self.__transportDomainMap[incomingTransport]
         else:
@@ -103,15 +119,18 @@ class AbstractTransportDispatcher:
     # Dispatcher API
 
     def registerRoutingCbFun(self, routingCbFun):
+        """Set the function that decides which receiver an inbound message belongs to."""
         if self.__routingCbFun:
             raise error.CarrierError("Data routing callback already registered")
         self.__routingCbFun = routingCbFun
 
     def unregisterRoutingCbFun(self):
+        """Drop the routing function, sending everything to the default receiver."""
         if self.__routingCbFun:
             self.__routingCbFun = None
 
     def registerRecvCbFun(self, recvCb, recvId=None):
+        """Register a receiver, `recvId` being `None` for the default one."""
         if recvId in self.__recvCallables:
             raise error.CarrierError(
                 "Receive callback {!r} already registered".format(
@@ -121,21 +140,25 @@ class AbstractTransportDispatcher:
         self.__recvCallables[recvId] = recvCb
 
     def unregisterRecvCbFun(self, recvId=None):
+        """Drop a receiver. Unknown ids are ignored."""
         if recvId in self.__recvCallables:
             del self.__recvCallables[recvId]
 
     def registerTimerCbFun(self, timerCbFun, tickInterval=None):
+        """Register a periodic callback, defaulting to the dispatcher's own resolution."""
         if not tickInterval:
             tickInterval = self.__timerResolution
         self.__timerCallables.append(TimerCallable(timerCbFun, tickInterval))
 
     def unregisterTimerCbFun(self, timerCbFun=None):
+        """Drop one timer callback, or all of them when given none."""
         if timerCbFun:
             self.__timerCallables.remove(timerCbFun)
         else:
             self.__timerCallables = []
 
     def registerTransport(self, tDomain, transport):
+        """Take ownership of a transport for one domain and wire its receive callback."""
         if tDomain in self.__transports:
             raise error.CarrierError(f"Transport {tDomain} already registered")
         transport.registerCbFun(self._cbFun)
@@ -143,6 +166,7 @@ class AbstractTransportDispatcher:
         self.__transportDomainMap[transport] = tDomain
 
     def unregisterTransport(self, tDomain):
+        """Release a transport, leaving it open. Closing it is the caller's to do."""
         if tDomain not in self.__transports:
             raise error.CarrierError(f"Transport {tDomain} not registered")
         self.__transports[tDomain].unregisterCbFun()
@@ -150,11 +174,13 @@ class AbstractTransportDispatcher:
         del self.__transports[tDomain]
 
     def getTransport(self, transportDomain):
+        """The transport registered for a domain. Raises where there is none."""
         if transportDomain in self.__transports:
             return self.__transports[transportDomain]
         raise error.CarrierError(f"Transport {transportDomain} not registered")
 
     def sendMessage(self, outgoingMessage, transportDomain, transportAddress):
+        """Hand a message to the transport for its domain."""
         if transportDomain in self.__transports:
             self.__transports[transportDomain].sendMessage(
                 outgoingMessage, transportAddress
@@ -165,9 +191,16 @@ class AbstractTransportDispatcher:
             )
 
     def getTimerResolution(self):
+        """Seconds between timer ticks."""
         return self.__timerResolution
 
     def setTimerResolution(self, timerResolution):
+        """Change the tick interval, moving callbacks that were on the old default.
+
+        A callback registered without an interval of its own took the resolution in
+        force at the time; those follow the new value, while one that named an interval
+        keeps it. Values outside 10ms to 10s are refused as unworkable.
+        """
         if timerResolution < 0.01 or timerResolution > 10:
             raise error.CarrierError("Impossible timer resolution")
 
@@ -180,9 +213,15 @@ class AbstractTransportDispatcher:
         self.__timerDelta = timerResolution * 0.05
 
     def getTimerTicks(self):
+        """Ticks since the dispatcher started, which is what timeouts are counted in."""
         return self.__ticks
 
     def handleTimerTick(self, timeNow):
+        """Advance the tick count and run whichever timer callbacks are due.
+
+        A tick fires slightly before the resolution has fully elapsed -- the delta --
+        so a callback due fractionally early is not held back a whole tick.
+        """
         if self.__nextTime == 0:  # initial initialization
             self.__nextTime = timeNow + self.__timerResolution - self.__timerDelta
 
@@ -196,23 +235,28 @@ class AbstractTransportDispatcher:
             timerCallable(timeNow)
 
     def jobStarted(self, jobId, count=1):
+        """Record outstanding work, which keeps the loop from exiting under it."""
         if jobId in self.__jobs:
             self.__jobs[jobId] += count
         else:
             self.__jobs[jobId] = count
 
     def jobFinished(self, jobId, count=1):
+        """Retire outstanding work; the loop may exit once nothing is left."""
         self.__jobs[jobId] -= count
         if self.__jobs[jobId] == 0:
             del self.__jobs[jobId]
 
     def jobsArePending(self):
+        """Whether anything is still outstanding."""
         return bool(self.__jobs)
 
     def runDispatcher(self, timeout=0.0):
+        """Run the I/O loop. Concrete dispatchers implement this."""
         raise error.CarrierError("Method not implemented")
 
     def closeDispatcher(self):
+        """Close every transport and drop every callback."""
         for tDomain in list(self.__transports):
             self.__transports[tDomain].closeTransport()
             self.unregisterTransport(tDomain)
@@ -232,13 +276,16 @@ class AbstractTransportAddress:
     _localAddress = None
 
     def setLocalAddress(self, s):
+        """Note which local address this was seen on, and return self for chaining."""
         self._localAddress = s
         return self
 
     def getLocalAddress(self):
+        """The local address this was seen on, or `None`."""
         return self._localAddress
 
     def clone(self, localAddress=None):
+        """Copy the address, carrying the local address across unless one is given."""
         return self.__class__(self).setLocalAddress(
             localAddress is None and self.getLocalAddress() or localAddress
         )
@@ -259,9 +306,15 @@ class AbstractTransport:
 
     @classmethod
     def isCompatibleWithDispatcher(cls, transportDispatcher):
+        """Whether this transport can run on that dispatcher.
+
+        The two share an I/O model, so a transport written against one dispatcher will
+        not work under another.
+        """
         return isinstance(transportDispatcher, cls.protoTransportDispatcher)
 
     def registerCbFun(self, cbFun):
+        """Set the callback inbound messages go to. Only one transport may hold it."""
         if self._cbFun:
             raise error.CarrierError(
                 f"Callback function {self._cbFun} already registered at {self}"
@@ -269,18 +322,23 @@ class AbstractTransport:
         self._cbFun = cbFun
 
     def unregisterCbFun(self):
+        """Drop the receive callback."""
         self._cbFun = None
 
     def closeTransport(self):
+        """Stop delivering inbound messages. Subclasses close the socket too."""
         self.unregisterCbFun()
 
     # Public API
 
     def openClientMode(self, iface=None):
+        """Open for sending. Concrete transports implement this."""
         raise error.CarrierError("Method not implemented")
 
     def openServerMode(self, iface):
+        """Bind for receiving. Concrete transports implement this."""
         raise error.CarrierError("Method not implemented")
 
     def sendMessage(self, outgoingMessage, transportAddress):
+        """Send one message. Concrete transports implement this."""
         raise error.CarrierError("Method not implemented")

--- a/pysnmp/debug.py
+++ b/pysnmp/debug.py
@@ -61,9 +61,11 @@ class Printer:
         self.__logger = logger
 
     def __call__(self, msg):
+        """Write one message at DEBUG level."""
         self.__logger.debug(msg)
 
     def __str__(self):
+        """Names the logging backend, for the banner debugging prints on startup."""
         return "<python built-in logging>"
 
 
@@ -120,15 +122,19 @@ class Debug:
             )
 
     def __str__(self):
+        """The categories currently switched on."""
         return f"logger {self._printer}, flags {self._flags:x}"
 
     def __call__(self, msg):
+        """Write one message through the printer."""
         self._printer(msg)
 
     def __and__(self, flag):
+        """Whether a category is on, as `debug.logger & flagIO` asks."""
         return self._flags & flag
 
     def __rand__(self, flag):
+        """Whether a category is on, with the operands the other way round."""
         return flag & self._flags
 
 
@@ -151,15 +157,19 @@ class DebugOff:
         """Discard `msg`. Nothing is listening."""
 
     def __and__(self, flag):
+        """Always falsy, so the message after the `and` is never built."""
         return flagNone
 
     def __rand__(self, flag):
+        """Always falsy, with the operands the other way round."""
         return flagNone
 
     def __bool__(self):
+        """Always false."""
         return False
 
     def __str__(self):
+        """Says debugging is off."""
         return "<debugging off>"
 
 

--- a/pysnmp/entity/engine.py
+++ b/pysnmp/entity/engine.py
@@ -254,6 +254,7 @@ class SnmpEngine:
                 )
 
     def __repr__(self) -> str:
+        """The class and this engine's ID, which is what distinguishes one from another."""
         return f"{self.__class__.__name__}(snmpEngineID={self.snmpEngineID!r})"
 
     # Transport dispatcher bindings
@@ -265,11 +266,17 @@ class SnmpEngine:
         transportAddress: Any,
         wholeMsg: Any,
     ) -> None:
+        """Hand a message the dispatcher received to the message dispatcher."""
         self.msgAndPduDsp.receiveMessage(
             self, transportDomain, transportAddress, wholeMsg
         )
 
     def __receiveTimerTickCbFun(self, timeNow: int) -> None:
+        """Pass the tick to the dispatcher and to every model that keeps timed state.
+
+        The message processing and security models expire their own caches, so the tick
+        has to reach each of them and not just the dispatcher.
+        """
         self.msgAndPduDsp.receiveTimerTick(self, timeNow)
         for mpHandler in self.messageProcessingSubsystems.values():
             mpHandler.receiveTimerTick(self, timeNow)
@@ -279,6 +286,12 @@ class SnmpEngine:
     def registerTransportDispatcher(
         self, transportDispatcher: Any, recvId: Any = None
     ) -> None:
+        """Attach a dispatcher, or add another receiver to the one already attached.
+
+        One engine has one dispatcher; registering the same one again under a different
+        `recvId` is how several applications share it, which is what lets a command
+        responder and a notification receiver run on one engine.
+        """
         if (
             self.transportDispatcher is not None
             and self.transportDispatcher is not transportDispatcher
@@ -290,6 +303,7 @@ class SnmpEngine:
             self.transportDispatcher = transportDispatcher
 
     def unregisterTransportDispatcher(self, recvId: Any = None) -> None:
+        """Detach the dispatcher and stop receiving on it."""
         if self.transportDispatcher is None:
             raise error.PySnmpError("Transport dispatcher not registered")
         self.transportDispatcher.unregisterRecvCbFun(recvId)
@@ -297,14 +311,22 @@ class SnmpEngine:
         self.transportDispatcher = None
 
     def getMibBuilder(self) -> Any:
+        """The builder whose modules this engine serves and resolves names against."""
         return self.msgAndPduDsp.mibInstrumController.mibBuilder
 
     # User app may attach opaque objects to SNMP Engine
     def setUserContext(self, **kwargs: Any) -> None:
+        """Attach opaque objects to the engine, under names of the caller's choosing.
+
+        Names are prefixed before being cached, so nothing an application attaches can
+        collide with what the engine keeps there itself.
+        """
         self.cache.update({f"__{k}": kwargs[k] for k in kwargs})
 
     def getUserContext(self, arg: str) -> Any:
+        """One attached object, or `None`."""
         return self.cache.get(f"__{arg}")
 
     def delUserContext(self, arg: str) -> None:
+        """Drop an attached object. Unknown names are ignored."""
         self.cache.pop(f"__{arg}", None)

--- a/pysnmp/entity/observer.py
+++ b/pysnmp/entity/observer.py
@@ -96,6 +96,7 @@ class MetaObserver:
         self.__execpoints = {}
 
     def registerObserver(self, cbFun, *execpoints, **kwargs):
+        """Call `cbFun` whenever the engine passes any of these execution points."""
         if cbFun in self.__contexts:
             raise error.PySnmpError(f"duplicate observer {cbFun}")
         else:
@@ -106,6 +107,7 @@ class MetaObserver:
             self.__observers[execpoint].append(cbFun)
 
     def unregisterObserver(self, cbFun=None):
+        """Drop one observer, or all of them when given none."""
         if cbFun is None:
             self.__observers.clear()
             self.__contexts.clear()
@@ -117,12 +119,14 @@ class MetaObserver:
                     del self.__observers[execpoint]
 
     def storeExecutionContext(self, snmpEngine, execpoint, variables):
+        """Record the state at an execution point and call whoever is watching it."""
         self.__execpoints[execpoint] = variables
         if execpoint in self.__observers:
             for cbFun in self.__observers[execpoint]:
                 cbFun(snmpEngine, execpoint, variables, self.__contexts[cbFun])
 
     def clearExecutionContext(self, snmpEngine, *execpoints):
+        """Forget the state at these execution points, or at all of them."""
         if execpoints:
             for execpoint in execpoints:
                 del self.__execpoints[execpoint]
@@ -130,6 +134,7 @@ class MetaObserver:
             self.__execpoints.clear()
 
     def getExecutionContext(self, execpoint):
+        """The state recorded at an execution point."""
         return self.__execpoints[execpoint]
 
     def _restore_execution_context(self, execpoint, variables):

--- a/pysnmp/entity/rfc3413/cmdgen.py
+++ b/pysnmp/entity/rfc3413/cmdgen.py
@@ -97,6 +97,16 @@ class CommandGenerator:
         sendPduHandle,
         cbCtx,
     ):
+        """Match a response to its request, retrying or reporting as the outcome asks.
+
+        Two different things are counted here. An ordinary failure spends a retry; an
+        `unknownEngineID` or `notInTimeWindow` spends a discovery retry instead and
+        resets the ordinary count, because the exchange did not fail so much as teach
+        this side what it did not yet know about the peer.
+
+        A v1 peer gets the request translated back to v1 before it is resent, since
+        everything above this works in SMIv2.
+        """
         origSendRequestHandle, cbFun, cbCtx = cbCtx
 
         # 3.1.1
@@ -242,6 +252,11 @@ class CommandGenerator:
     def sendPdu(
         self, snmpEngine, targetName, contextEngineId, contextName, PDU, cbFun, cbCtx
     ):
+        """Send a request to a configured target and register for the response.
+
+        The target's timeout is in hundredths of a second and the dispatcher counts in
+        ticks, so it is converted here against the dispatcher's own resolution.
+        """
         (
             transportDomain,
             transportAddress,
@@ -336,6 +351,7 @@ class GetCommandGenerator(CommandGenerator):
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
+        """Hand the response's bindings to the caller."""
         cbFun, cbCtx = cbCtx
 
         cbFun(
@@ -358,6 +374,7 @@ class GetCommandGenerator(CommandGenerator):
         cbFun,
         cbCtx=None,
     ):
+        """Ask for exactly the objects named."""
         reqPDU = v2c.GetRequestPDU()
         v2c.apiPDU.setDefaults(reqPDU)
 
@@ -380,6 +397,7 @@ class SetCommandGenerator(CommandGenerator):
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
+        """Hand the response's bindings to the caller."""
         cbFun, cbCtx = cbCtx
 
         cbFun(
@@ -402,6 +420,7 @@ class SetCommandGenerator(CommandGenerator):
         cbFun,
         cbCtx=None,
     ):
+        """Write the values given."""
         reqPDU = v2c.SetRequestPDU()
         v2c.apiPDU.setDefaults(reqPDU)
 
@@ -424,6 +443,7 @@ class NextCommandGeneratorSingleRun(CommandGenerator):
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
+        """Hand one step's bindings to the caller and stop there."""
         targetName, contextEngineId, contextName, reqPDU, cbFun, cbCtx = cbCtx
 
         cbFun(
@@ -446,6 +466,7 @@ class NextCommandGeneratorSingleRun(CommandGenerator):
         cbFun,
         cbCtx=None,
     ):
+        """Ask for the objects following those named, once."""
         reqPDU = v2c.GetNextRequestPDU()
         v2c.apiPDU.setDefaults(reqPDU)
 
@@ -473,6 +494,13 @@ class NextCommandGenerator(NextCommandGeneratorSingleRun):
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
+        """Hand the bindings over, then reissue from where they left off.
+
+        This is what makes a walk one call rather than many: the last row of the
+        response becomes the next request. It stops when the callback says to, when the
+        subtree runs out, or when the agent returns OIDs that do not advance -- which
+        would otherwise walk forever.
+        """
         targetName, contextEngineId, contextName, reqPDU, cbFun, cbCtx = cbCtx
 
         if errorIndication:
@@ -542,6 +570,7 @@ class BulkCommandGeneratorSingleRun(CommandGenerator):
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
+        """Hand one bulk response's rows to the caller and stop there."""
         (
             targetName,
             nonRepeaters,
@@ -575,6 +604,7 @@ class BulkCommandGeneratorSingleRun(CommandGenerator):
         cbFun,
         cbCtx=None,
     ):
+        """Ask for up to `maxRepetitions` rows, once."""
         reqPDU = v2c.GetBulkRequestPDU()
         v2c.apiBulkPDU.setDefaults(reqPDU)
 
@@ -609,6 +639,7 @@ class BulkCommandGenerator(BulkCommandGeneratorSingleRun):
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, PDU, cbCtx
     ):
+        """Hand the rows over, then reissue from the last one, as the GETNEXT walk does."""
         (
             targetName,
             nonRepeaters,

--- a/pysnmp/entity/rfc3413/cmdrsp.py
+++ b/pysnmp/entity/rfc3413/cmdrsp.py
@@ -38,10 +38,12 @@ class CommandResponderBase:
         self.__pendingReqs = {}
 
     def handleMgmtOperation(self, snmpEngine, stateReference, contextName, PDU, acInfo):
+        """Serve one request. Concrete responders implement this."""
         # Concrete responders implement their management operation here.
         pass
 
     def close(self, snmpEngine):
+        """Deregister from the dispatcher and drop what is still pending."""
         snmpEngine.msgAndPduDsp.unregisterContextEngineId(
             self.snmpContext.contextEngineId, self.pduTypes
         )
@@ -50,6 +52,7 @@ class CommandResponderBase:
     def sendVarBinds(
         self, snmpEngine, stateReference, errorStatus, errorIndex, varBinds
     ):
+        """Answer with these bindings and this error status."""
         (
             messageProcessingModel,
             securityModel,
@@ -78,6 +81,12 @@ class CommandResponderBase:
     sendRsp = sendVarBinds
 
     def sendPdu(self, snmpEngine, stateReference, PDU):
+        """Send a prepared response, translating it back to v1 for a v1 peer.
+
+        Everything above this works in SMIv2, so a v1 request is answered by converting
+        the v2c response -- the original request coming along because v1 has no way to
+        say some of what v2c can, and the translation needs to know what was asked.
+        """
         (
             messageProcessingModel,
             securityModel,
@@ -130,6 +139,7 @@ class CommandResponderBase:
     _counter64Type = rfc1902.Counter64.tagSet
 
     def releaseStateInformation(self, stateReference):
+        """Drop what was held for a request. Unknown references are ignored."""
         if stateReference in self.__pendingReqs:
             del self.__pendingReqs[stateReference]
 
@@ -147,7 +157,14 @@ class CommandResponderBase:
         maxSizeResponseScopedPDU,
         stateReference,
     ):
+        """Take one request, run the operation, and turn any failure into an error status.
 
+        The long run of handlers here is the point: the instrumentation raises SMI
+        errors and the wire carries error statuses, so each one is mapped to its status
+        and the index of the binding that caused it. Nothing is allowed to escape as an
+        exception, since a request that produced no response at all would leave the
+        manager waiting out its timeout for no reason.
+        """
         # Agent-side API complies with SMIv2
         if messageProcessingModel == 0:
             origPdu = PDU
@@ -286,6 +303,13 @@ class CommandResponderBase:
         self.releaseStateInformation(stateReference)
 
     def __verifyAccess(self, name, syntax, idx, viewType, acCtx):
+        """Check one binding against the access control model, as an SMI error.
+
+        The credentials come from the observer's record of the message rather than
+        being threaded down through the instrumentation, which never needs them for
+        anything else. ACM refusals are mapped to `AuthorizationError`, so an object
+        the caller may not see is indistinguishable from one that is not there.
+        """
         snmpEngine = acCtx
         execCtx = snmpEngine.observer.getExecutionContext(
             "rfc3412.receiveMessage:request"
@@ -365,6 +389,7 @@ class GetCommandResponder(CommandResponderBase):
 
     # rfc1905: 4.2.1
     def handleMgmtOperation(self, snmpEngine, stateReference, contextName, PDU, acInfo):
+        """Read exactly the objects named."""
         (acFun, acCtx) = acInfo
         # rfc1905: 4.2.1.1
         mgmtFun = self.snmpContext.getMibInstrum(contextName).readVars
@@ -385,6 +410,7 @@ class NextCommandResponder(CommandResponderBase):
 
     # rfc1905: 4.2.2
     def handleMgmtOperation(self, snmpEngine, stateReference, contextName, PDU, acInfo):
+        """Read the objects following those named."""
         (acFun, acCtx) = acInfo
         # rfc1905: 4.2.2.1
         mgmtFun = self.snmpContext.getMibInstrum(contextName).readNextVars
@@ -413,6 +439,12 @@ class BulkCommandResponder(CommandResponderBase):
 
     # rfc1905: 4.2.3
     def handleMgmtOperation(self, snmpEngine, stateReference, contextName, PDU, acInfo):
+        """Read repeatedly, capping the repetitions at what `maxVarBinds` allows.
+
+        The requester names the repetition count, so without a cap it decides how much
+        work the agent does and how large the response gets. :RFC:`3416` lets an agent
+        return fewer repetitions than asked for, which is what makes capping legal.
+        """
         (acFun, acCtx) = acInfo
         nonRepeaters = v2c.apiBulkPDU.getNonRepeaters(PDU)
         nonRepeaters = max(nonRepeaters, 0)
@@ -459,6 +491,7 @@ class SetCommandResponder(CommandResponderBase):
 
     # rfc1905: 4.2.5
     def handleMgmtOperation(self, snmpEngine, stateReference, contextName, PDU, acInfo):
+        """Write the bindings, which the instrumentation commits all or nothing."""
         (acFun, acCtx) = acInfo
         mgmtFun = self.snmpContext.getMibInstrum(contextName).writeVars
         # rfc1905: 4.2.5.1-13

--- a/pysnmp/entity/rfc3413/context.py
+++ b/pysnmp/entity/rfc3413/context.py
@@ -38,6 +38,11 @@ class SnmpContext:
         }  # Default name
 
     def registerContextName(self, contextName, mibInstrum=None):
+        """Serve a context name from an instrumentation, or from the default one.
+
+        This is what lets one agent present different sets of objects under different
+        context names, which v3 has and v1 and v2c reach only through the community.
+        """
         contextName = univ.OctetString(contextName).asOctets()
         if contextName in self.contextNames:
             raise error.PySnmpError(f"Duplicate contextName {contextName}")
@@ -50,6 +55,7 @@ class SnmpContext:
             self.contextNames[contextName] = mibInstrum
 
     def unregisterContextName(self, contextName):
+        """Stop serving a context name. Unknown names are ignored."""
         contextName = univ.OctetString(contextName).asOctets()
         if contextName in self.contextNames:
             debug.logger & debug.flagIns and debug.logger(
@@ -58,6 +64,7 @@ class SnmpContext:
             del self.contextNames[contextName]
 
     def getMibInstrum(self, contextName=b""):
+        """The instrumentation serving a context name. Raises where it is not registered."""
         contextName = univ.OctetString(contextName).asOctets()
         if contextName not in self.contextNames:
             debug.logger & debug.flagIns and debug.logger(

--- a/pysnmp/entity/rfc3413/ntforg.py
+++ b/pysnmp/entity/rfc3413/ntforg.py
@@ -141,6 +141,12 @@ class NotificationOriginator:
         sendPduHandle,
         cbInfo,
     ):
+        """Match an INFORM's acknowledgement to what was sent, retrying if it failed.
+
+        As on the command generator, an unknown engine or a bad time window spends a
+        discovery retry rather than an ordinary one, since a first INFORM to a peer is
+        expected to fail that way.
+        """
         sendRequestHandle, cbFun, cbCtx = cbInfo
 
         # 3.3.6d
@@ -280,6 +286,7 @@ class NotificationOriginator:
         cbFun=None,
         cbCtx=None,
     ):
+        """Send a notification to a configured target, translating it for a v1 peer."""
         (transportDomain, transportAddress, timeout, retryCount, params) = (
             config.getTargetAddr(snmpEngine, targetName)
         )
@@ -372,6 +379,11 @@ class NotificationOriginator:
     def processResponseVarBinds(
         self, snmpEngine, sendRequestHandle, errorIndication, pdu, cbCtx
     ):
+        """Report a notification finished once the last of its targets has answered.
+
+        One notification may go to several targets, and the caller is told once rather
+        than per target, so this counts the outstanding sends down to nothing.
+        """
         notificationHandle, cbFun, cbCtx = cbCtx
 
         self.__pendingNotifications[notificationHandle].remove(sendRequestHandle)
@@ -409,6 +421,12 @@ class NotificationOriginator:
         cbFun=None,
         cbCtx=None,
     ):
+        """Send to every target the notify tag names, filling in the required bindings.
+
+        :RFC:`3416` wants `sysUpTime` first and `snmpTrapOID` second, so both are moved
+        into place or supplied where the caller did not give them -- a notification
+        without them is not one a receiver can interpret.
+        """
         debug.logger & debug.flagApp and debug.logger(
             'sendVarBinds: notificationTarget {}, contextEngineId {}, contextName "{}", varBinds {}'.format(
                 notificationTarget,

--- a/pysnmp/entity/rfc3413/ntfrcv.py
+++ b/pysnmp/entity/rfc3413/ntfrcv.py
@@ -54,6 +54,7 @@ class NotificationReceiver:
         )
 
     def close(self, snmpEngine):
+        """Deregister from the dispatcher and drop the callback."""
         snmpEngine.msgAndPduDsp.unregisterContextEngineId(b"", self.pduTypes)
         self.__cbFun = self.__cbCtx = None
 
@@ -71,7 +72,12 @@ class NotificationReceiver:
         maxSizeResponseScopedPDU,
         stateReference,
     ):
+        """Take a notification, hand it to the application, and acknowledge it if asked.
 
+        A v1 trap is converted to v2c first, so the application sees one shape however
+        it arrived, and an INFORM is acknowledged with the bindings echoed back as
+        :RFC:`3416` requires. An unconfirmed trap gets no response at all.
+        """
         # Agent-side API complies with SMIv2
         if messageProcessingModel == 0:
             origPdu = PDU

--- a/pysnmp/entity/rfc3413/oneliner/cmdgen.py
+++ b/pysnmp/entity/rfc3413/oneliner/cmdgen.py
@@ -41,22 +41,28 @@ class AsynCommandGenerator:
         self.mibViewController = self.vbProcessor.getMibViewController(self.snmpEngine)
 
     def __del__(self):
+        """Unconfigure this generator's targets from the engine."""
         self.lcd.unconfigure(self.snmpEngine)
 
     def cfgCmdGen(self, authData, transportTarget):
+        """Obsolete. Configure credentials and a target on the engine."""
         return self.lcd.configure(self.snmpEngine, authData, transportTarget)
 
     def uncfgCmdGen(self, authData=None):
+        """Obsolete. Remove what `cfgCmdGen` configured."""
         return self.lcd.unconfigure(self.snmpEngine, authData)
 
     # compatibility stub
     def makeReadVarBinds(self, varNames):
+        """Obsolete. Pair each name with a null, as a read request wants."""
         return self.makeVarBinds([(x, self._null) for x in varNames])
 
     def makeVarBinds(self, varBinds):
+        """Obsolete. Resolve bindings against the MIB."""
         return self.vbProcessor.makeVarBinds(self.snmpEngine, varBinds)
 
     def unmakeVarBinds(self, varBinds, lookupNames, lookupValues):
+        """Obsolete. Turn resolved bindings back into names and values."""
         return self.vbProcessor.unmakeVarBinds(
             self.snmpEngine, varBinds, lookupNames or lookupValues
         )
@@ -72,6 +78,7 @@ class AsynCommandGenerator:
         contextEngineId=None,
         contextName=b"",
     ):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.get_cmd`."""
 
         def __cbFun(
             snmpEngine,
@@ -120,6 +127,7 @@ class AsynCommandGenerator:
         contextEngineId=None,
         contextName=b"",
     ):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.set_cmd`."""
 
         def __cbFun(
             snmpEngine,
@@ -168,6 +176,7 @@ class AsynCommandGenerator:
         contextEngineId=None,
         contextName=b"",
     ):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.next_cmd`."""
 
         def __cbFun(
             snmpEngine,
@@ -218,6 +227,7 @@ class AsynCommandGenerator:
         contextEngineId=None,
         contextName=b"",
     ):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.bulk_cmd`."""
 
         def __cbFun(
             snmpEngine,
@@ -264,11 +274,11 @@ class CommandGenerator:
     _null = univ.Null("")
 
     def __init__(self, snmpEngine=None, asynCmdGen=None):
-        # compatibility attributes
         """`asynCmdGen` is accepted for compatibility and ignored."""
         self.snmpEngine = snmpEngine or SnmpEngine()
 
     def getCmd(self, authData, transportTarget, *varNames, **kwargs):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.sync.get_cmd`."""
         if "lookupNames" not in kwargs:
             kwargs["lookupNames"] = False
         if "lookupValues" not in kwargs:
@@ -286,6 +296,7 @@ class CommandGenerator:
         return errorIndication, errorStatus, errorIndex, varBinds
 
     def setCmd(self, authData, transportTarget, *varBinds, **kwargs):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.sync.set_cmd`."""
         if "lookupNames" not in kwargs:
             kwargs["lookupNames"] = False
         if "lookupValues" not in kwargs:
@@ -304,6 +315,7 @@ class CommandGenerator:
         return errorIndication, errorStatus, errorIndex, rspVarBinds
 
     def nextCmd(self, authData, transportTarget, *varNames, **kwargs):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.sync.next_cmd`."""
         if "lookupNames" not in kwargs:
             kwargs["lookupNames"] = False
         if "lookupValues" not in kwargs:
@@ -336,6 +348,7 @@ class CommandGenerator:
         *varNames,
         **kwargs,
     ):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.sync.bulk_cmd`."""
         if "lookupNames" not in kwargs:
             kwargs["lookupNames"] = False
         if "lookupValues" not in kwargs:

--- a/pysnmp/entity/rfc3413/oneliner/ntforg.py
+++ b/pysnmp/entity/rfc3413/oneliner/ntforg.py
@@ -25,15 +25,19 @@ MibVariable = ObjectIdentity
 
 class ErrorIndicationReturn:
     def __init__(self, *vars):
+        """Holds the tuple a legacy caller unpacks, error indication first."""
         self.__vars = vars
 
     def __getitem__(self, i):
+        """One element of the result tuple."""
         return self.__vars[i]
 
     def __bool__(self):
+        """Truthy where there is an error indication, so `if result:` means failure."""
         return bool(self.__vars[0])
 
     def __str__(self):
+        """The error indication alone."""
         return str(self.__vars[0])
 
 
@@ -63,20 +67,25 @@ class AsynNotificationOriginator:
         self.mibViewController = self.vbProcessor.getMibViewController(self.snmpEngine)
 
     def __del__(self):
+        """Unconfigure this originator's targets from the engine."""
         self.uncfgNtfOrg()
 
     def cfgNtfOrg(self, authData, transportTarget, notifyType):
+        """Obsolete. Configure credentials, a target and a notify type on the engine."""
         return self.lcd.configure(
             self.snmpEngine, authData, transportTarget, notifyType
         )
 
     def uncfgNtfOrg(self, authData=None):
+        """Obsolete. Remove what `cfgNtfOrg` configured."""
         return self.lcd.unconfigure(self.snmpEngine, authData)
 
     def makeVarBinds(self, varBinds):
+        """Obsolete. Resolve bindings against the MIB."""
         return self.vbProcessor.makeVarBinds(self.snmpEngine, varBinds)
 
     def unmakeVarBinds(self, varBinds, lookupNames, lookupValues):
+        """Obsolete. Turn resolved bindings back into names and values."""
         return self.vbProcessor.unmakeVarBinds(
             self.snmpEngine, varBinds, lookupNames or lookupValues
         )
@@ -94,6 +103,7 @@ class AsynNotificationOriginator:
         contextEngineId=None,  # XXX ordering incompatibility
         contextName=b"",
     ):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.send_notification`."""
 
         def __cbFun(
             snmpEngine,
@@ -162,7 +172,6 @@ class NotificationOriginator:
     vbProcessor = NotificationOriginatorVarBinds()
 
     def __init__(self, snmpEngine=None, snmpContext=None, asynNtfOrg=None):
-        # compatibility attributes
         """`asynNtfOrg` is accepted for compatibility and ignored."""
         self.snmpEngine = snmpEngine or SnmpEngine()
         self.mibViewController = self.vbProcessor.getMibViewController(self.snmpEngine)
@@ -178,6 +187,7 @@ class NotificationOriginator:
         *varBinds,
         **kwargs,
     ):
+        """Obsolete. Use `pysnmp.hlapi.asyncio.sync.send_notification`."""
         if "lookupNames" not in kwargs:
             kwargs["lookupNames"] = False
         if "lookupValues" not in kwargs:

--- a/pysnmp/hlapi/auth.py
+++ b/pysnmp/hlapi/auth.py
@@ -178,9 +178,15 @@ class CommunityData:
         )
 
     def __hash__(self) -> NoReturn:
+        """Refuses to hash.
+
+        The community is mutable, and hashing it would leak the secret into
+        whatever the hash ends up in.
+        """
         raise TypeError(f"{self.__class__.__name__} is not hashable")
 
     def __repr__(self) -> str:
+        """Every field except the community itself, which is elided."""
         return f"{self.__class__.__name__}(communityIndex={self.communityIndex!r}, communityName=<COMMUNITY>, mpModel={self.mpModel!r}, contextEngineId={self.contextEngineId!r}, contextName={self.contextName!r}, tag={self.tag!r}, securityName={self.securityName!r})"
 
     def clone(
@@ -193,6 +199,7 @@ class CommunityData:
         tag: Any = None,
         securityName: str | None = None,
     ) -> "CommunityData":
+        """Copy with fields replaced. A lone argument is taken as the community name."""
         # a single arg is considered as a community name
         if communityName is None:
             communityName, communityIndex = communityIndex, None
@@ -450,9 +457,11 @@ class UsmUserData:
         self.privKeyType = privKeyType
 
     def __hash__(self) -> NoReturn:
+        """Refuses to hash, for the same reason as the community's."""
         raise TypeError(f"{self.__class__.__name__} is not hashable")
 
     def __repr__(self) -> str:
+        """Every field except the keys, which are elided."""
         return "{}(userName={!r}, authKey=<AUTHKEY>, privKey=<PRIVKEY>, authProtocol={!r}, privProtocol={!r}, securityEngineId={!r}, securityName={!r}, authKeyType={!r}, privKeyType={!r})".format(
             self.__class__.__name__,
             self.userName,
@@ -476,6 +485,7 @@ class UsmUserData:
         authKeyType: int | None = None,
         privKeyType: int | None = None,
     ) -> "UsmUserData":
+        """Copy with fields replaced, keeping the rest as they are."""
         return self.__class__(
             userName if userName is not None else self.userName,
             authKey if authKey is not None else self.authKey,

--- a/pysnmp/hlapi/context.py
+++ b/pysnmp/hlapi/context.py
@@ -55,4 +55,5 @@ class ContextData:
     contextName: Any = b""
 
     def __repr__(self) -> str:
+        """The engine ID and context name this was built with."""
         return f"{self.__class__.__name__}(contextEngineId={self.contextEngineId!r}, contextName={self.contextName!r})"

--- a/pysnmp/hlapi/lcd.py
+++ b/pysnmp/hlapi/lcd.py
@@ -25,6 +25,7 @@ class AbstractLcdConfigurator:
     cacheKeys: list[str] = []
 
     def _getCache(self, snmpEngine):
+        """The cache this configurator keeps on the engine, created on first use."""
         cacheId = self.__class__.__name__
         cache = snmpEngine.getUserContext(cacheId)
         if cache is None:
@@ -33,10 +34,12 @@ class AbstractLcdConfigurator:
         return cache
 
     def configure(self, snmpEngine, *args, **kwargs):
+        """Write configuration to the engine. Subclasses implement this."""
         # Subclasses provide protocol-specific configuration.
         pass
 
     def unconfigure(self, snmpEngine, *args, **kwargs):
+        """Take configuration back out. Subclasses implement this."""
         # Subclasses provide protocol-specific cleanup.
         pass
 
@@ -54,6 +57,12 @@ class CommandGeneratorLcdConfigurator(AbstractLcdConfigurator):
     def configure(
         self, snmpEngine, authData, transportTarget, contextName=b"", **options
     ):
+        """Write the rows a request needs, reusing what is already there.
+
+        Configuring the same credentials twice adds a user of the existing rows rather
+        than a second set, which is what lets several generators share one engine
+        without treading on each other.
+        """
         cache = self._getCache(snmpEngine)
         if isinstance(authData, CommunityData):
             if authData.communityIndex not in cache["auth"]:
@@ -142,6 +151,7 @@ class CommandGeneratorLcdConfigurator(AbstractLcdConfigurator):
         return addrName, paramsName
 
     def unconfigure(self, snmpEngine, authData=None, contextName=b"", **options):
+        """Remove rows once nothing is using them, or everything when given no credentials."""
         cache = self._getCache(snmpEngine)
         if authData:
             # A community index for v1/v2c, a (user, engine id) pair for v3.
@@ -229,6 +239,7 @@ class NotificationOriginatorLcdConfigurator(AbstractLcdConfigurator):
     def configure(
         self, snmpEngine, authData, transportTarget, notifyType, contextName, **options
     ):
+        """Write the rows a notification needs, including its notify tag."""
         cache = self._getCache(snmpEngine)
         notifyName = None
 
@@ -281,6 +292,7 @@ class NotificationOriginatorLcdConfigurator(AbstractLcdConfigurator):
         return notifyName
 
     def unconfigure(self, snmpEngine, authData=None, contextName=b"", **options):
+        """Remove those rows once nothing is using them."""
         cache = self._getCache(snmpEngine)
         if authData:
             authDataKey = (

--- a/pysnmp/hlapi/varbinds.py
+++ b/pysnmp/hlapi/varbinds.py
@@ -17,6 +17,11 @@ __all__ = ["CommandGeneratorVarBinds", "NotificationOriginatorVarBinds"]
 class AbstractVarBinds:
     @staticmethod
     def getMibViewController(snmpEngine: Any) -> Any:
+        """The engine's MIB view, built and attached on first use.
+
+        It lives on the engine rather than on the caller so every application sharing
+        the engine resolves names against one index.
+        """
         mibViewController = snmpEngine.getUserContext("mibViewController")
         if not mibViewController:
             mibViewController = view.MibViewController(snmpEngine.getMibBuilder())
@@ -28,6 +33,13 @@ class CommandGeneratorVarBinds(AbstractVarBinds):
     """Variable bindings for requests: resolves names to OIDs and back."""
 
     def makeVarBinds(self, snmpEngine: Any, varBinds: Any) -> list[Any]:
+        """Resolve bindings against the MIB, accepting every form a caller may pass.
+
+        Names arrive as `ObjectType`, as an identity and value, as a bare OID, or in the
+        legacy nested-tuple form, and all of them come out resolved. Errors are not
+        ignored here: a request naming an object this side does not know is a mistake
+        worth reporting before anything is sent.
+        """
         mibViewController = self.getMibViewController(snmpEngine)
         __varBinds = []
         for varBind in varBinds:
@@ -52,6 +64,7 @@ class CommandGeneratorVarBinds(AbstractVarBinds):
     def unmakeVarBinds(
         self, snmpEngine: Any, varBinds: Any, lookupMib: bool = True
     ) -> list[Any]:
+        """Resolve a response's bindings back to MIB names, unless asked not to."""
         if lookupMib:
             mibViewController = self.getMibViewController(snmpEngine)
             varBinds = [
@@ -71,6 +84,7 @@ class NotificationOriginatorVarBinds(AbstractVarBinds):
     """
 
     def makeVarBinds(self, snmpEngine: Any, varBinds: Any) -> list[Any]:
+        """Resolve a notification's bindings, and the notification itself where given one."""
         mibViewController = self.getMibViewController(snmpEngine)
         if isinstance(varBinds, NotificationType):
             varBinds.resolveWithMib(mibViewController, ignoreErrors=False)
@@ -90,6 +104,11 @@ class NotificationOriginatorVarBinds(AbstractVarBinds):
     def unmakeVarBinds(
         self, snmpEngine: Any, varBinds: Any, lookupMib: bool = False
     ) -> list[Any]:
+        """Resolve bindings back to MIB names, which for notifications is off by default.
+
+        The bindings of a notification were built on this side and are already what the
+        caller passed in, so there is normally nothing to look up.
+        """
         if lookupMib:
             mibViewController = self.getMibViewController(snmpEngine)
             varBinds = [

--- a/pysnmp/proto/errind.py
+++ b/pysnmp/proto/errind.py
@@ -32,12 +32,19 @@ class ErrorIndication(Exception):
             self.__descr = descr
 
     def __eq__(self, other):
+        """Compare equal to the bare string as well as to another indication.
+
+        The engine passes these around as objects but application code has always
+        tested them against strings, so both have to work.
+        """
         return self.__value == other
 
     def __lt__(self, other):
+        """Order by the same string comparison equality uses."""
         return self.__value < other
 
     def __str__(self):
+        """The description, which `descr` may have replaced with something longer."""
         return self.__descr
 
 

--- a/pysnmp/proto/error.py
+++ b/pysnmp/proto/error.py
@@ -43,12 +43,15 @@ class StatusInformation(SnmpV3Error):
         ) and debug.logger(f"StatusInformation: {kwargs}")
 
     def __str__(self):
+        """Every detail the status carries, not just an error name."""
         return str(self.__errorIndication)
 
     def __getitem__(self, key):
+        """One detail of the status."""
         return self.__errorIndication[key]
 
     def __contains__(self, key):
+        """Whether a detail was set."""
         return key in self.__errorIndication
 
     def get(self, key, defVal=None):

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -40,14 +40,21 @@ classTypes = (type,)
 
 class __AbstractMibSource:
     def __init__(self, srcName: str) -> None:
+        """Records where to look. Nothing is read until `init()`."""
         self._srcName = srcName
         self.__inited = None
         debug.logger & debug.flagBld and debug.logger(f"trying {self}")
 
     def __repr__(self) -> str:
+        """The source and where it points, for debug logging."""
         return f"{self.__class__.__name__}({self._srcName!r})"
 
     def _uniqNames(self, names: list[str]) -> tuple[str, ...]:
+        """Module names from filenames, with the suffixes stripped and duplicates gone.
+
+        One module shows up once as `.py` and again as `.pyc`, and `__init__` is not a
+        MIB module at all.
+        """
         u: set[str] = set()
 
         for f in names:
@@ -61,11 +68,19 @@ class __AbstractMibSource:
     # MibSource API follows
 
     def fullPath(self, *args: Any) -> str:
+        """Where a module would live in this source, whether or not it is there."""
         f = args[0] if args else ""
         sfx = args[1] if len(args) > 1 else ""
         return self._srcName + (f and (os.sep + f + sfx) or "")
 
     def init(self) -> Any:
+        """Open the source, returning self or another source to use in its place.
+
+        A source may find at open time that something else should serve it -- a zip
+        source pointed at an ordinary install being the case that matters, since a
+        wheel unpacks to a directory -- so it can hand back a substitute rather than
+        fail. Opening twice is a no-op.
+        """
         if self.__inited is None:
             self.__inited = self._init()
             if self.__inited is self:
@@ -77,6 +92,7 @@ class __AbstractMibSource:
             return self.__inited
 
     def listdir(self) -> tuple[str, ...]:
+        """The module names this source can supply."""
         return self._listdir()
 
     def read(self, f: str) -> Any:
@@ -172,15 +188,19 @@ class __AbstractMibSource:
 
     # Interfaces for subclasses
     def _init(self) -> Any:
+        """Open the source. Concrete sources implement this."""
         raise NotImplementedError
 
     def _listdir(self) -> tuple[str, ...]:
+        """List module names. Concrete sources implement this."""
         raise NotImplementedError
 
     def _getTimestamp(self, f: str) -> float:
+        """When a file was last written. Concrete sources implement this."""
         raise NotImplementedError
 
     def _getData(self, f: str, mode: str) -> tuple[Any, str]:
+        """Read a file, returning its content and path. Concrete sources implement this."""
         raise NotImplementedError
 
 
@@ -261,6 +281,11 @@ class ZipMibSource(__AbstractMibSource):
 
     @staticmethod
     def _parseDosTime(dosdate: int, dostime: int) -> float:
+        """Convert a zip entry's DOS date and time into a Unix timestamp.
+
+        Zip stores modification time in the packed MS-DOS format, which is what the
+        staleness check between a `.pyc` and its `.py` has to compare against.
+        """
         t = (
             ((dosdate >> 9) & 0x7F) + 1980,  # year
             ((dosdate >> 5) & 0x0F),  # month
@@ -306,6 +331,7 @@ class ZipMibSource(__AbstractMibSource):
             raise OSError(ENOENT, "No such file in ZIP archive", p)
 
     def _getData(self, f: str, mode: str | None = None) -> tuple[Any, str]:
+        """Read one archive member."""
         p = os.path.join(self._srcName, f)
         try:
             return self.__loader.get_data(p), p
@@ -327,10 +353,17 @@ class DirMibSource(__AbstractMibSource):
     """MIB modules loaded out of a filesystem directory."""
 
     def _init(self) -> Any:
+        """Normalize the path. There is nothing to open until a module is asked for."""
         self._srcName = os.path.normpath(self._srcName)
         return self
 
     def _listdir(self) -> tuple[str, ...]:
+        """The module names in the directory, or nothing where it cannot be read.
+
+        A MIB path routinely names directories that do not exist, so an unreadable one
+        is logged and skipped rather than raised -- the other sources may well have the
+        module.
+        """
         try:
             return self._uniqNames(os.listdir(self._srcName))
         except OSError as why:
@@ -340,6 +373,7 @@ class DirMibSource(__AbstractMibSource):
             return ()
 
     def _getTimestamp(self, f: str) -> float:
+        """When a file was last written."""
         p = os.path.join(self._srcName, f)
         try:
             return os.stat(p)[8]
@@ -347,6 +381,11 @@ class DirMibSource(__AbstractMibSource):
             raise OSError(ENOENT, f"No such file: {e}", p) from e
 
     def _getData(self, f: str, mode: str) -> tuple[Any, str]:
+        """Read one file, matching the name case-sensitively.
+
+        The directory listing is consulted rather than the file opened directly,
+        because MIB module names are case-sensitive and the filesystem may not be.
+        """
         p = os.path.join(self._srcName, "*")
         try:
             if f in os.listdir(self._srcName):  # make FS case-sensitive
@@ -616,9 +655,15 @@ class MibBuilder:
     # MIB compiler management
 
     def getMibCompiler(self) -> Any:
+        """The compiler that renders ASN.1 on demand, or `None` where none is set."""
         return self.__mibCompiler
 
     def setMibCompiler(self, mibCompiler: Any, destDir: str) -> Any:
+        """Attach a compiler and add its output directory as a source.
+
+        Adding the source is the point: a module the compiler renders has to be
+        loadable afterwards, and nothing else would put that directory on the path.
+        """
         self.addMibSources(DirMibSource(destDir))
         self.__mibCompiler = mibCompiler
         return self
@@ -626,18 +671,21 @@ class MibBuilder:
     # MIB modules management
 
     def addMibSources(self, *mibSources: Any) -> None:
+        """Add sources to search, opening each one."""
         self.__mibSources.extend([s.init() for s in mibSources])
         debug.logger & debug.flagBld and debug.logger(
             f"addMibSources: new MIB sources {self.__mibSources}"
         )
 
     def setMibSources(self, *mibSources: Any) -> None:
+        """Replace the sources to search, opening each one."""
         self.__mibSources = [s.init() for s in mibSources]
         debug.logger & debug.flagBld and debug.logger(
             f"setMibSources: new MIB sources {self.__mibSources}"
         )
 
     def getMibSources(self) -> tuple[Any, ...]:
+        """The sources currently searched."""
         return tuple(self.__mibSources)
 
     def getModulePath(self, modName: str) -> str | None:
@@ -652,9 +700,11 @@ class MibBuilder:
 
     # Legacy/compatibility methods (won't work for .eggs)
     def setMibPath(self, *mibPaths: str) -> None:
+        """Replace the sources with plain directories, for callers that predate sources."""
         self.setMibSources(*[DirMibSource(x) for x in mibPaths])
 
     def getMibPath(self) -> tuple[str, ...]:
+        """The sources as directory paths. Raises where any source is not a directory."""
         paths: tuple[str, ...] = ()
         for mibSource in self.getMibSources():
             if isinstance(mibSource, DirMibSource):
@@ -847,6 +897,12 @@ class MibBuilder:
         return self
 
     def unloadModules(self, *modNames: str) -> Any:
+        """Unload modules, or every loaded module when given none.
+
+        What was unloaded can be loaded again; the record of where it came from is
+        dropped along with the symbols, so a second load searches afresh and may well
+        find a different copy.
+        """
         # Snapshot, since the loop mutates mibSymbols as it goes.
         names = modNames or tuple(self.mibSymbols)
         for modName in names:
@@ -863,6 +919,7 @@ class MibBuilder:
     def importSymbols(
         self, modName: str, *symNames: str, **userCtx: Any
     ) -> tuple[Any, ...]:
+        """Fetch symbols from a module, loading the module first if it is not loaded."""
         if not modName:
             raise error.SmiError("importSymbols: empty MIB module name")
         r: tuple[Any, ...] = ()
@@ -879,6 +936,12 @@ class MibBuilder:
     def exportSymbols(
         self, modName: str, *anonymousSyms: Any, **namedSyms: Any
     ) -> None:
+        """Publish symbols under a module name, labelling those that have no label.
+
+        A symbol whose label differs from the name it was passed under is filed by the
+        label, since that is the name the MIB gives it and what a lookup will ask for.
+        Anonymous symbols get a generated name so they can be unloaded later.
+        """
         if modName not in self.mibSymbols:
             self.mibSymbols[modName] = {}
         mibSymbols = self.mibSymbols[modName]
@@ -909,6 +972,7 @@ class MibBuilder:
         self.lastBuildId += 1
 
     def unexportSymbols(self, modName: str, *symNames: str) -> None:
+        """Withdraw symbols, or the whole module when given none."""
         if modName not in self.mibSymbols:
             raise error.SmiError(f"No module {modName} at {self}")
         mibSymbols = self.mibSymbols[modName]

--- a/pysnmp/smi/error.py
+++ b/pysnmp/smi/error.py
@@ -45,21 +45,27 @@ class MibOperationError(SmiError):
         self.__outArgs = kwargs
 
     def __str__(self):
+        """The class name and everything the error was given."""
         return f"{self.__class__.__name__}({self.__outArgs})"
 
     def __getitem__(self, key):
+        """One detail of the error."""
         return self.__outArgs[key]
 
     def __contains__(self, key):
+        """Whether a detail was set."""
         return key in self.__outArgs
 
     def get(self, key, defVal=None):
+        """One detail, or `defVal` where it was not set."""
         return self.__outArgs.get(key, defVal)
 
     def keys(self):
+        """The details that were set."""
         return self.__outArgs.keys()
 
     def update(self, d):
+        """Add details to the error, which is how an error picks up context as it rises."""
         self.__outArgs.update(d)
 
 

--- a/pysnmp/smi/indices.py
+++ b/pysnmp/smi/indices.py
@@ -32,28 +32,39 @@ class OrderedDict(dict):
             self.update(**kwargs)
 
     def __setitem__(self, key, value):
+        """Insert, marking the order stale where the key is new."""
         if key not in self:
             self.__keys.append(key)
             self.__dirty = True
         super().__setitem__(key, value)
 
     def __delitem__(self, key):
+        """Remove, marking the order stale."""
         if key in self:
             self.__keys.remove(key)
             self.__dirty = True
         super().__delitem__(key)
 
     def clear(self):
+        """Empty the mapping and forget the order."""
         super().clear()
         self.__keys = []
         self.__dirty = True
 
     def keys(self):
+        """The keys in order, sorting first if anything has changed since the last read."""
         if self.__dirty:
             self.__order()
         return list(self.__keys)
 
     def __iter__(self):
+        """Iterate in order, not in insertion order.
+
+        `dict.__iter__` would hand back insertion order, which is not the order this
+        class exists to impose. Everything that walks a mapping goes through here, so
+        overriding it is what keeps `list(d)`, `dict(d)` and `**d` agreeing with
+        `keys()`.
+        """
         # dict.__iter__ would hand back insertion order, which is not the
         # order this class exists to impose. Everything that walks one of
         # these -- `for k in d`, `list(d)`, `dict(d)`, `**d` -- has to see the
@@ -61,16 +72,23 @@ class OrderedDict(dict):
         return iter(self.keys())
 
     def values(self):
+        """The values, in key order."""
         if self.__dirty:
             self.__order()
         return [self[k] for k in self.__keys]
 
     def items(self):
+        """The pairs, in key order."""
         if self.__dirty:
             self.__order()
         return [(k, self[k]) for k in self.__keys]
 
     def update(self, *args, **kwargs):
+        """Insert from a mapping or from pairs, one key at a time.
+
+        Each key goes through `__setitem__` rather than `dict.update`, since that is
+        what maintains the key order and, in the OID subclass, the sort cache.
+        """
         if args:
             iterable = args[0]
             if hasattr(iterable, "keys"):
@@ -85,14 +103,21 @@ class OrderedDict(dict):
                 self[k] = v
 
     def sortingFun(self, keys):
+        """Sort the keys in place. Subclasses override this to order differently."""
         keys.sort()
 
     def __order(self):
+        """Sort the keys and note the distinct key lengths, longest first."""
         self.sortingFun(self.__keys)
         self.__keysLens = sorted({len(k) for k in self.__keys}, reverse=True)
         self.__dirty = False
 
     def nextKey(self, key):
+        """The key after this one, whether or not this one is present.
+
+        GETNEXT asks for the successor of an OID that need not exist, which is the whole
+        reason for keeping the keys ordered. Raises `KeyError` past the last key.
+        """
         if self.__dirty:
             self.__order()
 
@@ -111,6 +136,11 @@ class OrderedDict(dict):
             raise KeyError(key)
 
     def getKeysLens(self):
+        """The distinct key lengths, longest first.
+
+        Resolving an OID to a table row means trying successively shorter prefixes, and
+        only these lengths can possibly match.
+        """
         if self.__dirty:
             self.__order()
         return self.__keysLens
@@ -130,6 +160,11 @@ class OidOrderedDict(OrderedDict):
         OrderedDict.__init__(self, *args, **kwargs)
 
     def __setitem__(self, key, value):
+        """Insert, caching the OID tuple this key will sort by.
+
+        Keys arrive both as tuples and as dotted strings, and the sort needs the numeric
+        form of each; converting once here keeps it off the comparison path.
+        """
         OrderedDict.__setitem__(self, key, value)
         if key not in self.__keysCache:
             if isinstance(key, tuple):
@@ -138,9 +173,16 @@ class OidOrderedDict(OrderedDict):
                 self.__keysCache[key] = [int(x) for x in key.split(".") if x]
 
     def __delitem__(self, key):
+        """Remove, dropping the cached OID tuple with it."""
         OrderedDict.__delitem__(self, key)
         if key in self.__keysCache:
             del self.__keysCache[key]
 
     def sortingFun(self, keys):
+        """Sort by OID component rather than lexically.
+
+        This is what puts 1.3.6.1.10 after 1.3.6.1.9 instead of before it, and a walk
+        that sorted the other way would return rows in the wrong order and never
+        terminate correctly.
+        """
         keys.sort(key=lambda k, d=self.__keysCache: d[k])

--- a/pysnmp/smi/instrum.py
+++ b/pysnmp/smi/instrum.py
@@ -26,16 +26,19 @@ class AbstractMibInstrumController:
     def readVars(
         self, varBinds: Any, acInfo: tuple[Any, Any] = (None, None)
     ) -> list[Any]:
+        """Read bindings. This base serves nothing, so every OID is a missing instance."""
         raise error.NoSuchInstanceError(idx=0)
 
     def readNextVars(
         self, varBinds: Any, acInfo: tuple[Any, Any] = (None, None)
     ) -> list[Any]:
+        """Walk to the next bindings. This base has none, so the walk ends at once."""
         raise error.EndOfMibViewError(idx=0)
 
     def writeVars(
         self, varBinds: Any, acInfo: tuple[Any, Any] = (None, None)
     ) -> list[Any]:
+        """Write bindings. This base holds nothing writable."""
         raise error.NoSuchObjectError(idx=0)
 
 
@@ -93,11 +96,18 @@ class MibInstrumController(AbstractMibInstrumController):
         self.lastBuildSyms: dict[str, Any] = {}
 
     def getMibBuilder(self) -> Any:
+        """The builder whose loaded modules this serves."""
         return self.mibBuilder
 
     # MIB indexing
 
     def __indexMib(self) -> None:
+        """Rebuild the OID tree, unless the builder has loaded nothing since last time.
+
+        Loading a module changes what can be served, and the tree is what turns an OID
+        into the object that answers for it. The builder's build counter is what makes
+        this cheap enough to call on the front of every operation.
+        """
         # Build a tree from MIB objects found at currently loaded modules
         if self.lastBuildId == self.mibBuilder.lastBuildId:
             return
@@ -217,6 +227,17 @@ class MibInstrumController(AbstractMibInstrumController):
     def flipFlopFsm(
         self, fsmTable: dict[tuple[str, str], str], inputVarBinds: Any, acInfo: Any
     ) -> list[Any]:
+        """Run one operation over every binding as a state machine.
+
+        SNMP requires a SET to be all or nothing: each phase runs across all the
+        bindings before the next begins, so a failure in the test phase means nothing
+        was committed, and a failure after that unwinds what was. Reads run the same
+        machine with a shorter table, which is what keeps one code path for all three
+        operations.
+
+        The first exception is the one reported even if unwinding raises others, since
+        the later ones are consequences of the first.
+        """
         self.__indexMib()
         debug.logger & debug.flagIns and debug.logger(
             f"flipFlopFsm: input var-binds {inputVarBinds!r}"
@@ -277,14 +298,17 @@ class MibInstrumController(AbstractMibInstrumController):
     def readVars(
         self, varBinds: Any, acInfo: tuple[Any, Any] = (None, None)
     ) -> list[Any]:
+        """Read the bindings named, as GET does."""
         return self.flipFlopFsm(self.fsmReadVar, varBinds, acInfo)
 
     def readNextVars(
         self, varBinds: Any, acInfo: tuple[Any, Any] = (None, None)
     ) -> list[Any]:
+        """Read the bindings after those named, as GETNEXT and GETBULK do."""
         return self.flipFlopFsm(self.fsmReadNextVar, varBinds, acInfo)
 
     def writeVars(
         self, varBinds: Any, acInfo: tuple[Any, Any] = (None, None)
     ) -> list[Any]:
+        """Write the bindings, testing all of them before committing any."""
         return self.flipFlopFsm(self.fsmWriteVar, varBinds, acInfo)

--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -213,12 +213,14 @@ class ObjectIdentity:
             raise SmiError(f"{self.__class__.__name__} object not fully initialized")
 
     def getMibNode(self):
+        """The MIB object this resolved to. Raises until `resolveWithMib()` has run."""
         if self.__state & self.stClean:
             return self.__mibNode
         else:
             raise SmiError(f"{self.__class__.__name__} object not fully initialized")
 
     def isFullyResolved(self):
+        """Whether the MIB lookup has happened and the OID and node are known."""
         return self.__state & self.stClean
 
     #
@@ -586,6 +588,7 @@ class ObjectIdentity:
             raise SmiError("Non-OID, label or MIB symbol")
 
     def prettyPrint(self):
+        """The MIB name, as `MODULE::symbol` with any index appended."""
         if self.__state & self.stClean:
             s = rfc1902.OctetString()
             return "{}::{}{}{}".format(
@@ -605,6 +608,7 @@ class ObjectIdentity:
             raise SmiError(f"{self.__class__.__name__} object not fully initialized")
 
     def __repr__(self):
+        """How this identity was constructed, not what it resolved to."""
         return "{}({})".format(
             self.__class__.__name__, ", ".join([repr(x) for x in self.__args])
         )
@@ -612,60 +616,75 @@ class ObjectIdentity:
     # Redirect some attrs access to the OID object to behave alike
 
     def __str__(self):
+        """The OID in dotted form."""
         if self.__state & self.stClean:
             return str(self.__oid)
         else:
             raise SmiError(f"{self.__class__.__name__} object not properly initialized")
 
     def __eq__(self, other):
+        """Compare by OID."""
         if self.__state & self.stClean:
             return self.__oid == other
         else:
             raise SmiError(f"{self.__class__.__name__} object not properly initialized")
 
     def __lt__(self, other):
+        """Order by OID."""
         if self.__state & self.stClean:
             return self.__oid < other
         else:
             raise SmiError(f"{self.__class__.__name__} object not properly initialized")
 
     def __bool__(self):
+        """Whether the OID is non-empty."""
         if self.__state & self.stClean:
             return bool(self.__oid)
         else:
             raise SmiError(f"{self.__class__.__name__} object not properly initialized")
 
     def __getitem__(self, i):
+        """One sub-identifier, or a slice of them."""
         if self.__state & self.stClean:
             return self.__oid[i]
         else:
             raise SmiError(f"{self.__class__.__name__} object not properly initialized")
 
     def __len__(self):
+        """How many sub-identifiers the OID has."""
         if self.__state & self.stClean:
             return len(self.__oid)
         else:
             raise SmiError(f"{self.__class__.__name__} object not properly initialized")
 
     def __add__(self, other):
+        """Extend the OID on the right."""
         if self.__state & self.stClean:
             return self.__oid + other
         else:
             raise SmiError(f"{self.__class__.__name__} object not properly initialized")
 
     def __radd__(self, other):
+        """Extend the OID on the left."""
         if self.__state & self.stClean:
             return other + self.__oid
         else:
             raise SmiError(f"{self.__class__.__name__} object not properly initialized")
 
     def __hash__(self):
+        """Hash by OID. Raises until resolved, since the OID is what identifies it."""
         if self.__state & self.stClean:
             return hash(self.__oid)
         else:
             raise SmiError(f"{self.__class__.__name__} object not properly initialized")
 
     def __getattr__(self, attr):
+        """Forward the OID's own methods, once there is an OID to forward to.
+
+        This stands in for inheriting from `ObjectIdentifier`: an identity is not an OID
+        until it has been resolved against a MIB, so the methods appear only then
+        rather than being present and wrong beforehand.
+        """
         if self.__state & self.stClean:
             if attr in (
                 "asTuple",
@@ -766,20 +785,24 @@ class ObjectType:
         self.__units = ""
 
     def __getitem__(self, i):
+        """The identity at 0, the value at 1, as a binding is a pair."""
         if self.__state & self.stClean:
             return self.__args[i]
         else:
             raise SmiError(f"{self.__class__.__name__} object not fully initialized")
 
     def __str__(self):
+        """The binding as `MODULE::symbol.index = value`."""
         return self.prettyPrint()
 
     def __repr__(self):
+        """The identity and value this was constructed from."""
         return "{}({})".format(
             self.__class__.__name__, ", ".join([repr(x) for x in self.__args])
         )
 
     def isFullyResolved(self):
+        """Whether the identity resolved and the value took its MIB-defined type."""
         return self.__state & self.stClean
 
     def addAsn1MibSource(self, *asn1Sources, **kwargs):
@@ -1000,6 +1023,7 @@ class ObjectType:
             raise SmiError(f"{self.__class__.__name__} object not fully initialized")
 
     def prettyPrint(self):
+        """The binding with both halves rendered as the MIB defines them."""
         if self.__state & self.stClean:
             return f"{self.__args[0].prettyPrint()} = {self.__args[1].prettyPrint()}"
         else:
@@ -1094,12 +1118,14 @@ class NotificationType:
         self.__state = self.stDirty
 
     def __getitem__(self, i):
+        """One of the notification's bindings, by position."""
         if self.__state & self.stClean:
             return self.__varBinds[i]
         else:
             raise SmiError(f"{self.__class__.__name__} object not fully initialized")
 
     def __repr__(self):
+        """The identity, instance index and objects this was constructed from."""
         return f"{self.__class__.__name__}({self.__objectIdentity!r}, {self.__instanceIndex!r}, {self.__objects!r})"
 
     def addVarBinds(self, *varBinds):
@@ -1229,6 +1255,7 @@ class NotificationType:
         return self
 
     def isFullyResolved(self):
+        """Whether the notification and every object it carries have resolved."""
         return self.__state & self.stClean
 
     def resolveWithMib(self, mibViewController, ignoreErrors=True):
@@ -1333,6 +1360,7 @@ class NotificationType:
         return self
 
     def prettyPrint(self):
+        """The notification and its bindings, each rendered as the MIB defines them."""
         if self.__state & self.stClean:
             return " ".join(
                 [

--- a/pysnmp/smi/view.py
+++ b/pysnmp/smi/view.py
@@ -37,6 +37,11 @@ class MibViewController:
     # Indexing part
 
     def indexMib(self):
+        """Rebuild the name and OID indices, unless nothing has been loaded since.
+
+        Every lookup calls this first, so the builder's build counter is what keeps it
+        from re-indexing on each one.
+        """
         if self.lastBuildId == self.mibBuilder.lastBuildId:
             return
 
@@ -158,6 +163,7 @@ class MibViewController:
     # Module management
 
     def getOrderedModuleName(self, index):
+        """The loaded module at that position, counting from either end."""
         self.indexMib()
         modNames = self.__mibSymbolsIdx.keys()
         if modNames:
@@ -165,12 +171,15 @@ class MibViewController:
         raise error.SmiError(f"No modules loaded at {self}")
 
     def getFirstModuleName(self):
+        """The first loaded module."""
         return self.getOrderedModuleName(0)
 
     def getLastModuleName(self):
+        """The last loaded module."""
         return self.getOrderedModuleName(-1)
 
     def getNextModuleName(self, modName):
+        """The module after this one."""
         self.indexMib()
         try:
             return self.__mibSymbolsIdx.nextKey(modName)
@@ -202,6 +211,13 @@ class MibViewController:
         return oid, label, suffix
 
     def getNodeNameByOid(self, nodeName, modName=""):
+        """Resolve an OID or a label to `(oid, label, suffix)`.
+
+        An OID need not name an object exactly: the longest known prefix is what
+        resolves, and the rest comes back as the suffix, which is how an instance under
+        a column is named. An OID that resolves to nothing but itself is not in this
+        MIB view at all.
+        """
         self.indexMib()
         if modName in self.__mibSymbolsIdx:
             mibMod = self.__mibSymbolsIdx[modName]
@@ -220,6 +236,7 @@ class MibViewController:
         return oid, label, suffix
 
     def getNodeNameByDesc(self, nodeName, modName=""):
+        """Resolve a MIB symbol's name to `(oid, label, suffix)`."""
         self.indexMib()
         if modName in self.__mibSymbolsIdx:
             mibMod = self.__mibSymbolsIdx[modName]
@@ -237,6 +254,11 @@ class MibViewController:
         return self.getNodeNameByOid(oid, modName)
 
     def getNodeName(self, nodeName, modName=""):
+        """Resolve either an OID, a label, or a `(symbol, index...)` tuple.
+
+        The forms are tried in that order, since a caller may have any of the three and
+        they cannot be told apart reliably by shape.
+        """
         # nodeName may be either an absolute OID/label or a
         # ( MIB-symbol, su, ff, ix)
         try:
@@ -249,6 +271,7 @@ class MibViewController:
             return self.getNodeNameByOid(oid + suffix + nodeName[1:], modName)
 
     def getOrderedNodeName(self, index, modName="", nodeType=None):
+        """The object at that position in the module, optionally of one node type."""
         self.indexMib()
         if modName in self.__mibSymbolsIdx:
             mibMod = self.__mibSymbolsIdx[modName]
@@ -307,12 +330,19 @@ class MibViewController:
         return oid, label, ()
 
     def getFirstNodeName(self, modName="", nodeType=None):
+        """The first object in the module, or the first of one node type."""
         return self.getOrderedNodeName(0, modName, nodeType)
 
     def getLastNodeName(self, modName="", nodeType=None):
+        """The last object in the module, or the last of one node type."""
         return self.getOrderedNodeName(-1, modName, nodeType)
 
     def getNextNodeName(self, nodeName, modName=""):
+        """The object after this one, in OID order.
+
+        OID order is neither the order the modules were loaded in nor lexical order on
+        their names, which is why this cannot be answered from a plain mapping.
+        """
         oid, label, suffix = self.getNodeName(nodeName, modName)
         try:
             return self.getNodeName(
@@ -325,6 +355,7 @@ class MibViewController:
             ) from exc
 
     def getParentNodeName(self, nodeName, modName=""):
+        """The object one level up, its last sub-identifier moved onto the suffix."""
         oid, label, suffix = self.getNodeName(nodeName, modName)
         if len(oid) < 2:
             raise error.NoSuchObjectError(
@@ -333,12 +364,19 @@ class MibViewController:
         return oid[:-1], label[:-1], oid[-1:] + suffix
 
     def getNodeLocation(self, nodeName, modName=""):
+        """Which module defines an object, and under what label.
+
+        The answer comes from the index across all modules rather than from any one of
+        them, since the caller is asking precisely because they do not know which module
+        it is in.
+        """
         oid, label, suffix = self.getNodeName(nodeName, modName)
         return self.__mibSymbolsIdx[""]["oidToModIdx"][oid], label[-1], suffix
 
     # MIB type management
 
     def getTypeName(self, typeName, modName=""):
+        """Which module defines a textual convention or type."""
         self.indexMib()
         if modName in self.__mibSymbolsIdx:
             mibMod = self.__mibSymbolsIdx[modName]
@@ -353,6 +391,7 @@ class MibViewController:
         return m, typeName
 
     def getOrderedTypeName(self, index, modName=""):
+        """The type at that position in the module, counting from either end."""
         self.indexMib()
         if modName in self.__mibSymbolsIdx:
             mibMod = self.__mibSymbolsIdx[modName]
@@ -366,12 +405,15 @@ class MibViewController:
         return mibMod["typeToModIdx"][t], t
 
     def getFirstTypeName(self, modName=""):
+        """The first type the module defines."""
         return self.getOrderedTypeName(0, modName)
 
     def getLastTypeName(self, modName=""):
+        """The last type the module defines."""
         return self.getOrderedTypeName(-1, modName)
 
     def getNextType(self, typeName, modName=""):
+        """The type after this one."""
         m, t = self.getTypeName(typeName, modName)
         try:
             return self.__mibSymbolsIdx[m]["typeToModIdx"].nextKey(t)


### PR DESCRIPTION
Finishes #186. Two commits: the remaining 183 D102 sites, then the last 7 D105 sites. After this the whole docstring family is on — every module, package, class, function, constructor, method and magic method in the package says what it is for.

## D102 part 2 (183 sites)

`smi` 57, `entity` 61, `carrier` 62, `hlapi`/`debug` 28. Accessors stay one line naming what comes back. The words went where a signature actively misleads:

- **`MibBuilder.exportSymbols()` files a symbol under its MIB label**, not under the name it was passed — so a lookup finds it by the name the MIB gives it, not the name the caller used.
- **`__AbstractMibSource.init()` may return a different source than the one asked.** A zip source pointed at an unpacked wheel hands back a `DirMibSource`.
- **`OidOrderedDict.sortingFun()` is why 1.3.6.1.10 follows 1.3.6.1.9.** Sorting lexically would return rows in the wrong order and never terminate correctly.
- **`flipFlopFsm()` runs every phase across all bindings before the next begins** — that is what makes a SET all-or-nothing — and reports the *first* exception, not whatever unwinding raised last.
- **`CommandResponderBase.processPdu()` maps every SMI error onto a wire status** so nothing escapes as an exception. A request that produced no response at all would leave the manager waiting out its timeout for nothing.
- **`__verifyAccess()` maps ACM refusals to `AuthorizationError`**, making an object the caller may not see indistinguishable from one that is not there.
- **`sendVarBinds()` moves `sysUpTime` and `snmpTrapOID` into the first two positions**, since RFC 3416 requires them there.
- **`getLocalAddress()` falls back to the transport's wildcard** because POSIX and Windows disagree on how to name an unbound socket.
- **`CommunityData.__hash__` and `UsmUserData.__hash__` refuse rather than return**, so a mutable secret cannot leak into whatever the hash ends up in.

### Corrections made while reading

Five drafted claims did not survive checking the code, and were fixed before commit:

- `DirMibSource._init()` only normalizes the path; it is `ZipMibSource._init()` that stands aside for a directory.
- `Udp6AsyncioTransport.normalizeAddress()` strips the zone ID and scope — it does **not** map IPv4 into IPv6 space.
- `UnixAsyncioTransport.openClientMode()` invents a temporary path when given none, since a unix datagram socket cannot be replied to unless bound.
- `BulkCommandResponder` caps repetitions at `maxVarBinds`, not at a message size.
- `NotificationType.__getitem__` indexes bindings by position, not by OID.

### Placement fault, same as #222

Twelve docstrings first landed *below* a leading comment, separating that comment from the code it describes. All twelve moved above. Two `# compatibility attributes` comments went with them — they say what their docstring already says, and after the move they read as describing an unrelated assignment.

The `ast` audit now checks both conditions: docstring is the function's first statement, **and** no comment sits between the `def` and the docstring. My first script for this had a bug — for a multi-line signature it treated a trailing comment *inside the parameter list* as a leading comment and moved it. Caught by the deletion count, fixed, re-verified.

## D105 (7 sites)

Only 7 left, not the 48 the staging note projected — the D101 and D102 passes had already covered the rest, since ruff files a dunder under whichever rule its class context puts it in.

`ErrorIndication.__eq__` is the one worth reading: it compares against the bare string as well as another indication, because the engine passes these around as objects while application code has always tested them against string literals. Both have to keep working.

## Verification

`ruff check` and `format`, `mypy` (147 files), 1258 passed / 12 skipped, `sphinx-build -n -W`. Insertions only, apart from the `pyproject.toml` note and the two redundant comments above.

Closes #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API documentation across transport, dispatcher, SNMP engine, protocol, MIB, and high-level API components.
  * Clarified address handling, lifecycle operations, error behavior, data conversion, and compatibility interfaces.
  * Updated legacy wrapper guidance to reference current synchronous and asynchronous APIs.
* **Developer Experience**
  * Enabled the complete documentation rule set to improve consistency and completeness of public API documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->