### PR TITLE
build(deps): require pysmi 4.0.0rc4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
 # sibling release candidate is better than a required dependency doing it, but
 # it is still not what a GA should ship.
 [project.optional-dependencies]
-compile = ["pysnmp-pysmi >=4.0.0rc3,<5.0.0"]
+compile = ["pysnmp-pysmi >=4.0.0rc4,<5.0.0"]
 
 [project.urls]
 repository = "https://github.com/pysnmp/pysnmp"
@@ -87,7 +87,7 @@ repository = "https://github.com/pysnmp/pysnmp"
 # does.
 [dependency-groups]
 dev = [
-    "pysnmp-pysmi >=4.0.0rc3,<5.0.0",
+    "pysnmp-pysmi >=4.0.0rc4,<5.0.0",
     "sphinx >=7.0.0,<9.0.0",
     "myst-parser >=4.0.0,<5.0.0",
     "pytest >=9.0.3,<10.0.0",

--- a/pysnmp/smi/mibs/PYSNMP-MIB.py
+++ b/pysnmp/smi/mibs/PYSNMP-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module PYSNMP-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source PYSNMP-MIB.txt
 # Source digest sha256:45033dc08c328f8c3f7f4ccb13bfa26b06a813301c75fe87e2ba7fcb1debfc83
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "201704140000Z"
 

--- a/pysnmp/smi/mibs/PYSNMP-SOURCE-MIB.py
+++ b/pysnmp/smi/mibs/PYSNMP-SOURCE-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module PYSNMP-SOURCE-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source PYSNMP-SOURCE-MIB.txt
 # Source digest sha256:8196d30b7c7197db3aeb5eb58b52b72679ad102176a1ce4dcf97762cd00874f5
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "201704140000Z"
 

--- a/pysnmp/smi/mibs/PYSNMP-USM-MIB.py
+++ b/pysnmp/smi/mibs/PYSNMP-USM-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module PYSNMP-USM-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source PYSNMP-USM-MIB.txt
 # Source digest sha256:7789d11fb75f3c642f1397ea491949c5a88b5a93fe3286fa7b414720929ec16d
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "201704140000Z"
 

--- a/pysnmp/smi/mibs/SNMP-COMMUNITY-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-COMMUNITY-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module SNMP-COMMUNITY-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source SNMP-COMMUNITY-MIB
 # Source digest sha256:296ed1c1a59302ad700a713a6a85169323014626e929bae75473a164b55d0263
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "200308060000Z"
 

--- a/pysnmp/smi/mibs/SNMP-FRAMEWORK-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-FRAMEWORK-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module SNMP-FRAMEWORK-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source SNMP-FRAMEWORK-MIB
 # Source digest sha256:8e097e7b3fae34f5767a7b7d8ecb7f5765921642b08ec3c62cd8e1f30ef27f42
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "200210140000Z"
 

--- a/pysnmp/smi/mibs/SNMP-MPD-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-MPD-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module SNMP-MPD-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source SNMP-MPD-MIB
 # Source digest sha256:9eb9f3324c9c345fe0ee57b1bb0879ae8e52594756f27534d447d20342d60364
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "200210140000Z"
 

--- a/pysnmp/smi/mibs/SNMP-TARGET-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-TARGET-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module SNMP-TARGET-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source SNMP-TARGET-MIB
 # Source digest sha256:39d11d27f1da4e7d6087e0f019e5d82000a28430dba1dc2fa29885c4704af249
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "200210140000Z"
 

--- a/pysnmp/smi/mibs/SNMP-USER-BASED-SM-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-USER-BASED-SM-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module SNMP-USER-BASED-SM-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source SNMP-USER-BASED-SM-MIB
 # Source digest sha256:58811e542d99a71346ec748c573366935e2e075c93a0175999131daa773f78b0
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "200210160000Z"
 

--- a/pysnmp/smi/mibs/SNMP-VIEW-BASED-ACM-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-VIEW-BASED-ACM-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module SNMP-VIEW-BASED-ACM-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source SNMP-VIEW-BASED-ACM-MIB
 # Source digest sha256:5b2a1d85a8d6484d55a3a1856512ef8ee50acf381e5404a323858c5ee878e1e3
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "200210160000Z"
 

--- a/pysnmp/smi/mibs/SNMPv2-MIB.py
+++ b/pysnmp/smi/mibs/SNMPv2-MIB.py
@@ -2,7 +2,7 @@
 # PySNMP MIB module SNMPv2-MIB (http://snmplabs.com/pysmi)
 # ASN.1 source SNMPv2-MIB
 # Source digest sha256:afe553d34532d3ed7e4242adf4c4ce6adde6672a686a449b96a1a32a77bf4bdc
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
 #
 PYSNMP_MODULE_REVISION = "200210160000Z"
 

--- a/uv.lock
+++ b/uv.lock
@@ -897,15 +897,15 @@ wheels = [
 
 [[package]]
 name = "pysnmp-pysmi"
-version = "4.0.0rc3"
+version = "4.0.0rc4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/90/1712c34f3dc8f659b672fc147673da6aa2b3241dde05a4acfabc6f1f2a6c/pysnmp_pysmi-4.0.0rc3.tar.gz", hash = "sha256:a0bc81bc53ac2b1be7b4e79d3c893e818e913285934263119439f730d38e3905", size = 4407902, upload-time = "2026-09-10T13:56:34.68Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/ed/eb92b83b9eec935114a74384966176a3c869ffd43521d121dbabc62041f7/pysnmp_pysmi-4.0.0rc4.tar.gz", hash = "sha256:b0707feae5e5ab006c49534e2db18a5e41ed575b9eb4996b4ac039f32afd94db", size = 4421105, upload-time = "2026-09-10T17:12:00.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/c4/acd6564d842885bcf19b60bd046ca45a8a97a274167008cdbd50a22aa752/pysnmp_pysmi-4.0.0rc3-py3-none-any.whl", hash = "sha256:ca5f9ce9254d983bd65c62f011f80459854c1048f4ef3cb56514c12790284106", size = 3157408, upload-time = "2026-09-10T13:56:32.514Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f0/faf10f904311657859e922f0fd48836199f5b86a0440e1964dd62f294bb9/pysnmp_pysmi-4.0.0rc4-py3-none-any.whl", hash = "sha256:5121944976b8a46e3e531e9c0d2fd01e18945c3447794af1b9e870dd992d1879", size = 3157796, upload-time = "2026-09-10T17:11:58.449Z" },
 ]
 
 [[package]]
@@ -938,7 +938,7 @@ dev = [
 requires-dist = [
     { name = "pycryptodomex", specifier = ">=3.11.0,<4.0.0" },
     { name = "pysnmp-pyasn1", specifier = ">=2.0.2,<3.0.0" },
-    { name = "pysnmp-pysmi", marker = "extra == 'compile'", specifier = ">=4.0.0rc3,<5.0.0" },
+    { name = "pysnmp-pysmi", marker = "extra == 'compile'", specifier = ">=4.0.0rc4,<5.0.0" },
 ]
 provides-extras = ["compile"]
 
@@ -947,7 +947,7 @@ dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.2.0,<8.0.0" },
     { name = "mypy", specifier = ">=1.15.0,<3.0.0" },
     { name = "myst-parser", specifier = ">=4.0.0,<5.0.0" },
-    { name = "pysnmp-pysmi", specifier = ">=4.0.0rc3,<5.0.0" },
+    { name = "pysnmp-pysmi", specifier = ">=4.0.0rc4,<5.0.0" },
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "ruff", specifier = ">=0.4.0,<1.0.0" },
     { name = "sphinx", specifier = ">=7.0.0,<9.0.0" },


### PR DESCRIPTION
Moves the `pysnmp-pysmi` floor from `4.0.0rc3` to `4.0.0rc4` in the `compile`
extra and the dev group, and re-renders the ten committed MIB modules against
it.

The floor is load-bearing rather than cosmetic: `tests/test_generated_mibs.py`
checks the committed modules against a fresh render, so the pinned producer and
the committed output have to move together.

## What changed

One line per module, the producer stamp:

```
-# Produced by pysmi-4.0.0-rc.3
+# Produced by pysmi-4.0.0-rc.4
```

Nothing else. No node, type, behavior fragment or `DEFVAL` moved, and every
ASN.1 source digest is unchanged.

## Checks

- ruff check and ruff format clean
- mypy clean
- 1314 passed, 12 skipped

Not a 6.0.0 GA step on its own -- the floor is still an RC pin, and GA waits on
pysmi cutting 4.0.0 final.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the minimum supported prerelease version of the MIB compilation tooling to the latest release candidate.
  - Refreshed generated MIB metadata to accurately identify the updated tooling version.

- **Compatibility**
  - No changes were made to runtime behavior, MIB definitions, public interfaces, or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->