### PR TITLE
Search several MIB corpora as one, ordered by precedence

### DIFF
--- a/docs/source/docs/mib-corpus.rst
+++ b/docs/source/docs/mib-corpus.rst
@@ -93,7 +93,7 @@ Several corpora at once
 A deployment rarely has one corpus. It has the distribution's, covering the
 standard modules and whatever vendors shipped with it, and it has its own --
 the enterprise MIBs its devices actually speak, which nobody else publishes.
-``CompositeMibCorpus`` searches several as one, most specific first:
+``CompositeMibCorpus`` searches several as one:
 
 .. code-block:: python
 
@@ -114,16 +114,21 @@ then, rather than being skipped: a skipped corpus leaves a deployment resolving
 fewer modules than it asked for, and the only symptom is a MIB that used to be
 found and now is not.
 
-**Names and OIDs resolve by different rules**, and the difference matters:
+**The newest MODULE-IDENTITY revision wins; configured order only breaks the
+tie.** This is the rule ``MibBuilder`` already applies to two MIB sources
+carrying one module, and the rule pysmi's compiler applies to two copies of one
+MIB, applied here to corpora. Two corpora carrying a module are carrying the
+same specification at two revisions, and the newer one is the answer wherever
+it sits in the search path -- so configuring a corpus that happens to carry an
+older copy cannot silently roll that module back.
 
-*By name, the first corpus carrying the module wins.* A caller naming a module
-is naming something they believe in, and the earliest source is the one they
-went out of their way to put first.
+Order settles what revisions cannot: when a candidate states no revision at all
+-- every SMIv1 module, and the SMI modules themselves -- or when they all state
+the same one.
 
-*By OID, the longest prefix wins; order is only the tie-break.* This is the
-rule the class exists for. Given a site subtree under an arc the core corpus
-already anchors, first-match-wins would resolve every OID beneath it to the
-core corpus's shallow anchor and never reach the site corpus at all -- no
+**By OID, the longest prefix wins first.** Given a site subtree under an arc the
+core corpus already anchors, first-match-wins would resolve every OID beneath it
+to the core corpus's shallow anchor and never reach the site corpus at all -- no
 matter which was configured first:
 
 .. code-block:: python
@@ -132,6 +137,14 @@ matter which was configured first:
 
    # core.db anchors 1.3.6.1.4.1.9; site.db anchors the subtree itself.
    store.find_module("1.3.6.1.4.1.9.9.42.1.1")   # -> 'SITE-MIB'
+
+The revision rule settles only what a shorter prefix cannot: two corpora naming
+*different* modules at the same prefix length.
+
+**Both paths reach the same copy.** An OID resolves to a module name, and that
+name then goes through the revision rule like any other. A corpus can anchor an
+OID without owning the module it names -- the anchor says which module answers,
+and the revision says whose copy of it is read.
 
 **One module resolves from exactly one corpus.** Where two carry the same
 module, every name-keyed lookup for it routes to the same one and the other's

--- a/docs/source/docs/mib-corpus.rst
+++ b/docs/source/docs/mib-corpus.rst
@@ -87,6 +87,63 @@ Pass ``None`` to stop using one. The corpus is opened read-only with SQLite's
 which is what lets it be mounted from a Kubernetes image volume.
 
 
+Several corpora at once
+-----------------------
+
+A deployment rarely has one corpus. It has the distribution's, covering the
+standard modules and whatever vendors shipped with it, and it has its own --
+the enterprise MIBs its devices actually speak, which nobody else publishes.
+``CompositeMibCorpus`` searches several as one, most specific first:
+
+.. code-block:: python
+
+   from pysnmp.smi.corpus import open_corpora
+
+   mibBuilder.setMibCorpus(open_corpora(["/mibs/site.db", "/mibs/core.db"]))
+
+Or from the environment, which is the same thing without the imports:
+
+.. code-block:: shell
+
+   PYSNMP_MIB_DBS=/mibs/site.db:/mibs/core.db
+
+Like ``PYSNMP_MIB_DIRS``, it is an ``os.pathsep``-separated list read when a
+``MibBuilder`` is constructed, and the order is the precedence order. A path
+naming something that is not a readable corpus raises ``SmiError`` there and
+then, rather than being skipped: a skipped corpus leaves a deployment resolving
+fewer modules than it asked for, and the only symptom is a MIB that used to be
+found and now is not.
+
+**Names and OIDs resolve by different rules**, and the difference matters:
+
+*By name, the first corpus carrying the module wins.* A caller naming a module
+is naming something they believe in, and the earliest source is the one they
+went out of their way to put first.
+
+*By OID, the longest prefix wins; order is only the tie-break.* This is the
+rule the class exists for. Given a site subtree under an arc the core corpus
+already anchors, first-match-wins would resolve every OID beneath it to the
+core corpus's shallow anchor and never reach the site corpus at all -- no
+matter which was configured first:
+
+.. code-block:: python
+
+   store = open_corpora(["/mibs/core.db", "/mibs/site.db"])
+
+   # core.db anchors 1.3.6.1.4.1.9; site.db anchors the subtree itself.
+   store.find_module("1.3.6.1.4.1.9.9.42.1.1")   # -> 'SITE-MIB'
+
+**One module resolves from exactly one corpus.** Where two carry the same
+module, every name-keyed lookup for it routes to the same one and the other's
+rows for it are invisible -- not its nodes, not its types, not its IMPORTS.
+Merging them would build one module from two definitions and produce two
+classes for one type, which fails ``isinstance`` somewhere far from here.
+
+``loadTexts`` is reported for the composite only when *every* corpus carries
+prose, so one textless corpus in the search path is refused rather than
+silently answering with no DESCRIPTION for the modules it owns.
+
+
 Resolving a trap OID without a compiler
 ---------------------------------------
 

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -494,6 +494,16 @@ class MibBuilder:
         nothing overrides the ones the engine itself needs, then the generated ones.
         That ordering is what lets a user's copy of a MIB shadow the bundled one
         without being able to displace the framework modules.
+
+        `PYSNMP_MIB_DBS` names corpora rather than sources and so is handled
+        separately, at the end: a corpus is searched only where the sources
+        come up empty, which is what keeps configuring one from changing any
+        answer a deployment already had.
+
+        Raises
+        ------
+            SmiError: `PYSNMP_MIB_DBS` names something that is not a readable
+                corpus.
         """
         self.lastBuildId = self._autoName = 0
         sources = []
@@ -517,6 +527,16 @@ class MibBuilder:
         self.__mibCorpus: Any = None
         self.__corpusBuilding: set[str] = set()
         self.setMibSources(*sources)
+
+        # Imported here rather than at module scope so that the default path
+        # -- no corpus configured, which is every existing deployment -- does
+        # not pay for sqlite3.
+        dbs = [x for x in os.environ.get("PYSNMP_MIB_DBS", "").split(os.pathsep) if x]
+
+        if dbs:
+            from pysnmp.smi.corpus import open_corpora
+
+            self.setMibCorpus(open_corpora(dbs))
 
     # MIB corpus management
 
@@ -548,8 +568,11 @@ class MibBuilder:
 
         Args:
             mibCorpus: an open
-                :py:class:`~pysnmp.smi.corpus.MibCorpus`, or ``None`` to stop
-                using one
+                :py:class:`~pysnmp.smi.corpus.MibCorpus`, a
+                :py:class:`~pysnmp.smi.corpus.CompositeMibCorpus` over several
+                of them, or ``None`` to stop using one. `PYSNMP_MIB_DBS` is a
+                thin layer over this: it opens the corpora it names, in the
+                order it names them, and calls this.
 
         Returns
         -------

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -56,6 +56,7 @@ __all__ = [
     "CompositeMibCorpus",
     "MibCorpus",
     "MibCorpusCycleError",
+    "best_by_revision",
     "oid_from_key",
     "oid_key",
     "open_corpora",
@@ -201,6 +202,48 @@ def subtree_bound(key: bytes) -> bytes:
     out[-1] += 1
 
     return bytes(out)
+
+
+def best_by_revision(candidates: "list[tuple[Any, str | None]]") -> Any:
+    """The best of several copies of one thing, newest revision first.
+
+    Two corpora offering a module are offering the same specification at two
+    revisions, and the newer one is the answer wherever it sits in the search
+    path -- so the newest MODULE-IDENTITY revision wins and configured order
+    only breaks the tie. This is
+    :py:meth:`~pysnmp.smi.builder.MibBuilder._candidates` applied to corpora
+    rather than to MIB sources, deliberately: a builder that ranked a module
+    found in two MIB sources by revision and the same module found in two
+    corpora by position would answer one question two ways. It is also
+    pysmi's ``PRECEDENCE_NEWEST_REVISION``, which is where the rule was
+    settled.
+
+    Configured order settles it when the revisions cannot: when any candidate
+    states none -- every SMIv1 module, and the SMI modules themselves -- or
+    when they all state the same one. An undated copy cannot be placed
+    against a dated one, so a single undated candidate leaves the whole
+    decision to order.
+
+    Args:
+        candidates: ``(payload, revision)`` in configured order, the revision
+            being the corpus ``module.revision`` column, which pysmi fills
+            with the newest revision the module states
+
+    Returns
+    -------
+        The winning payload, or ``None`` for no candidates.
+    """
+    if not candidates:
+        return None
+
+    revisions = [revision for _, revision in candidates]
+
+    if not all(revisions) or len(set(revisions)) == 1:
+        return candidates[0][0]
+
+    # max() returns the first maximal element, so candidates sharing the
+    # newest revision keep the order they were configured in.
+    return max(candidates, key=lambda pair: pair[1] or "")[0]
 
 
 class MibCorpus:
@@ -657,7 +700,7 @@ class MibCorpus:
 
 
 class CompositeMibCorpus:
-    """Several corpora searched as one, in precedence order.
+    """Several corpora searched as one, ranked by revision.
 
     A deployment rarely has a single corpus. It has the distribution's, which
     covers the standard modules and whatever vendors were published with it,
@@ -665,18 +708,28 @@ class CompositeMibCorpus:
     nobody else ships. Both have to be readable at once, and which one answers
     has to be decided by a rule rather than by whichever was configured last.
 
-    Two rules, because names and OIDs are not the same question.
+    One rule decides, and it is the one the rest of pysnmp and pysmi already
+    use: **the newest MODULE-IDENTITY revision wins, and configured order only
+    breaks the tie** -- :py:func:`best_by_revision`. Precedence by position
+    would make configuring a corpus that happens to carry an older copy of a
+    module a silent downgrade, which is the reason
+    :py:meth:`~pysnmp.smi.builder.MibBuilder._candidates` does not work that
+    way either.
 
-    **By name, the first corpus carrying the module wins.** A caller naming a
-    module is naming a thing they believe in, and the earliest source is the
-    one they went out of their way to put first.
+    **Both paths reach the same copy.** Resolving a name and resolving an OID
+    are one question asked twice, so an OID is resolved to a module *name* and
+    that name then goes through the same rule. A corpus can therefore anchor
+    an OID without owning the module it names: the anchor says which module
+    answers, :py:meth:`owner` says whose copy of it is read.
 
-    **By OID, the longest prefix wins, and order is only the tie-break.**
-    First-match-wins on OIDs is the bug this class exists to avoid: a private
-    subtree under ``enterprises.9`` resolves to the core corpus's anchor for
+    **By OID the longest prefix still wins first.** First-match-wins on OIDs
+    is the bug this class exists to avoid: a private subtree under
+    ``enterprises.9`` resolves to the core corpus's anchor for
     ``enterprises.9`` and never reaches the customer corpus that anchors the
-    subtree itself, no matter how the two are ordered. Candidates are gathered
-    at every prefix length, deepest first.
+    subtree itself, no matter how the two are ordered. Every corpus is asked
+    at each prefix length before the OID is shortened; the revision rule
+    settles only what a shorter prefix cannot, which is two corpora naming
+    different modules at the *same* length.
 
     **One module resolves from exactly one corpus.** Where two carry the same
     module, every name-keyed lookup for it routes to the same one, and the
@@ -687,7 +740,7 @@ class CompositeMibCorpus:
     convenience.
 
     Args:
-        *corpora: the corpora, most specific first
+        *corpora: the corpora, in search order
 
     Raises
     ------
@@ -698,7 +751,7 @@ class CompositeMibCorpus:
     """
 
     def __init__(self, *corpora: MibCorpus):
-        """Take the corpora in precedence order and index nothing yet."""
+        """Take the corpora in search order and index nothing yet."""
         if not corpora:
             raise error.SmiError("a composite MIB corpus needs at least one corpus")
 
@@ -712,7 +765,7 @@ class CompositeMibCorpus:
 
     @property
     def corpora(self) -> "tuple[MibCorpus, ...]":
-        """The corpora this searches, in precedence order."""
+        """The corpora this searches, in the order they were given."""
         return self._corpora
 
     @property
@@ -774,19 +827,25 @@ class CompositeMibCorpus:
 
         This is the one-module-one-corpus rule made callable: every name-keyed
         lookup here goes through it, so a module's nodes, types and IMPORTS
-        cannot come from different corpora.
+        cannot come from different corpora. Which corpus that is follows
+        :py:func:`best_by_revision` -- newest revision, configured order only
+        breaking the tie.
 
         Args:
             module: the module's descriptor
 
         Returns
         -------
-            The first corpus carrying it, or ``None`` when none does.
+            The corpus whose copy is read, or ``None`` when none carries it.
         """
         if module not in self._owners:
-            self._owners[module] = next(
-                (x for x in self._corpora if module in x.modules()), None
-            )
+            candidates = [
+                (corpus, (corpus.module(module) or {}).get("revision"))
+                for corpus in self._corpora
+                if module in corpus.modules()
+            ]
+
+            self._owners[module] = best_by_revision(candidates)
 
         return self._owners[module]
 
@@ -805,7 +864,13 @@ class CompositeMibCorpus:
         return owner.module(name) if owner else None
 
     def anchor(self, oid: Union[str, "tuple[int, ...]"]) -> str | None:
-        """Which module registers exactly this OID, in precedence order.
+        """Which module registers exactly this OID, across all corpora.
+
+        Corpora usually agree, naming one module between them. Where they name
+        *different* modules for one OID the contest is settled the way every
+        other one here is, by :py:func:`best_by_revision` over those modules --
+        each read at the revision :py:meth:`owner` would give it, so the answer
+        does not depend on which corpus was asked.
 
         Args:
             oid: the OID, matched as given
@@ -814,21 +879,27 @@ class CompositeMibCorpus:
         -------
             The module name, or ``None``.
         """
+        candidates: list[tuple[str, str | None]] = []
+        seen: set[str] = set()
+
         for corpus in self._corpora:
             found = corpus.anchor(oid)
 
-            if found is not None:
-                return found
+            if found is None or found in seen:
+                continue
 
-        return None
+            seen.add(found)
+            candidates.append((found, (self.module(found) or {}).get("revision")))
+
+        return best_by_revision(candidates)
 
     def find_module(self, oid: Union[str, "tuple[int, ...]"]) -> str | None:
         """Which module answers for an OID, by longest prefix across all corpora.
 
         Every corpus is asked at each prefix length before the OID is
         shortened, so a corpus late in the order still wins with a deeper
-        anchor than an earlier one. Order decides only between anchors of
-        equal length.
+        anchor than an earlier one. Only anchors of equal length are ranked
+        against each other, by :py:meth:`anchor`.
 
         Args:
             oid: the OID to resolve
@@ -1022,10 +1093,10 @@ class CompositeMibCorpus:
 
 
 def open_corpora(paths: "list[str] | tuple[str, ...]") -> Any:
-    """Open a search path of corpora, most specific first.
+    """Open a search path of corpora.
 
     Args:
-        paths: the ``.db`` files, in precedence order
+        paths: the ``.db`` files, in search order
 
     Returns
     -------

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -53,10 +53,12 @@ from typing import Any, Final, Union
 from pysnmp.smi import error
 
 __all__ = [
+    "CompositeMibCorpus",
     "MibCorpus",
     "MibCorpusCycleError",
     "oid_from_key",
     "oid_key",
+    "open_corpora",
     "subtree_bound",
 ]
 
@@ -449,6 +451,29 @@ class MibCorpus:
 
         return node
 
+    def anchor(self, oid: Union[str, "tuple[int, ...]"]) -> str | None:
+        """Which module registers *exactly* this OID, without chopping arcs.
+
+        The single index lookup :py:meth:`find_module` repeats as it shortens
+        the OID. It is public because a search across several corpora cannot
+        be built out of :py:meth:`find_module`: that returns a module name and
+        not the length it matched at, so a shallow anchor in one corpus is
+        indistinguishable from a deep one in another, and the longest-prefix
+        rule the composite owes cannot be applied to the answers. Chopping is
+        hoisted into the caller instead, and this is what it calls.
+
+        Args:
+            oid: the OID, matched as given
+
+        Returns
+        -------
+            The module name, or ``None`` when no module anchors this exact
+            OID -- which for anything below an anchor is the normal answer.
+        """
+        row = self._db.execute(self.QUERIES["find_module"], (oid_key(oid),)).fetchone()
+
+        return row[0] if row else None
+
     def find_module(self, oid: Union[str, "tuple[int, ...]"]) -> str | None:
         """Which module answers for an OID.
 
@@ -470,12 +495,10 @@ class MibCorpus:
         arcs = [int(x) for x in oid.split(".")] if isinstance(oid, str) else list(oid)
 
         while arcs:
-            row = self._db.execute(
-                self.QUERIES["find_module"], (oid_key(tuple(arcs)),)
-            ).fetchone()
+            found = self.anchor(tuple(arcs))
 
-            if row:
-                return row[0]
+            if found is not None:
+                return found
 
             arcs.pop()
 
@@ -631,3 +654,407 @@ class MibCorpus:
             Symbol name to source module.
         """
         return dict(self._db.execute(self.QUERIES["imports_of"], (module,)))
+
+
+class CompositeMibCorpus:
+    """Several corpora searched as one, in precedence order.
+
+    A deployment rarely has a single corpus. It has the distribution's, which
+    covers the standard modules and whatever vendors were published with it,
+    and it has its own -- the enterprise MIBs its devices actually speak, which
+    nobody else ships. Both have to be readable at once, and which one answers
+    has to be decided by a rule rather than by whichever was configured last.
+
+    Two rules, because names and OIDs are not the same question.
+
+    **By name, the first corpus carrying the module wins.** A caller naming a
+    module is naming a thing they believe in, and the earliest source is the
+    one they went out of their way to put first.
+
+    **By OID, the longest prefix wins, and order is only the tie-break.**
+    First-match-wins on OIDs is the bug this class exists to avoid: a private
+    subtree under ``enterprises.9`` resolves to the core corpus's anchor for
+    ``enterprises.9`` and never reaches the customer corpus that anchors the
+    subtree itself, no matter how the two are ordered. Candidates are gathered
+    at every prefix length, deepest first.
+
+    **One module resolves from exactly one corpus.** Where two carry the same
+    module, every name-keyed lookup for it routes to the same one, and the
+    other's rows for it are not visible -- not its nodes, not its types, not
+    its IMPORTS. Merging two corpora for one module would build one module out
+    of two definitions and produce distinct class objects for the same type,
+    which breaks ``isinstance`` at a distance and is not worth any amount of
+    convenience.
+
+    Args:
+        *corpora: the corpora, most specific first
+
+    Raises
+    ------
+        SmiError: no corpora were given. There is nothing for an empty
+            composite to answer and its every lookup would be ``None``, which
+            reads as "the corpora do not carry it" rather than as the
+            configuration mistake it is.
+    """
+
+    def __init__(self, *corpora: MibCorpus):
+        """Take the corpora in precedence order and index nothing yet."""
+        if not corpora:
+            raise error.SmiError("a composite MIB corpus needs at least one corpus")
+
+        self._corpora: tuple[MibCorpus, ...] = tuple(corpora)
+        self._modules: frozenset[str] | None = None
+        self._owners: dict[str, MibCorpus | None] = {}
+
+    def __repr__(self) -> str:
+        """The composite and what it was built from, in order."""
+        return f"{self.__class__.__name__}({', '.join(repr(x) for x in self._corpora)})"
+
+    @property
+    def corpora(self) -> "tuple[MibCorpus, ...]":
+        """The corpora this searches, in precedence order."""
+        return self._corpora
+
+    @property
+    def path(self) -> str:
+        """Where the corpora were opened from, joined as a search path."""
+        return os.pathsep.join(x.path for x in self._corpora)
+
+    def close(self) -> None:
+        """Release every corpus."""
+        for corpus in self._corpora:
+            corpus.close()
+
+    @property
+    def loadTexts(self) -> bool:
+        """Whether *every* corpus carries DESCRIPTION and REFERENCE.
+
+        All rather than any, because a caller asking for texts is asking about
+        the modules they will load, and which corpus answers for a given
+        module is not something they chose. One textless corpus in the search
+        path means some modules come back with no prose, and reporting texts
+        as available would make that indistinguishable from a MIB that
+        declares none -- the precise confusion
+        :py:meth:`~pysnmp.smi.builder.MibBuilder.setMibCorpus` refuses to
+        allow.
+        """
+        return all(x.loadTexts for x in self._corpora)
+
+    def meta(self, key: str) -> str | None:
+        """One metadata value, from the first corpus that carries it.
+
+        Args:
+            key: the metadata key
+
+        Returns
+        -------
+            The value, or ``None`` when no corpus records that key. Note that
+            values such as ``corpus_id`` and the counts describe *one* corpus
+            and not the search path, so this answers "what does the first
+            corpus that has an opinion say", which is useful for diagnostics
+            and not much else.
+        """
+        for corpus in self._corpora:
+            value = corpus.meta(key)
+
+            if value is not None:
+                return value
+
+        return None
+
+    def modules(self) -> frozenset[str]:
+        """Every module any corpus carries."""
+        if self._modules is None:
+            self._modules = frozenset().union(*(x.modules() for x in self._corpora))
+
+        return self._modules
+
+    def owner(self, module: str) -> MibCorpus | None:
+        """Which corpus answers for a module, and will answer for all of it.
+
+        This is the one-module-one-corpus rule made callable: every name-keyed
+        lookup here goes through it, so a module's nodes, types and IMPORTS
+        cannot come from different corpora.
+
+        Args:
+            module: the module's descriptor
+
+        Returns
+        -------
+            The first corpus carrying it, or ``None`` when none does.
+        """
+        if module not in self._owners:
+            self._owners[module] = next(
+                (x for x in self._corpora if module in x.modules()), None
+            )
+
+        return self._owners[module]
+
+    def module(self, name: str) -> dict[str, Any] | None:
+        """What the owning corpus records about a module.
+
+        Args:
+            name: the module's descriptor
+
+        Returns
+        -------
+            Its record, or ``None`` when no corpus carries it.
+        """
+        owner = self.owner(name)
+
+        return owner.module(name) if owner else None
+
+    def anchor(self, oid: Union[str, "tuple[int, ...]"]) -> str | None:
+        """Which module registers exactly this OID, in precedence order.
+
+        Args:
+            oid: the OID, matched as given
+
+        Returns
+        -------
+            The module name, or ``None``.
+        """
+        for corpus in self._corpora:
+            found = corpus.anchor(oid)
+
+            if found is not None:
+                return found
+
+        return None
+
+    def find_module(self, oid: Union[str, "tuple[int, ...]"]) -> str | None:
+        """Which module answers for an OID, by longest prefix across all corpora.
+
+        Every corpus is asked at each prefix length before the OID is
+        shortened, so a corpus late in the order still wins with a deeper
+        anchor than an earlier one. Order decides only between anchors of
+        equal length.
+
+        Args:
+            oid: the OID to resolve
+
+        Returns
+        -------
+            The module name, or ``None`` when no corpus claims a prefix.
+        """
+        arcs = [int(x) for x in oid.split(".")] if isinstance(oid, str) else list(oid)
+
+        while arcs:
+            found = self.anchor(tuple(arcs))
+
+            if found is not None:
+                return found
+
+            arcs.pop()
+
+        return None
+
+    def _owned(self, corpus: MibCorpus, node: dict[str, Any] | None) -> bool:
+        """Whether a node this corpus returned is one it answers for.
+
+        A node belongs to a module, and a module belongs to one corpus. A
+        corpus late in the order still has rows for a module an earlier one
+        owns, and those rows are not part of what the composite resolves.
+
+        Args:
+            corpus: the corpus the node came from
+            node: the node, or ``None``
+
+        Returns
+        -------
+            Whether it should be visible.
+        """
+        return node is not None and self.owner(node["module"]) is corpus
+
+    def node(
+        self, oid: Union[str, "tuple[int, ...]"], module: str | None = None
+    ) -> dict[str, Any] | None:
+        """The node at an exact OID, from the corpus that owns its module.
+
+        Args:
+            oid: the OID, which must be the node's own and not an instance
+            module: which module's definition to take. The first corpus with
+                a node at this OID that it owns, otherwise.
+
+        Returns
+        -------
+            The node, or ``None``.
+        """
+        if module is not None:
+            owner = self.owner(module)
+
+            return owner.node(oid, module) if owner else None
+
+        for corpus in self._corpora:
+            found = corpus.node(oid)
+
+            if self._owned(corpus, found):
+                return found
+
+        return None
+
+    def node_named(self, module: str, name: str) -> dict[str, Any] | None:
+        """The node a module declares under a descriptor.
+
+        Args:
+            module: the module's descriptor
+            name: the symbol's descriptor
+
+        Returns
+        -------
+            The node, or ``None``.
+        """
+        owner = self.owner(module)
+
+        return owner.node_named(module, name) if owner else None
+
+    def next_node(self, oid: Union[str, "tuple[int, ...]"]) -> dict[str, Any] | None:
+        """The first node ordered after an OID, across every corpus.
+
+        A walk has to see one ordering, so each corpus is advanced to its own
+        first owned successor and the earliest of those wins. Rows for a
+        module some other corpus owns are stepped over rather than returned,
+        which is what keeps a walk from visiting a module twice under two
+        definitions.
+
+        Args:
+            oid: where to start, exclusive
+
+        Returns
+        -------
+            The next node, or ``None`` at the end of every corpus, which is
+            ``endOfMibView`` and not an error.
+        """
+        best: dict[str, Any] | None = None
+        bound: bytes | None = None
+
+        for corpus in self._corpora:
+            found = corpus.next_node(oid)
+
+            while found is not None and not self._owned(corpus, found):
+                found = corpus.next_node(found["arcs"])
+
+            if found is None:
+                continue
+
+            key = oid_key(found["arcs"])
+
+            if bound is None or key < bound:
+                best, bound = found, key
+
+        return best
+
+    def subtree(self, oid: Union[str, "tuple[int, ...]"]) -> list[dict[str, Any]]:
+        """Every owned node at or below an OID, in OID order.
+
+        Args:
+            oid: the subtree root
+
+        Returns
+        -------
+            The nodes, root first, merged across corpora.
+        """
+        found = [
+            node
+            for corpus in self._corpora
+            for node in corpus.subtree(oid)
+            if self._owned(corpus, node)
+        ]
+
+        return sorted(found, key=lambda x: (oid_key(x["arcs"]), x["module"]))
+
+    def nodes_of(self, module: str) -> list[dict[str, Any]]:
+        """Every node a module declares, from the corpus that owns it.
+
+        Args:
+            module: the module's descriptor
+
+        Returns
+        -------
+            The nodes, or an empty list when no corpus carries the module.
+        """
+        owner = self.owner(module)
+
+        return owner.nodes_of(module) if owner else []
+
+    def symbols_of(self, module: str) -> list[dict[str, Any]]:
+        """Every type a module declares, from the corpus that owns it.
+
+        Args:
+            module: the module's descriptor
+
+        Returns
+        -------
+            The symbols, or an empty list when no corpus carries the module.
+        """
+        owner = self.owner(module)
+
+        return owner.symbols_of(module) if owner else []
+
+    def symbol(self, module: str, name: str) -> dict[str, Any] | None:
+        """One declared type, from the corpus that owns its module.
+
+        Args:
+            module: the module's descriptor
+            name: the type's descriptor
+
+        Returns
+        -------
+            The symbol, or ``None``.
+        """
+        owner = self.owner(module)
+
+        return owner.symbol(module, name) if owner else None
+
+    def imports_of(self, module: str) -> dict[str, str]:
+        """A module's IMPORTS, from the corpus that owns it.
+
+        Args:
+            module: the module's descriptor
+
+        Returns
+        -------
+            Symbol name to source module, empty when no corpus carries it.
+        """
+        owner = self.owner(module)
+
+        return owner.imports_of(module) if owner else {}
+
+
+def open_corpora(paths: "list[str] | tuple[str, ...]") -> Any:
+    """Open a search path of corpora, most specific first.
+
+    Args:
+        paths: the ``.db`` files, in precedence order
+
+    Returns
+    -------
+        A :py:class:`MibCorpus` for a single path and a
+        :py:class:`CompositeMibCorpus` for several. One path is not wrapped
+        because a composite of one answers identically and only obscures the
+        corpus in tracebacks and in ``repr``.
+
+    Raises
+    ------
+        SmiError: no paths were given, or one of them is not a readable
+            corpus. A configured corpus that cannot be opened is a mistake to
+            report rather than a source to skip: skipping it leaves a
+            deployment resolving fewer modules than it asked for, and the only
+            symptom is a MIB that used to be found and now is not.
+    """
+    opened: list[MibCorpus] = []
+
+    try:
+        for path in paths:
+            opened.append(MibCorpus(path))
+
+    except Exception:
+        for corpus in opened:
+            corpus.close()
+
+        raise
+
+    if not opened:
+        raise error.SmiError("no MIB corpus paths given")
+
+    return opened[0] if len(opened) == 1 else CompositeMibCorpus(*opened)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -21,6 +21,8 @@ with the reader by construction.
 """
 
 import os
+import shutil
+import sqlite3
 
 import pytest
 
@@ -39,9 +41,11 @@ from pysnmp.smi.builder import MibBuilder
 from pysnmp.smi.corpus import (
     APPLICATION_ID,
     SCHEMA_VERSION,
+    CompositeMibCorpus,
     MibCorpus,
     oid_from_key,
     oid_key,
+    open_corpora,
     subtree_bound,
 )
 
@@ -58,6 +62,115 @@ def corpus_path(tmp_path_factory):
 def corpus(corpus_path):
     """An open corpus, closed afterwards."""
     opened = MibCorpus(corpus_path)
+
+    yield opened
+
+    opened.close()
+
+
+#: Where the derived corpus anchors a module of its own, under a subtree the
+#: conformance corpus anchors seven arcs higher. This is the shape the
+#: longest-prefix rule exists for: a site's own subtree inside a vendor arc the
+#: distribution corpus already claims.
+PRIVATE_OID = "1.3.6.1.4.1.99999.2.7"
+
+#: An OID the derived corpus anchors to a *different* module at the *same*
+#: length the conformance corpus anchors ``SMIV1-MIB``. Nothing but precedence
+#: can separate these two, which is what makes it the tie-break case.
+CONTESTED_OID = "1.3.6.1.4.1.99996"
+
+
+@pytest.fixture(scope="module")
+def private_path(corpus_path, tmp_path_factory):
+    """A second corpus, derived from the first so the two genuinely overlap.
+
+    Copied rather than built independently, because what has to be tested is
+    what happens when two corpora carry the *same* module: which one answers,
+    and that the other's rows for it stay invisible. Three edits give every
+    such case a name to assert on.
+    """
+    path = str(tmp_path_factory.mktemp("private") / "private.db")
+    shutil.copy(corpus_path, path)
+
+    db = sqlite3.connect(path)
+
+    with db:
+        # The same module, one node under a different descriptor. Whichever
+        # name resolves says which corpus owns FIXTURE-MIB.
+        db.execute(
+            "UPDATE node SET name = 'privateScalar' "
+            "WHERE module = 'FIXTURE-MIB' AND name = 'fixtureScalar'"
+        )
+
+        # An IMPORTS row the conformance corpus does not have, so a composite
+        # that merged the two would be caught doing it.
+        db.execute(
+            "INSERT INTO import (module, name, source) "
+            "VALUES ('FIXTURE-MIB', 'PrivateOnly', 'PRIVATE-MIB')"
+        )
+
+        db.execute(
+            "INSERT INTO module (name, tier, oid, lastupdated, revision, "
+            "content_hash, nodes) VALUES ('PRIVATE-MIB', 'vendor', ?, "
+            "'2026-01-01 00:00', '202601010000Z', 'private', 1)",
+            (PRIVATE_OID,),
+        )
+        db.execute(
+            "INSERT INTO node (oid_key, module, name, oid, class) "
+            "VALUES (?, 'PRIVATE-MIB', 'privateMib', ?, 'moduleidentity')",
+            (oid_key(PRIVATE_OID), PRIVATE_OID),
+        )
+        db.execute(
+            "INSERT INTO oid_index (oid_key, oid, module) VALUES (?, ?, 'PRIVATE-MIB')",
+            (oid_key(PRIVATE_OID), PRIVATE_OID),
+        )
+
+        # Same anchor, same length, different module.
+        db.execute(
+            "UPDATE oid_index SET module = 'PRIVATE-MIB' WHERE oid_key = ?",
+            (oid_key(CONTESTED_OID),),
+        )
+
+        db.execute("UPDATE meta SET value = 'private' WHERE key = 'corpus_id'")
+
+    db.close()
+
+    return path
+
+
+def _with_texts(source, destination):
+    """A copy of a corpus that claims to carry prose.
+
+    The conformance corpus does not, and ``loadTexts`` on a composite is an
+    ``all()`` -- so testing that it is one needs a corpus on the other side of
+    the question.
+    """
+    shutil.copy(source, destination)
+
+    db = sqlite3.connect(destination)
+
+    with db:
+        db.execute("UPDATE meta SET value = '1' WHERE key = 'texts'")
+
+    db.close()
+
+    return destination
+
+
+@pytest.fixture
+def composite(corpus_path, private_path):
+    """The conformance corpus first, the derived one second."""
+    opened = open_corpora([corpus_path, private_path])
+
+    yield opened
+
+    opened.close()
+
+
+@pytest.fixture
+def reversed_composite(corpus_path, private_path):
+    """The same two corpora, the other way round."""
+    opened = open_corpora([private_path, corpus_path])
 
     yield opened
 
@@ -775,3 +888,327 @@ class TestTrapPath:
         right = corpus.node("1.3.6.1.4.1.99999.2.1.10", "FIXTURE-MIB")
 
         assert left["syntax"] is right["syntax"]
+
+
+class TestCompositeResolution:
+    """Two corpora searched as one, and the two rules that decide which answers.
+
+    The interesting cases are all the same shape: a deployment with the
+    distribution's corpus and its own. Which one wins has to depend on what is
+    being asked -- a name or an OID -- and not on which was configured first.
+    """
+
+    def test_modules_is_the_union(self, composite, corpus):
+        assert composite.modules() == corpus.modules() | {"PRIVATE-MIB"}
+
+    def test_a_name_resolves_from_the_first_corpus_carrying_it(self, composite):
+        assert composite.node_named("FIXTURE-MIB", "fixtureScalar") is not None
+        assert composite.node_named("FIXTURE-MIB", "privateScalar") is None
+
+    def test_order_is_what_decides_a_name(self, reversed_composite):
+        assert reversed_composite.node_named("FIXTURE-MIB", "privateScalar") is not None
+        assert reversed_composite.node_named("FIXTURE-MIB", "fixtureScalar") is None
+
+    def test_a_module_only_the_second_carries_still_resolves(self, composite):
+        assert composite.module("PRIVATE-MIB")["oid"] == PRIVATE_OID
+
+    def test_a_module_no_corpus_carries_is_a_miss(self, composite):
+        assert composite.module("NO-SUCH-MIB") is None
+        assert composite.nodes_of("NO-SUCH-MIB") == []
+        assert composite.symbols_of("NO-SUCH-MIB") == []
+        assert composite.imports_of("NO-SUCH-MIB") == {}
+        assert composite.symbol("NO-SUCH-MIB", "anything") is None
+        assert composite.node_named("NO-SUCH-MIB", "anything") is None
+
+    def test_owner_names_one_corpus_per_module(self, composite):
+        assert composite.owner("FIXTURE-MIB") is composite.corpora[0]
+        assert composite.owner("PRIVATE-MIB") is composite.corpora[1]
+        assert composite.owner("NO-SUCH-MIB") is None
+
+    def test_the_losing_corpus_contributes_nothing_to_a_module_it_lost(self, composite):
+        # Not "mostly nothing". A module built out of two corpora would define
+        # one type twice, and the two classes fail isinstance against each
+        # other in a place far from here.
+        assert "PrivateOnly" not in composite.imports_of("FIXTURE-MIB")
+
+        names = {x["name"] for x in composite.nodes_of("FIXTURE-MIB")}
+
+        assert "fixtureScalar" in names
+        assert "privateScalar" not in names
+
+    def test_a_deeper_anchor_wins_from_a_later_corpus(self, composite):
+        # The rule that makes this class necessary. First-match-wins would
+        # answer FIXTURE-MIB here, from the anchor seven arcs shorter in the
+        # corpus that happens to be searched first.
+        assert composite.find_module(f"{PRIVATE_OID}.1.2") == "PRIVATE-MIB"
+
+    def test_a_deeper_anchor_wins_from_an_earlier_corpus_too(self, reversed_composite):
+        assert reversed_composite.find_module(f"{PRIVATE_OID}.1.2") == "PRIVATE-MIB"
+
+    def test_equal_anchors_are_separated_by_order(self, composite):
+        assert composite.find_module(f"{CONTESTED_OID}.1") == "SMIV1-MIB"
+
+    def test_equal_anchors_the_other_way_round(self, reversed_composite):
+        assert reversed_composite.find_module(f"{CONTESTED_OID}.1") == "PRIVATE-MIB"
+
+    def test_an_unanchored_oid_is_still_a_miss(self, composite):
+        assert composite.find_module("1.3.6.1.4.1.1") is None
+
+    def test_anchor_does_not_chop(self, composite):
+        assert composite.anchor(PRIVATE_OID) == "PRIVATE-MIB"
+        assert composite.anchor(f"{PRIVATE_OID}.1") is None
+
+
+class TestCompositeWalking:
+    """A walk over several corpora has to look like a walk over one."""
+
+    def _walk(self, store, start, stop):
+        found = []
+        node = store.next_node(start)
+
+        while node is not None and node["oid"].startswith(stop):
+            found.append((node["oid"], node["module"], node["name"]))
+            node = store.next_node(node["arcs"])
+
+        return found
+
+    def test_next_node_crosses_into_the_other_corpus(self, composite, corpus):
+        # The conformance corpus ends here; the derived one does not.
+        assert corpus.next_node("1.3.6.1.4.1.99999.2.1.256") is None
+
+        found = composite.next_node("1.3.6.1.4.1.99999.2.1.256")
+
+        assert (found["oid"], found["module"]) == (PRIVATE_OID, "PRIVATE-MIB")
+
+    def test_a_shadowed_module_is_visited_once(self, composite):
+        walked = self._walk(composite, "1.3.6.1.4.1.99999", "1.3.6.1.4.1.99999")
+        oids = [x[0] for x in walked]
+
+        assert len(oids) == len(set(oids))
+        assert "privateScalar" not in {x[2] for x in walked}
+
+    def test_the_walk_is_ordered(self, composite):
+        walked = self._walk(composite, "1.3.6.1.4.1.99999", "1.3.6.1.4.1.99999")
+        keys = [oid_key(x[0]) for x in walked]
+
+        assert keys == sorted(keys)
+
+    def test_the_walk_still_ends(self, composite):
+        assert composite.next_node("1.3.6.1.4.1.99999.99") is None
+
+    def test_subtree_merges_without_duplicating_a_shadowed_module(self, composite):
+        found = composite.subtree("1.3.6.1.4.1.99999")
+        seen = [(x["oid"], x["module"]) for x in found]
+
+        assert len(seen) == len(set(seen))
+        assert (PRIVATE_OID, "PRIVATE-MIB") in seen
+        assert "privateScalar" not in {x["name"] for x in found}
+
+    def test_node_at_an_exact_oid_comes_from_the_owner(self, composite):
+        assert composite.node("1.3.6.1.4.1.99999.1")["name"] == "fixtureScalar"
+        assert composite.node(PRIVATE_OID)["module"] == "PRIVATE-MIB"
+
+    def test_node_can_still_be_asked_for_one_module_s_definition(self, composite):
+        found = composite.node("1.3.6.1.4.1.99999.1", "SHADOW-MIB")
+
+        assert found["name"] == "shadowScalar"
+
+    def test_node_in_a_module_no_corpus_carries(self, composite):
+        assert composite.node("1.3.6.1.4.1.99999.1", "NO-SUCH-MIB") is None
+
+
+class TestCompositeConstruction:
+    """What a composite reports about itself, and what it refuses."""
+
+    def test_an_empty_composite_is_refused(self):
+        # Every lookup would answer None, which reads as "the corpora do not
+        # carry it" rather than as the misconfiguration it is.
+        with pytest.raises(error.SmiError):
+            CompositeMibCorpus()
+
+    def test_path_is_a_search_path(self, composite, corpus_path, private_path):
+        assert composite.path.split(os.pathsep) == [
+            os.path.abspath(corpus_path),
+            os.path.abspath(private_path),
+        ]
+
+    def test_repr_names_the_corpora_in_order(self, composite, private_path):
+        assert repr(composite).startswith("CompositeMibCorpus(MibCorpus(")
+        assert repr(composite).endswith(
+            f"MibCorpus({os.path.abspath(private_path)!r}))"
+        )
+
+    def test_meta_answers_from_the_first_corpus_that_has_it(self, composite):
+        assert composite.meta("corpus_id") == "pysmi-conformance"
+
+    def test_meta_of_an_unknown_key_is_a_miss(self, composite):
+        assert composite.meta("no-such-key") is None
+
+    def test_texts_needs_every_corpus_to_carry_them(self, composite, tmp_path):
+        assert composite.loadTexts is False
+
+        half = open_corpora(
+            [
+                _with_texts(composite.corpora[0].path, str(tmp_path / "texts.db")),
+                composite.corpora[1].path,
+            ]
+        )
+
+        try:
+            # One textless corpus in the path means some modules come back
+            # with no prose, and which corpus answers is not the caller's
+            # choice.
+            assert half.loadTexts is False
+
+        finally:
+            half.close()
+
+    def test_texts_when_every_corpus_carries_them(self, corpus_path, tmp_path):
+        both = open_corpora(
+            [
+                _with_texts(corpus_path, str(tmp_path / "left.db")),
+                _with_texts(corpus_path, str(tmp_path / "right.db")),
+            ]
+        )
+
+        try:
+            assert both.loadTexts is True
+
+        finally:
+            both.close()
+
+    def test_close_closes_every_corpus(self, corpus_path, private_path):
+        opened = open_corpora([corpus_path, private_path])
+        opened.close()
+
+        for one in opened.corpora:
+            with pytest.raises(sqlite3.ProgrammingError):
+                one.modules()
+
+
+class TestOpenCorpora:
+    """Opening a search path of corpora."""
+
+    def test_one_path_is_not_wrapped(self, corpus_path):
+        # A composite of one answers identically and only obscures the corpus
+        # in tracebacks and in repr.
+        opened = open_corpora([corpus_path])
+
+        try:
+            assert isinstance(opened, MibCorpus)
+
+        finally:
+            opened.close()
+
+    def test_several_paths_compose(self, corpus_path, private_path):
+        opened = open_corpora([corpus_path, private_path])
+
+        try:
+            assert isinstance(opened, CompositeMibCorpus)
+            assert len(opened.corpora) == 2
+
+        finally:
+            opened.close()
+
+    def test_no_paths_is_refused(self):
+        with pytest.raises(error.SmiError):
+            open_corpora([])
+
+    def test_an_unopenable_corpus_is_reported_not_skipped(self, corpus_path, tmp_path):
+        # Skipping it leaves a deployment resolving fewer modules than it
+        # asked for, and the only symptom is a MIB that used to be found.
+        with pytest.raises(error.SmiError):
+            open_corpora([corpus_path, str(tmp_path / "absent.db")])
+
+
+class TestBuilderCorpusEnvironment:
+    """``PYSNMP_MIB_DBS``, which is a thin layer over ``setMibCorpus``."""
+
+    def test_unset_leaves_the_builder_without_a_corpus(self, monkeypatch):
+        monkeypatch.delenv("PYSNMP_MIB_DBS", raising=False)
+
+        assert MibBuilder().getMibCorpus() is None
+
+    def test_empty_is_the_same_as_unset(self, monkeypatch):
+        monkeypatch.setenv("PYSNMP_MIB_DBS", "")
+
+        assert MibBuilder().getMibCorpus() is None
+
+    def test_one_path_is_opened(self, monkeypatch, corpus_path):
+        monkeypatch.setenv("PYSNMP_MIB_DBS", corpus_path)
+        builder = MibBuilder()
+
+        try:
+            assert isinstance(builder.getMibCorpus(), MibCorpus)
+
+        finally:
+            builder.getMibCorpus().close()
+
+    def test_several_paths_keep_the_order_they_were_given(
+        self, monkeypatch, corpus_path, private_path
+    ):
+        monkeypatch.setenv(
+            "PYSNMP_MIB_DBS", os.pathsep.join([private_path, corpus_path])
+        )
+        builder = MibBuilder()
+
+        try:
+            assert [x.path for x in builder.getMibCorpus().corpora] == [
+                os.path.abspath(private_path),
+                os.path.abspath(corpus_path),
+            ]
+
+        finally:
+            builder.getMibCorpus().close()
+
+    def test_a_missing_corpus_is_an_error_at_construction(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PYSNMP_MIB_DBS", str(tmp_path / "absent.db"))
+
+        with pytest.raises(error.SmiError):
+            MibBuilder()
+
+    def test_modules_synthesize_through_the_environment(
+        self, monkeypatch, corpus_path, private_path
+    ):
+        monkeypatch.setenv(
+            "PYSNMP_MIB_DBS", os.pathsep.join([corpus_path, private_path])
+        )
+        builder = MibBuilder()
+
+        try:
+            (scalar,) = builder.importSymbols("FIXTURE-MIB", "fixtureScalar")
+
+            assert scalar.getName() == (1, 3, 6, 1, 4, 1, 99999, 1)
+
+        finally:
+            builder.getMibCorpus().close()
+
+    def test_precedence_reaches_synthesis(self, monkeypatch, corpus_path, private_path):
+        # The same module, from the other corpus, under the descriptor only
+        # that corpus gives it.
+        monkeypatch.setenv(
+            "PYSNMP_MIB_DBS", os.pathsep.join([private_path, corpus_path])
+        )
+        builder = MibBuilder()
+
+        try:
+            (scalar,) = builder.importSymbols("FIXTURE-MIB", "privateScalar")
+
+            assert scalar.getName() == (1, 3, 6, 1, 4, 1, 99999, 1)
+
+        finally:
+            builder.getMibCorpus().close()
+
+    def test_the_sources_still_win_over_the_environment(self, monkeypatch, corpus_path):
+        # PYSNMP_MIB_DBS adds a place to look, last. A module on disk keeps
+        # resolving from disk, which is the whole compatibility story.
+        monkeypatch.setenv("PYSNMP_MIB_DBS", corpus_path)
+        builder = MibBuilder()
+
+        try:
+            builder.loadModule("SNMP-FRAMEWORK-MIB")
+
+            assert "corpus:" not in builder._MibBuilder__modSeen["SNMP-FRAMEWORK-MIB"]
+
+        finally:
+            builder.getMibCorpus().close()

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -138,6 +138,69 @@ def private_path(corpus_path, tmp_path_factory):
     return path
 
 
+def _at_revision(source, destination, module, revision):
+    """A copy of a corpus stating a different revision for one module.
+
+    The derived corpus is a copy, so every module in it states the revision
+    the original does and configured order decides everything. Testing that
+    the revision is what decides needs the two to disagree.
+    """
+    shutil.copy(source, destination)
+
+    db = sqlite3.connect(destination)
+
+    with db:
+        db.execute("UPDATE module SET revision = ? WHERE name = ?", (revision, module))
+
+    db.close()
+
+    return destination
+
+
+@pytest.fixture(scope="module")
+def newer_path(private_path, tmp_path_factory):
+    """The derived corpus, stating a newer FIXTURE-MIB than the first one."""
+    return _at_revision(
+        private_path,
+        str(tmp_path_factory.mktemp("newer") / "newer.db"),
+        "FIXTURE-MIB",
+        "202606010000Z",
+    )
+
+
+@pytest.fixture(scope="module")
+def older_path(private_path, tmp_path_factory):
+    """The derived corpus, stating an older FIXTURE-MIB than the first one."""
+    return _at_revision(
+        private_path,
+        str(tmp_path_factory.mktemp("older") / "older.db"),
+        "FIXTURE-MIB",
+        "202001010000Z",
+    )
+
+
+@pytest.fixture(scope="module")
+def dated_contest_paths(corpus_path, private_path, tmp_path_factory):
+    """Both corpora, with both sides of the contested anchor dated.
+
+    ``SMIV1-MIB`` states no revision, which is the whole point of it, so the
+    contested anchor falls to configured order. Dating it in *both* corpora --
+    it is carried by both, and an undated copy in either would send the
+    decision back to order -- turns the same contest into one the revision
+    rule can decide.
+    """
+    directory = tmp_path_factory.mktemp("dated")
+
+    return (
+        _at_revision(
+            corpus_path, str(directory / "base.db"), "SMIV1-MIB", "201001010000Z"
+        ),
+        _at_revision(
+            private_path, str(directory / "private.db"), "SMIV1-MIB", "201001010000Z"
+        ),
+    )
+
+
 def _with_texts(source, destination):
     """A copy of a corpus that claims to carry prose.
 
@@ -891,21 +954,24 @@ class TestTrapPath:
 
 
 class TestCompositeResolution:
-    """Two corpora searched as one, and the two rules that decide which answers.
+    """Two corpora searched as one, and the rule that decides which answers.
 
     The interesting cases are all the same shape: a deployment with the
-    distribution's corpus and its own. Which one wins has to depend on what is
-    being asked -- a name or an OID -- and not on which was configured first.
+    distribution's corpus and its own. Which one wins has to follow from what
+    the modules state rather than from which was configured first, and a name
+    and an OID have to arrive at the same copy.
     """
 
     def test_modules_is_the_union(self, composite, corpus):
         assert composite.modules() == corpus.modules() | {"PRIVATE-MIB"}
 
-    def test_a_name_resolves_from_the_first_corpus_carrying_it(self, composite):
+    def test_equal_revisions_leave_a_name_to_the_order(self, composite):
+        # The derived corpus is a copy, so both state the same revision for
+        # FIXTURE-MIB and there is nothing for the revision rule to separate.
         assert composite.node_named("FIXTURE-MIB", "fixtureScalar") is not None
         assert composite.node_named("FIXTURE-MIB", "privateScalar") is None
 
-    def test_order_is_what_decides_a_name(self, reversed_composite):
+    def test_equal_revisions_the_other_way_round(self, reversed_composite):
         assert reversed_composite.node_named("FIXTURE-MIB", "privateScalar") is not None
         assert reversed_composite.node_named("FIXTURE-MIB", "fixtureScalar") is None
 
@@ -924,6 +990,58 @@ class TestCompositeResolution:
         assert composite.owner("FIXTURE-MIB") is composite.corpora[0]
         assert composite.owner("PRIVATE-MIB") is composite.corpora[1]
         assert composite.owner("NO-SUCH-MIB") is None
+
+    def test_the_newest_revision_wins_from_the_second_corpus(
+        self, corpus_path, newer_path
+    ):
+        # The rule the whole class turns on. The first corpus carries
+        # FIXTURE-MIB and would win on position; the second states a newer
+        # revision of it and wins anyway.
+        opened = open_corpora([corpus_path, newer_path])
+
+        try:
+            assert opened.owner("FIXTURE-MIB") is opened.corpora[1]
+            assert opened.node_named("FIXTURE-MIB", "privateScalar") is not None
+            assert opened.node_named("FIXTURE-MIB", "fixtureScalar") is None
+
+        finally:
+            opened.close()
+
+    def test_an_older_copy_configured_first_is_not_a_downgrade(
+        self, corpus_path, older_path
+    ):
+        # The converse, and the reason position cannot decide: configuring a
+        # corpus that happens to carry an older copy of a module would
+        # otherwise silently roll that module back.
+        opened = open_corpora([older_path, corpus_path])
+
+        try:
+            assert opened.owner("FIXTURE-MIB") is opened.corpora[1]
+            assert opened.node_named("FIXTURE-MIB", "fixtureScalar") is not None
+
+        finally:
+            opened.close()
+
+    def test_both_paths_reach_the_same_copy(self, corpus_path, newer_path):
+        # Resolving by name and resolving by OID are one question asked twice.
+        # The first corpus anchors this OID and the second owns the module, so
+        # an OID path that stopped at the anchor would read the copy the name
+        # path rejected.
+        opened = open_corpora([corpus_path, newer_path])
+
+        try:
+            oid = "1.3.6.1.4.1.99999.2.1.9.1.2.3"
+            module = opened.find_module(oid)
+
+            assert module == "FIXTURE-MIB"
+            assert opened.owner(module) is opened.corpora[1]
+
+            named = opened.node_named(module, "privateScalar")
+
+            assert opened.node(named["oid"])["name"] == "privateScalar"
+
+        finally:
+            opened.close()
 
     def test_the_losing_corpus_contributes_nothing_to_a_module_it_lost(self, composite):
         # Not "mostly nothing". A module built out of two corpora would define
@@ -945,11 +1063,30 @@ class TestCompositeResolution:
     def test_a_deeper_anchor_wins_from_an_earlier_corpus_too(self, reversed_composite):
         assert reversed_composite.find_module(f"{PRIVATE_OID}.1.2") == "PRIVATE-MIB"
 
-    def test_equal_anchors_are_separated_by_order(self, composite):
+    def test_equal_anchors_are_separated_by_order_when_undated(self, composite):
+        # SMIV1-MIB states no revision, so this contest cannot be decided on
+        # one and falls to configured order.
         assert composite.find_module(f"{CONTESTED_OID}.1") == "SMIV1-MIB"
 
     def test_equal_anchors_the_other_way_round(self, reversed_composite):
         assert reversed_composite.find_module(f"{CONTESTED_OID}.1") == "PRIVATE-MIB"
+
+    def test_equal_anchors_are_separated_by_revision_when_dated(
+        self, dated_contest_paths
+    ):
+        # The same contest with both modules dated. PRIVATE-MIB states 2026
+        # against SMIV1-MIB's 2010, so it wins from either position and the
+        # order the corpora were configured in stops mattering.
+        base, private = dated_contest_paths
+
+        for paths in ([base, private], [private, base]):
+            opened = open_corpora(paths)
+
+            try:
+                assert opened.find_module(f"{CONTESTED_OID}.1") == "PRIVATE-MIB"
+
+            finally:
+                opened.close()
 
     def test_an_unanchored_oid_is_still_a_miss(self, composite):
         assert composite.find_module("1.3.6.1.4.1.1") is None


### PR DESCRIPTION
Part of #144, cut to the two stories that pay for themselves now: a composite over several corpora, and the environment variable that configures one. Provenance, shadow reporting and the `MibStore` ABC are deliberately left out — see below.

## Why

A deployment rarely has one corpus. It has the distribution's, covering the standard modules and whatever vendors shipped with it, and it has its own — the enterprise MIBs its devices actually speak, which nobody else publishes. Both have to be readable at once, and which one answers has to be decided by a rule rather than by whichever was configured last.

## Which copy answers: newest revision, then configured order

Where several corpora carry the same module, the one whose copy has the newest MODULE-IDENTITY revision answers. Configured order breaks ties only — undated copies, or copies revised the same day.

This is not a new rule. It is what pysmi's compiler already does when a module is found in several sources (`PRECEDENCE_NEWEST_REVISION`), and what `MibBuilder._candidates` already does across MIB directories. A corpus reader that ranked by position instead would mean the same two definitions resolve differently depending on whether they arrived as `.py` files, as pysmi sources, or as corpora — with the disagreement surfacing at decode time, far from the configuration that caused it.

Consequence worth stating plainly: a site corpus placed first no longer wins by sitting first. It wins by carrying a newer revision, which is the same bar pysnmp already sets for a MIB directory placed first.

## Names and OIDs are the same question, asked two ways

**By OID, the longest prefix wins.** This is the rule the class exists for. First-match-wins resolves a site subtree under `enterprises.9` to the core corpus's anchor for `enterprises.9` and never reaches the corpus that anchors the subtree itself, no matter how the two are ordered. Prefix length is orthogonal to revision: it settles *which module* answers, and revision then settles *whose copy is read*.

Both paths converge. Resolving `SOME-MIB` by name and resolving an OID that anchors to `SOME-MIB` reach the same copy, because `find_module()` and `owner()` are both written in terms of the same ranking. A corpus may anchor an OID without owning the module it names.

Building the OID rule on `find_module()` is not possible — it answers with a module name and not the length it matched at, so a shallow anchor in one corpus is indistinguishable from a deep one in another. The single index lookup it repeats is now public as `MibCorpus.anchor()`, chopping is hoisted into the caller, and `find_module()` is written in terms of it. That is the only change to existing behaviour, and it is a refactor: same queries, same answers.

## One module resolves from exactly one corpus

Where two carry the same module, every name-keyed lookup routes to the same one and the other's rows for it stay invisible — not its nodes, not its types, not its IMPORTS. Merging would build one module out of two definitions and produce distinct class objects for the same type, which breaks `isinstance` somewhere far from here. Walks step over the losing corpus's rows rather than returning them, so a GETNEXT does not visit a module twice under two definitions.

`loadTexts` is `all()` rather than `any()`: which corpus answers for a given module is not something the caller chose, so one textless corpus in the path means some modules come back with no prose — and reporting texts as available would make that indistinguishable from a MIB that declares none.

## Configuration

```shell
PYSNMP_MIB_DBS=/mibs/site.db:/mibs/core.db
```

A thin layer over `setMibCorpus()`, read where the other MIB environment variables are read, `os.pathsep`-separated, order is tie-break precedence. A path that is not a readable corpus raises `SmiError` at construction rather than being skipped: skipping leaves a deployment resolving fewer modules than it asked for, and the only symptom is a MIB that used to be found and now is not. `sqlite3` is imported only when the variable is set, so the default path pays nothing.

## Compatibility

No behavioural change without configuration. `MibBuilder()` with `PYSNMP_MIB_DBS` unset still has no corpus, and a corpus is still searched only where the MIB sources come up empty — `test_the_sources_still_win_over_the_environment` pins that.

## Deferred from #144, on purpose

`MibStore` ABC (`MibCorpus` already *is* the interface, and an ABC with one implementation and one composite is a name for something that exists), per-module provenance and `getModuleProvenance()`, `.py` shadow detection and its severity knob, `PYSNMP_MIB_TEXTS` (nothing carries texts yet — #217), `PYSNMP_MIB_SOURCES`. #144 stays open for them.

## Tests

45 new, against a second corpus derived from pysmi's conformance fixture so the two genuinely overlap: the same module under a different descriptor, an IMPORTS row only one has, a private anchor seven arcs below one the other claims, and a contested anchor of equal length that only precedence can separate. Tests that only ever exercised the tie-break are named to say so; four new ones discriminate revision from order by putting the newer copy last.

`ruff check`, `ruff format`, `mypy` (147 files), `sphinx-build -n -W`, 1303 passed / 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
