### PR TITLE
fix(smi): let a compiler render the texts a corpus cannot carry

### DIFF
--- a/docs/source/docs/mib-corpus.rst
+++ b/docs/source/docs/mib-corpus.rst
@@ -153,8 +153,9 @@ Merging them would build one module from two definitions and produce two
 classes for one type, which fails ``isinstance`` somewhere far from here.
 
 ``loadTexts`` is reported for the composite only when *every* corpus carries
-prose, so one textless corpus in the search path is refused rather than
-silently answering with no DESCRIPTION for the modules it owns.
+prose, so one textless corpus in the search path makes the whole composite
+textless rather than silently answering with no DESCRIPTION for the modules it
+owns. What that then means is the subject of `What a corpus does not carry`_.
 
 
 Resolving a trap OID without a compiler
@@ -195,20 +196,62 @@ What a corpus does not carry
 
 **Prose.** No DESCRIPTION, no REFERENCE. They are roughly a third of a
 generated module's bytes, the runtime discards them under the default
-``loadTexts = False``, and pysmi's published ``json/`` tree already serves the
-one consumer that wants them -- a MIB browser.
+``loadTexts = False``, and the one consumer that wants them -- a MIB browser --
+has two other ways to get them: pysmi's published ``json/`` tree, and the
+compiler.
 
-Because of that, ``setMibCorpus()`` **refuses** a textless corpus when
-``loadTexts`` is set:
+So a corpus cannot satisfy ``loadTexts``. What happens when it is asked to
+depends on whether anything else can.
+
+Corpus for speed, compiler for prose
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Configure both. The corpus resolves the thousands of modules a deployment
+touches, cheaply and without executing anything; the compiler renders the few
+whose text is going on screen:
 
 .. code-block:: python
 
+   mibBuilder.setMibCorpus(MibCorpus("/mibs/core.db"))
+   mibBuilder.setMibCompiler(mibCompiler, destDir)
    mibBuilder.loadTexts = True
-   mibBuilder.setMibCorpus(corpus)   # raises SmiError
+
+   mibBuilder.loadModules("IF-MIB")   # compiled from ASN.1, DESCRIPTION intact
+
+Sources are searched first, then the corpus, and only for a module neither
+carried does the compiler run. Under ``loadTexts`` the corpus **steps aside**
+rather than answering with no prose, so the module falls through to the
+compiler and comes back with its text. Clear ``loadTexts`` and the corpus
+answers again, without compiling anything.
+
+Two consequences worth knowing:
+
+* Only ``loadModules()`` compiles. ``loadModule()`` never has, so a corpus that
+  steps aside there raises ``MibNotFoundError`` -- which is what it already
+  raises for a module nothing carries.
+* ``setMibCompiler()`` puts its output directory on the search path, so a
+  module compiled once is the copy every later load finds. The corpus does not
+  take it back when ``loadTexts`` is cleared again.
+
+With no compiler configured
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There is nothing to fall through to, so the request is refused:
+
+.. code-block:: python
+
+   mibBuilder.setMibCorpus(corpus)
+   mibBuilder.loadTexts = True
+   mibBuilder.loadModules("IF-MIB")   # raises SmiError
 
 Refused rather than silently satisfied: a caller that asked for descriptions
 and got a module with none has no way to tell that from a MIB that declares
-none. Load texts from the ``json/`` tree, or clear ``loadTexts``.
+none. Attach a compiler, read the text from the ``json/`` tree, or clear
+``loadTexts``.
+
+Attaching the corpus is not where this is decided. A compiler may be attached
+after a corpus is, so refusing at ``setMibCorpus()`` would make a working
+configuration depend on the order the two were set up in.
 
 
 How a module is built

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -577,45 +577,54 @@ class MibBuilder:
         Returns
         -------
             This builder.
-
-        Raises
-        ------
-            SmiError: ``loadTexts`` is set and the corpus carries no prose.
-                Refused rather than silently satisfied: a caller that asked
-                for descriptions and got a module with none has no way to
-                tell that from a MIB that declares none.
         """
-        self._checkCorpusTexts(mibCorpus)
-
         self.__mibCorpus = mibCorpus
 
         return self
 
-    def _checkCorpusTexts(self, mibCorpus: Any) -> None:
-        """Refuse a textless corpus while ``loadTexts`` asks for prose.
+    def _corpusMayAnswer(self) -> bool:
+        """Whether the corpus may build the next module, given ``loadTexts``.
 
-        Called both when a corpus is attached and again before each synthesis,
-        because ``loadTexts`` is a plain attribute a caller may set at any
-        time. Checking only at attachment would leave a builder that turned
-        texts on afterwards silently building modules with none.
+        A corpus carries no DESCRIPTION and no REFERENCE, so it cannot satisfy
+        ``loadTexts``. What that should mean depends on whether anything else
+        can. A compiler renders ASN.1 with ``genTexts``, so declining leaves
+        the module to fall through to it and come back with its prose intact --
+        which is the whole point of running both: the corpus answers the many
+        modules cheaply, the compiler answers the few a caller wants to read.
 
-        Args:
-            mibCorpus: the corpus about to be used, or ``None``
+        With no compiler there is nothing to fall through to, and a caller that
+        asked for descriptions and got a module with none cannot tell that from
+        a MIB declaring none. That case is refused outright.
+
+        Decided here rather than once at attachment. ``loadTexts`` is a plain
+        attribute a caller may set at any time, and a compiler may be attached
+        after the corpus is, so an answer computed at ``setMibCorpus()`` would
+        depend on the order the two were configured in.
+
+        Returns
+        -------
+            Whether the corpus should be asked for the module.
 
         Raises
         ------
-            SmiError: texts were asked for and the corpus has none.
+            SmiError: texts were asked for, the corpus has none, and no
+                compiler is configured to render them.
         """
-        if (
-            mibCorpus is not None
-            and self.loadTexts
-            and not getattr(mibCorpus, "loadTexts", False)
-        ):
-            raise error.SmiError(
-                f"loadTexts is set but the corpus at {mibCorpus} carries no "
-                f"texts; load descriptions from the published json/ tree, or "
-                f"clear loadTexts"
+        if not self.loadTexts or getattr(self.__mibCorpus, "loadTexts", False):
+            return True
+
+        if self.__mibCompiler is not None:
+            debug.logger & debug.flagBld and debug.logger(
+                f"_corpusMayAnswer: corpus at {self.__mibCorpus} carries no "
+                f"texts, leaving the module to the compiler"
             )
+            return False
+
+        raise error.SmiError(
+            f"loadTexts is set but the corpus at {self.__mibCorpus} carries no "
+            f"texts; attach a MIB compiler to render descriptions from ASN.1, "
+            f"read them from the published json/ tree, or clear loadTexts"
+        )
 
     def _loadModuleFromCorpus(self, modName: str) -> bool:
         """Build a module out of the corpus, if one is configured and has it.
@@ -630,10 +639,11 @@ class MibBuilder:
         if self.__mibCorpus is None:
             return False
 
-        # Re-checked here, not only at setMibCorpus(). loadTexts is a plain
-        # attribute, so setting it after a corpus is attached would otherwise
-        # slip past the check and quietly build modules with no DESCRIPTION.
-        self._checkCorpusTexts(self.__mibCorpus)
+        # Declining under loadTexts is how the module reaches the compiler:
+        # loadModule() raises MibNotFoundError when nothing built it, which is
+        # what loadModules() catches to compile with genTexts.
+        if not self._corpusMayAnswer():
+            return False
 
         if modName in self.__corpusBuilding:
             # A module reached again while it is being built. Synthesis

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -679,12 +679,24 @@ class TestBuilderWithACorpus:
 
     def test_load_texts_with_a_textless_corpus_is_refused(self, corpus):
         # A caller that asked for descriptions and got a module with none has
-        # no way to tell that from a MIB that declares none.
+        # no way to tell that from a MIB that declares none. With no compiler
+        # there is nothing else that could supply them.
+        builder = MibBuilder()
+        builder.loadTexts = True
+        builder.setMibCorpus(corpus)
+
+        with pytest.raises(error.SmiError, match="no texts"):
+            builder.loadModule("FIXTURE-MIB")
+
+    def test_attaching_a_textless_corpus_under_load_texts_is_allowed(self, corpus):
+        # Attachment is not where this is decided: a compiler may be attached
+        # after the corpus is, and refusing here would make a working
+        # configuration depend on the order the two were set up in.
         builder = MibBuilder()
         builder.loadTexts = True
 
-        with pytest.raises(error.SmiError, match="no texts"):
-            builder.setMibCorpus(corpus)
+        assert builder.setMibCorpus(corpus) is builder
+        assert builder.getMibCorpus() is corpus
 
     def test_type_resolves_when_imports_names_a_module_without_it(
         self, builder, corpus, monkeypatch
@@ -915,6 +927,115 @@ class TestBuilderWithACorpus:
 
         with pytest.raises(error.MibNotFoundError):
             builder.loadModule("FIXTURE-MIB")
+
+
+class TestCorpusWithACompiler:
+    """Corpus for the many modules, compiler for the few worth reading.
+
+    A corpus carries no prose and a compiler renders it, so the two together
+    are what a MIB browser wants: everything resolves out of the database,
+    and the handful of modules whose DESCRIPTION is going on screen are
+    rendered from ASN.1 on demand. That only works if a corpus asked for
+    texts it does not have steps aside instead of raising.
+    """
+
+    COMPILED = (
+        '(MibScalar,) = mibBuilder.importSymbols("SNMPv2-SMI", "MibScalar")\n'
+        '(Integer32,) = mibBuilder.importSymbols("SNMPv2-SMI", "Integer32")\n'
+        "compiledScalar = MibScalar(\n"
+        "    (1, 3, 6, 1, 4, 1, 99999, 1), Integer32()\n"
+        ').setMaxAccess("readonly")\n'
+        'compiledScalar.setDescription("Rendered from ASN.1, prose and all.")\n'
+        'mibBuilder.exportSymbols("FIXTURE-MIB", compiledScalar=compiledScalar)\n'
+    )
+
+    @pytest.fixture
+    def compiler(self, tmp_path):
+        class RecordingCompiler:
+            """A compiler that records its calls and renders one known module."""
+
+            def __init__(self, destDir):
+                self.destDir = destDir
+                self.calls = []
+
+            def compile(self, modName, **options):
+                self.calls.append((modName, options))
+
+                with open(os.path.join(self.destDir, f"{modName}.py"), "w") as fp:
+                    fp.write(TestCorpusWithACompiler.COMPILED)
+
+                return {modName: "compiled"}
+
+        return RecordingCompiler(str(tmp_path))
+
+    @pytest.fixture
+    def builder(self, corpus, compiler):
+        built = MibBuilder()
+        built.setMibCorpus(corpus)
+        built.setMibCompiler(compiler, compiler.destDir)
+
+        return built
+
+    def test_texts_send_the_module_to_the_compiler(self, builder, compiler):
+        builder.loadTexts = True
+
+        builder.loadModules("FIXTURE-MIB")
+
+        assert compiler.calls == [("FIXTURE-MIB", {"genTexts": True})]
+
+        (scalar,) = builder.importSymbols("FIXTURE-MIB", "compiledScalar")
+
+        assert scalar.getDescription() == "Rendered from ASN.1, prose and all."
+
+    def test_without_texts_the_corpus_answers_and_the_compiler_idles(
+        self, builder, compiler
+    ):
+        # The corpus is the cheap path and stays the default. Nothing is
+        # compiled for a module it can already resolve.
+        builder.loadModules("FIXTURE-MIB")
+
+        assert compiler.calls == []
+
+        (scalar,) = builder.importSymbols("FIXTURE-MIB", "fixtureScalar")
+
+        assert scalar.getName() == (1, 3, 6, 1, 4, 1, 99999, 1)
+
+    def test_loading_one_module_does_not_reach_the_compiler(self, builder, compiler):
+        # loadModule() never compiles, with or without a corpus. Declining
+        # turns into MibNotFoundError there, which is what it has always been
+        # for a module nothing carries.
+        builder.loadTexts = True
+
+        with pytest.raises(error.MibNotFoundError):
+            builder.loadModule("FIXTURE-MIB")
+
+        assert compiler.calls == []
+
+    def test_a_module_the_compiler_cannot_render_is_reported(self, builder, compiler):
+        builder.loadTexts = True
+        compiler.compile = lambda modName, **options: {modName: "missing"}
+
+        with pytest.raises(error.MibNotFoundError, match="compilation error"):
+            builder.loadModules("FIXTURE-MIB")
+
+    def test_a_compiled_module_is_what_later_loads_find(self, builder, compiler):
+        # The compiler writes into a directory that setMibCompiler() puts on
+        # the search path, and sources are searched before the corpus. So a
+        # module compiled once for its prose is the copy every later load
+        # resolves to, whether or not texts are still wanted -- the corpus does
+        # not take it back.
+        builder.loadTexts = True
+        builder.loadModules("FIXTURE-MIB")
+        builder.unloadModules("FIXTURE-MIB")
+
+        builder.loadTexts = False
+        builder.loadModules("FIXTURE-MIB")
+
+        assert compiler.calls == [("FIXTURE-MIB", {"genTexts": True})]
+
+        (scalar,) = builder.importSymbols("FIXTURE-MIB", "compiledScalar")
+
+        assert scalar.getDescription() == "Rendered from ASN.1, prose and all."
 
 
 class TestTrapPath:


### PR DESCRIPTION
Closes #217.

## What was wrong

A corpus carries no DESCRIPTION and no REFERENCE, so `loadTexts` against one was refused. Two problems with how:

- The refusal raised plain `SmiError`. `MibNotFoundError` ⊂ `MibLoadError` ⊂ `SmiError`, so the raise is the *parent* of what `loadModules()` catches to invoke the compiler — it escaped, and the compiler was never reached. It was already wired for exactly this: `compile(modName, genTexts=self.loadTexts)`.
- It also fired at `setMibCorpus()`, before a compiler could be attached. So corpus + compiler + `loadTexts` could not be assembled in that order at all.

Net: the configuration a MIB browser wants — corpus for the thousands of modules it resolves against, compiler for the handful whose text goes on screen — was unreachable.

## What changed

A textless corpus under `loadTexts` now **steps aside** when a compiler is configured, and refuses only when none is. `loadModule()` then raises `MibNotFoundError`, which is what it already raises for a module nothing carries, and `loadModules()` catches it and compiles with `genTexts=True`.

Decided per module rather than at attachment, so the two setters no longer have to be called in a particular order.

## Why this and not a prose-carrying corpus

The alternative on the table was a second published artifact — corpus with prose, ~380 MB against 256 MB — plus a DDL column, a schema bump and a coordinated pysnmp/pysmi/mibs release. The compile path already renders prose per module, on demand, for only what a caller touches. Nothing to build, nothing to ship, nothing to keep in sync.

## Notes

- No behaviour change with `loadTexts` off, which is the default.
- The error message now names the compiler as an option alongside the `json/` tree.
- `setMibCompiler()` puts its output directory on the search path, so a module compiled once is the copy later loads find; the corpus does not take it back when `loadTexts` is cleared. Pinned by a test.

## Verification

`ruff check`, `ruff format --check`, `mypy` (147 files), `sphinx-build -n -W`, 1309 passed / 12 skipped. Six new tests in `TestCorpusWithACompiler`; the two existing texts-guard tests repointed from attachment to load time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Textless corpora can now be attached even when text loading is enabled.
  * Modules requiring descriptions now report an error only when loaded and no compiler is available.
  * When configured, the compiler can provide module descriptions while preserving corpus-based loading when text loading is disabled.
  * Improved handling of compiler failures and subsequent loading of compiled modules.

* **Documentation**
  * Clarified composite corpus behavior, compiler precedence, and how compiled modules affect future module searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->