### PR TITLE
Derive the SHA-1 key from a SHA-1 hash of the passphrase

### DIFF
--- a/pysnmp/proto/secmod/rfc3414/localkey.py
+++ b/pysnmp/proto/secmod/rfc3414/localkey.py
@@ -82,16 +82,8 @@ def passwordToKeyMD5(passphrase, snmpEngineId):
 
 
 def passwordToKeySHA(passphrase, snmpEngineId):
-    """A passphrase localized to `snmpEngineId` with SHA-1.
-
-    Does not implement :RFC:`3414#appendix-A.2.2`: the passphrase is hashed with
-    MD5 rather than SHA-1 before being localized, so the key this returns does not
-    match what another implementation derives from the same passphrase. Nothing in
-    pysnmp calls it -- the SHA-1 authentication service uses `hashPassphraseSHA()`
-    and `localizeKeySHA()`, which are correct -- and changing it would change the
-    keys of anyone who does.
-    """
-    return localizeKey(hashPassphraseMD5(passphrase), snmpEngineId, sha1)
+    """A SHA-1 passphrase hashed and localized to `snmpEngineId`."""
+    return localizeKey(hashPassphraseSHA(passphrase), snmpEngineId, sha1)
 
 
 def localizeKeyMD5(passKey, snmpEngineId):

--- a/tests/test_secmod.py
+++ b/tests/test_secmod.py
@@ -363,40 +363,72 @@ class TestAes256Priv:
         assert aes256.Aes256.keySize == 32
 
 
+RFC3414_PASSPHRASE = "maplesyrup"
+RFC3414_ENGINE_ID = univ.OctetString(hexValue="000000000000000000000002")
+RFC3414_KU_MD5 = "0x9faf3283884e92834ebc9847d8edd963"
+RFC3414_KUL_MD5 = "0x526f5eed9fcce26f8964c2930787d82b"
+RFC3414_KU_SHA = "0x9fb5cc0381497b3793528939ff788d5d79145211"
+RFC3414_KUL_SHA = "0x6695febc9288e36282235fc7151f128497b38f3f"
+
+
 class TestLocalkey:
+    """The RFC 3414 appendix A.3 vectors, which pin the derivation itself.
+
+    A length assertion cannot tell these functions apart: localization is what
+    fixes the digest size, so hashing the passphrase with the wrong algorithm
+    still yields a key of the expected length.
+    """
+
     def test_hash_passphrase_md5(self):
-        result = localkey.hashPassphraseMD5("testpassphrase")
-        assert len(result) == 16
+        result = localkey.hashPassphraseMD5(RFC3414_PASSPHRASE)
+        assert result.prettyPrint() == RFC3414_KU_MD5
 
     def test_hash_passphrase_sha(self):
-        result = localkey.hashPassphraseSHA("testpassphrase")
-        assert len(result) == 20
+        result = localkey.hashPassphraseSHA(RFC3414_PASSPHRASE)
+        assert result.prettyPrint() == RFC3414_KU_SHA
 
     def test_password_to_key_md5(self):
-        result = localkey.passwordToKeyMD5(
-            "testpassphrase", univ.OctetString(hexValue="0102030405")
-        )
-        assert len(result) == 16
+        result = localkey.passwordToKeyMD5(RFC3414_PASSPHRASE, RFC3414_ENGINE_ID)
+        assert result.prettyPrint() == RFC3414_KUL_MD5
 
     def test_password_to_key_sha(self):
-        result = localkey.passwordToKeySHA(
-            "testpassphrase", univ.OctetString(hexValue="0102030405")
+        result = localkey.passwordToKeySHA(RFC3414_PASSPHRASE, RFC3414_ENGINE_ID)
+        assert result.prettyPrint() == RFC3414_KUL_SHA
+
+    def test_password_to_key_sha_does_not_hash_with_md5(self):
+        assert localkey.passwordToKeySHA(
+            RFC3414_PASSPHRASE, RFC3414_ENGINE_ID
+        ) != localkey.localizeKeySHA(
+            localkey.hashPassphraseMD5(RFC3414_PASSPHRASE), RFC3414_ENGINE_ID
         )
-        assert len(result) == 20
 
     def test_localize_key_md5(self):
-        hashed = localkey.hashPassphraseMD5("testpassphrase")
-        result = localkey.localizeKeyMD5(
-            hashed, univ.OctetString(hexValue="0102030405")
-        )
-        assert len(result) == 16
+        hashed = localkey.hashPassphraseMD5(RFC3414_PASSPHRASE)
+        result = localkey.localizeKeyMD5(hashed, RFC3414_ENGINE_ID)
+        assert result.prettyPrint() == RFC3414_KUL_MD5
 
     def test_localize_key_sha(self):
-        hashed = localkey.hashPassphraseSHA("testpassphrase")
-        result = localkey.localizeKeySHA(
-            hashed, univ.OctetString(hexValue="0102030405")
+        hashed = localkey.hashPassphraseSHA(RFC3414_PASSPHRASE)
+        result = localkey.localizeKeySHA(hashed, RFC3414_ENGINE_ID)
+        assert result.prettyPrint() == RFC3414_KUL_SHA
+
+    def test_the_auth_services_agree_with_the_vectors(self):
+        """The engine path was always correct; these pin it against drift."""
+        md5_svc = hmacmd5.HmacMd5()
+        sha_svc = hmacsha.HmacSha()
+
+        assert (
+            md5_svc.localizeKey(
+                md5_svc.hashPassphrase(RFC3414_PASSPHRASE), RFC3414_ENGINE_ID
+            ).prettyPrint()
+            == RFC3414_KUL_MD5
         )
-        assert len(result) == 20
+        assert (
+            sha_svc.localizeKey(
+                sha_svc.hashPassphrase(RFC3414_PASSPHRASE), RFC3414_ENGINE_ID
+            ).prettyPrint()
+            == RFC3414_KUL_SHA
+        )
 
 
 class TestAbstractAuthBase:


### PR DESCRIPTION
Fixes #225.

```python
def passwordToKeySHA(passphrase, snmpEngineId):
    return localizeKey(hashPassphraseMD5(passphrase), snmpEngineId, sha1)
```

The passphrase was hashed with **MD5** and the result localized with SHA-1. :RFC:`3414#appendix-A.2.2` says the password-to-key hash is SHA-1. It reads like the function was copied from its MD5 sibling directly above and only the localization argument was changed.

The key it returned therefore matched nothing any other implementation derives from the same passphrase, and a user configured through it could not authenticate anywhere.

## Blast radius

Nothing inside pysnmp calls it. The SHA-1 authentication service composes the two correct halves itself:

```python
# pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
return localkey.hashPassphraseSHA(authKey)
return localkey.localizeKeySHA(authKey, snmpEngineID)
```

So `addV3User()`, the engine and every configured session are unaffected. What was broken is the public module-level helper, for callers deriving keys themselves.

## Why the tests did not catch it

They asserted a length:

```python
result = localkey.passwordToKeySHA("testpassphrase", univ.OctetString(hexValue="0102030405"))
assert len(result) == 20
```

Localization is what fixes the digest size, so hashing the passphrase with the wrong algorithm still yields twenty bytes. The assertion holds either way and says nothing about the derivation.

## What replaces them

The :RFC:`3414#appendix-A.3` vectors — passphrase `maplesyrup`, engine ID `000000000000000000000002` — for both algorithms, at both stages:

| | Ku (hashed) | Kul (localized) |
|---|---|---|
| MD5 | `9faf3283884e92834ebc9847d8edd963` | `526f5eed9fcce26f8964c2930787d82b` |
| SHA-1 | `9fb5cc0381497b3793528939ff788d5d79145211` | `6695febc9288e36282235fc7151f128497b38f3f` |

Before this change `passwordToKeySHA()` returned `737c3892550fbfc64ad9aca1cd1aadd9cb16e32b`.

Three additions beyond swapping the assertions:

- `test_password_to_key_sha_does_not_hash_with_md5` pins the specific mistake, so a future copy-paste of the MD5 sibling fails on its own name rather than on a hex mismatch.
- `test_the_auth_services_agree_with_the_vectors` puts the engine path under the same vectors. It was always correct and nothing pinned it.
- A class docstring saying why a length assertion cannot tell these functions apart, since that is the trap that hid this for years.

## Compatibility

**Breaking for direct callers of `passwordToKeySHA()`.** Stored keys derived from it must be re-derived. The keys it returned before could not be used against any other implementation, so a caller storing them was either talking to another pysnmp using the same helper, or already failing to authenticate.

`ruff check`, `ruff format`, `mypy` (147 files), 1305 passed / 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
