### PR TITLE
feat(smi): report which source a module came from, and what it shadowed

### DIFF
--- a/docs/source/docs/mib-corpus.rst
+++ b/docs/source/docs/mib-corpus.rst
@@ -158,6 +158,79 @@ textless rather than silently answering with no DESCRIPTION for the modules it
 owns. What that then means is the subject of `What a corpus does not carry`_.
 
 
+Which copy answered
+-------------------
+
+A module can be carried by a directory, a package, the wheel, a corpus and the
+compiler's output all at once, and exactly one of them answers. Which one is not
+readable from the path: a wheel and a directory of overrides are both
+directories under ``site-packages``, and a corpus is not a path in that sense at
+all.
+
+.. code-block:: python
+
+   builder.loadModule("IF-MIB")
+
+   builder.getModuleProvenance("IF-MIB")
+   # -> (MibSourceKind.DB, '/mibs/vendor.db')
+
+   builder.getModulePath("IF-MIB")
+   # -> 'corpus:/mibs/vendor.db/IF-MIB'
+
+The kind is one of ``override`` (pysnmp's own copies of the engine MIBs),
+``wheel``, ``dir``, ``pkg``, ``db`` or ``compiled``; the id names the particular
+source, which is what tells a distro corpus from a customer one. A module that
+is not loaded has no provenance, and unloading it forgets what it had --
+reloading can well pick a different copy.
+
+It is tracked per module rather than per node, because a module resolves from
+exactly one source: a per-node record would be the same answer repeated across
+every OID in the module.
+
+
+What was passed over
+--------------------
+
+The other half of the same question. A leftover ``.py`` directory that a corpus
+was meant to replace still outranks the corpus, so the corpus is the copy being
+skipped -- the opposite of what adding one usually means.
+
+.. code-block:: python
+
+   builder.shadowedModules()
+   # -> {'IF-MIB': [(MibSourceKind.DIR, '/opt/mibs'),
+   #                (MibSourceKind.DB, '/mibs/core.db')]}
+
+   builder.reportShadowedModules()   # same answer, and says so out loud
+
+``reportShadowedModules()`` runs by itself inside ``loadModules()`` when it is
+called with no names, since that path already enumerates every source and the
+enumeration is the whole cost. Loading modules by name does not trigger it; call
+it directly there.
+
+How loudly is ``moduleConflictSeverity``:
+
+``warn`` (default)
+    One ``PySnmpShadowedModuleWarning`` per shadowed module.
+
+``error``
+    Raises ``SmiError`` before anything is loaded. The setting for a deployment
+    that has finished migrating off generated ``.py`` and wants any survivor to
+    be fatal.
+
+``silent``
+    Says nothing, still returns the answer.
+
+Two things it deliberately does not do. It **never claims the copies differ, or
+match**: answering that means reading and normalizing both, which is the work a
+corpus exists to avoid, so it reports only that a second copy exists and is
+being passed over. And it **says nothing about a stock install**, where
+``pysnmp.smi.mibs`` shadows the wheel for the seven modules the engine needs --
+that is what the search order is for, and warning about it would mean warning
+every user who configured nothing. ``shadowedModules()`` still reports it, being
+a question about the sources rather than about the configuration.
+
+
 Resolving a trap OID without a compiler
 ---------------------------------------
 

--- a/pysnmp/error.py
+++ b/pysnmp/error.py
@@ -24,6 +24,22 @@ class PySnmpNonStandardCryptoWarning(PySnmpCryptoWarning):
     """The selected protocol is not standards-track and may not interoperate."""
 
 
+class PySnmpShadowedModuleWarning(UserWarning):
+    """A MIB module is present in more than one source, and one copy was chosen.
+
+    Raised while enumerating sources rather than while decoding, because that
+    is where the configuration that caused it can still be changed. Derived
+    from `UserWarning` for the same reason the crypto warnings are: a
+    deployment carrying two copies of a MIB is resolving every OID in it
+    against whichever copy won, and that is worth seeing under the default
+    filters.
+
+    Which copy won is stated, never whether the copies differ -- answering
+    that means loading and normalizing both, which is the work a corpus
+    exists to avoid.
+    """
+
+
 class PySnmpError(Exception):
     """Base class for pysnmp exceptions.
 

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -13,6 +13,7 @@ rendered from ASN.1.
 """
 
 import dis
+import enum
 import importlib
 import importlib.machinery
 import importlib.util
@@ -21,11 +22,13 @@ import os
 import struct
 import time
 import traceback
+import warnings
 from errno import ENOENT
 from typing import Any, cast
 
 from pysnmp import debug
 from pysnmp import version as pysnmp_version
+from pysnmp.error import PySnmpShadowedModuleWarning
 from pysnmp.smi import error
 from pysnmp.smi.mibs import behavior
 
@@ -38,12 +41,104 @@ PY_SUFFIXES = SOURCE_SUFFIXES + BYTECODE_SUFFIXES
 classTypes = (type,)
 
 
+class MibSourceKind(str, enum.Enum):
+    """What kind of place a module came from.
+
+    A caller asking where a symbol came from is usually asking one of two
+    questions -- is this still resolving out of the wheel, or has my corpus
+    taken over; and did this come from the copy I installed or the one the
+    framework ships -- and neither is answerable from a path alone. Two
+    directories look the same, and the package a wheel unpacks to looks like
+    any other directory.
+
+    A ``str`` enum so that a value logs, compares and serializes as its own
+    name without a caller having to import this to read it.
+    """
+
+    #: `pysnmp.smi.mibs` and `pysnmp.smi.mibs.instances` -- the modules the
+    #: engine itself needs, searched first so nothing can displace them.
+    OVERRIDE = "override"
+
+    #: `pysmi.mibs.pysnmp`, the modules generated into the wheel pysnmp
+    #: depends on. Searched last.
+    WHEEL = "wheel"
+
+    #: A plain directory of generated modules, registered by a caller.
+    DIR = "dir"
+
+    #: An importable package of generated modules, `PYSNMP_MIB_PKGS` included.
+    PKG = "pkg"
+
+    #: A corpus database, from `PYSNMP_MIB_DBS` or `setMibCorpus()`.
+    DB = "db"
+
+    #: Rendered on demand by an attached compiler, into its output directory.
+    COMPILED = "compiled"
+
+
+#: How to report a module found in more than one source.
+#:
+#: ``warn`` is the default because shadowing is a configuration a deployment
+#: may well intend -- a local copy of a vendor MIB, deliberately placed ahead
+#: of the bundled one. ``error`` is the setting for a deployment that has
+#: finished migrating off `.py` and wants any surviving copy to be fatal;
+#: ``silent`` for one that has decided to live with it.
+CONFLICT_SEVERITIES = ("warn", "error", "silent")
+
+#: The one shadowing pysnmp arranges itself, and so does not report.
+#:
+#: `defaultCoreMibs` exists to be searched ahead of `defaultGeneratedMibs`:
+#: pysnmp carries its own copy of the seven modules the engine needs and the
+#: wheel carries them too. Every stock install is therefore shadowing seven
+#: modules before a caller has configured anything, and warning about it would
+#: mean the default install warns -- which is both noise and a broken promise,
+#: since nothing about that install has changed.
+#:
+#: Any other combination is the caller's doing and is reported. A local
+#: directory shadowing the wheel is reported; a corpus shadowing an override
+#: is reported.
+FRAMEWORK_SHADOW = frozenset({MibSourceKind.OVERRIDE, MibSourceKind.WHEEL})
+
+
 class __AbstractMibSource:
-    def __init__(self, srcName: str) -> None:
-        """Records where to look. Nothing is read until `init()`."""
+    #: What a source of this class is, absent anything more specific from the
+    #: caller. `MibBuilder` overrides it for the sources it registers itself,
+    #: which are packages by class and something more particular by intent.
+    defaultKind: MibSourceKind = MibSourceKind.DIR
+
+    def __init__(
+        self,
+        srcName: str,
+        kind: "MibSourceKind | None" = None,
+        sourceId: str | None = None,
+    ) -> None:
+        """Records where to look. Nothing is read until `init()`.
+
+        Args:
+            srcName: the directory or importable package to search
+            kind: what this source is, for provenance. Defaults to what the
+                class is, which is the right answer for a caller registering
+                a directory or a package of their own
+            sourceId: a stable name for this source, defaulting to *srcName*.
+                Given separately because `ZipMibSource.init` rewrites
+                `_srcName` to a path inside the archive, and provenance has to
+                keep naming what the caller registered
+        """
         self._srcName = srcName
+        self._sourceId = srcName if sourceId is None else sourceId
+        self.mibSourceKind = self.defaultKind if kind is None else kind
         self.__inited = None
         debug.logger & debug.flagBld and debug.logger(f"trying {self}")
+
+    @property
+    def sourceId(self) -> str:
+        """A stable name for this source, as the caller named it."""
+        return self._sourceId
+
+    @property
+    def provenance(self) -> "tuple[MibSourceKind, str]":
+        """What this source is and which one it is, as provenance records it."""
+        return self.mibSourceKind, self._sourceId
 
     def __repr__(self) -> str:
         """The source and where it points, for debug logging."""
@@ -207,6 +302,8 @@ class __AbstractMibSource:
 class ZipMibSource(__AbstractMibSource):
     """MIB modules loaded out of a zip archive, including an egg or a wheel."""
 
+    defaultKind = MibSourceKind.PKG
+
     # zipimport.zipimporter carries the archive directory privately, and
     # typeshed describes neither it nor the loader `__import__` hands back, so
     # there is nothing narrower to say here than what `_archiveFiles` checks.
@@ -240,6 +337,11 @@ class ZipMibSource(__AbstractMibSource):
         what a wheel unpacks to -- so this hands back a ``DirMibSource`` for
         both the installed and the relative-to-CWD case, and answers with
         itself only for a genuine archive.
+
+        A substitute carries this source's kind and id rather than taking a
+        directory's: which of them serves a package is an installation detail,
+        and provenance that changed with it would report `dir` for the same
+        wheel a zip install reports `wheel` for.
         """
         try:
             p = __import__(self._srcName, globals(), locals(), ["__init__"])
@@ -254,13 +356,19 @@ class ZipMibSource(__AbstractMibSource):
                 # Dir relative to PYTHONPATH. __file__ is Optional -- a
                 # namespace package has none -- but the guard above has
                 # already established this one has a path.
-                return DirMibSource(os.path.split(cast(str, p.__file__))[0]).init()
+                return DirMibSource(
+                    os.path.split(cast(str, p.__file__))[0],
+                    kind=self.mibSourceKind,
+                    sourceId=self._sourceId,
+                ).init()
             else:
                 raise error.MibLoadError(f"{p} access error")
 
         except ImportError:
             # Dir relative to CWD
-            return DirMibSource(self._srcName).init()
+            return DirMibSource(
+                self._srcName, kind=self.mibSourceKind, sourceId=self._sourceId
+            ).init()
 
     def fullPath(self, *args: Any) -> str:
         """Qualify the archive member with the archive it lives in.
@@ -469,6 +577,15 @@ class MibBuilder:
 
     loadTexts = False
 
+    #: What to do about a module more than one source carries: ``warn``,
+    #: ``error`` or ``silent``, from `CONFLICT_SEVERITIES`.
+    #:
+    #: Shared with the compiler's own idea of severity in the sense that it
+    #: answers the same question -- a deployment part-way through migrating off
+    #: generated `.py` wants to see what is still shadowed, and one that has
+    #: finished wants any survivor to be fatal.
+    moduleConflictSeverity = "warn"
+
     # MIB modules can use this to select the features they can use
     version = pysnmp_version
 
@@ -515,17 +632,19 @@ class MibBuilder:
             for m in self.defaultMiscMibs.split(os.pathsep):
                 sources.append(ZipMibSource(m))
         for m in self.defaultCoreMibs.split(os.pathsep):
-            sources.insert(0, ZipMibSource(m))
+            sources.insert(0, ZipMibSource(m, kind=MibSourceKind.OVERRIDE))
         if self.defaultGeneratedMibs:
             for m in self.defaultGeneratedMibs.split(os.pathsep):
-                sources.append(ZipMibSource(m))
+                sources.append(ZipMibSource(m, kind=MibSourceKind.WHEEL))
         self.mibSymbols: dict[str, dict[str, Any]] = {}
         self.__mibSources: list[MibSource] = []
         self.__modSeen: dict[str, str] = {}
         self.__modPathsSeen: set[str] = set()
+        self.__modProvenance: dict[str, tuple[MibSourceKind, str]] = {}
         self.__mibCompiler: Any = None
         self.__mibCorpus: Any = None
         self.__corpusBuilding: set[str] = set()
+        self.__shadowsReported = False
         self.setMibSources(*sources)
 
         # Imported here rather than at module scope so that the default path
@@ -579,6 +698,7 @@ class MibBuilder:
             This builder.
         """
         self.__mibCorpus = mibCorpus
+        self.__shadowsReported = False
 
         return self
 
@@ -679,6 +799,18 @@ class MibBuilder:
         self.__modSeen[modName] = f"corpus:{self.__mibCorpus.path}/{modName}"
         self.__modPathsSeen.add(self.__modSeen[modName])
 
+        # Which corpus, not which composite: a module resolves from exactly
+        # one, and naming the whole search path would make provenance unable
+        # to tell a distro corpus from a customer one, which is most of what
+        # it is for.
+        owner = getattr(self.__mibCorpus, "owner", None)
+        carrier = owner(modName) if owner else None
+
+        self.__modProvenance[modName] = (
+            MibSourceKind.DB,
+            getattr(carrier, "path", self.__mibCorpus.path),
+        )
+
         debug.logger & debug.flagBld and debug.logger(
             f"loadModule: {modName} built from corpus {self.__mibCorpus.path}"
         )
@@ -697,7 +829,7 @@ class MibBuilder:
         Adding the source is the point: a module the compiler renders has to be
         loadable afterwards, and nothing else would put that directory on the path.
         """
-        self.addMibSources(DirMibSource(destDir))
+        self.addMibSources(DirMibSource(destDir, kind=MibSourceKind.COMPILED))
         self.__mibCompiler = mibCompiler
         return self
 
@@ -706,6 +838,7 @@ class MibBuilder:
     def addMibSources(self, *mibSources: Any) -> None:
         """Add sources to search, opening each one."""
         self.__mibSources.extend([s.init() for s in mibSources])
+        self.__shadowsReported = False
         debug.logger & debug.flagBld and debug.logger(
             f"addMibSources: new MIB sources {self.__mibSources}"
         )
@@ -713,6 +846,7 @@ class MibBuilder:
     def setMibSources(self, *mibSources: Any) -> None:
         """Replace the sources to search, opening each one."""
         self.__mibSources = [s.init() for s in mibSources]
+        self.__shadowsReported = False
         debug.logger & debug.flagBld and debug.logger(
             f"setMibSources: new MIB sources {self.__mibSources}"
         )
@@ -730,6 +864,155 @@ class MibBuilder:
         ask.
         """
         return self.__modSeen.get(modName)
+
+    def getModuleProvenance(self, modName: str) -> "tuple[MibSourceKind, str] | None":
+        """What kind of source a loaded module came from, and which one.
+
+        `getModulePath` answers with a path, which is what a person reads and
+        not what a program can act on: a wheel and a directory of overrides are
+        both directories, and a corpus is not a path in the sense the others
+        are. This answers ``(kind, source_id)`` instead -- the kind for
+        deciding, the id for telling two sources of that kind apart, a distro
+        corpus from a customer one above all.
+
+        Tracked per module rather than per node. One module resolves from one
+        source, so a per-node record would be the same answer repeated once per
+        OID: on the order of a thousand entries either way against several
+        hundred thousand.
+
+        Args:
+            modName: the module, as it was loaded
+
+        Returns
+        -------
+            The pair, or ``None`` for a module that is not loaded. A module
+            that was unloaded is not loaded.
+        """
+        return self.__modProvenance.get(modName)
+
+    def __corporaInPlay(self) -> "tuple[Any, ...]":
+        """The corpora configured, flattened out of a composite if it is one."""
+        if self.__mibCorpus is None:
+            return ()
+
+        return tuple(getattr(self.__mibCorpus, "corpora", (self.__mibCorpus,)))
+
+    def shadowedModules(self) -> "dict[str, list[tuple[MibSourceKind, str]]]":
+        """Modules more than one source can supply, and which sources those are.
+
+        Name-level only, and deliberately: answering whether two copies of a
+        module differ means reading and normalizing both, which is the work a
+        corpus exists to avoid. So this reports *shadowing* -- that a second
+        copy exists and will be passed over -- and never claims the copies are
+        equal or that they differ.
+
+        Sources in the order `_candidates` searches them, then the corpora.
+        That is not the winning order: revision decides among sources, and
+        reading it means reading every candidate module, which is the cost
+        this avoids. A caller wanting the copy that actually won asks
+        `getModuleProvenance` once the module is loaded.
+
+        Returns
+        -------
+            Module name to the sources carrying it, for the modules more than
+            one source carries. Empty when nothing is shadowed.
+        """
+        carriers: dict[str, list[tuple[MibSourceKind, str]]] = {}
+
+        for mibSource in self.__mibSources:
+            for modName in mibSource.listdir():
+                carriers.setdefault(modName, []).append(mibSource.provenance)
+
+        for corpus in self.__corporaInPlay():
+            for modName in corpus.modules():
+                carriers.setdefault(modName, []).append((MibSourceKind.DB, corpus.path))
+
+        return {modName: found for modName, found in carriers.items() if len(found) > 1}
+
+    def reportShadowedModules(self) -> "dict[str, list[tuple[MibSourceKind, str]]]":
+        """Report every shadowed module once, at the configured severity.
+
+        Enumerating every source is the cost, and `loadModules()` called with
+        no names already pays it, so that is the path that calls this. A caller
+        who loads modules by name and still wants the report calls it directly.
+
+        Reported once per builder, so a program that loads modules in several
+        passes does not emit the same lines each time. `addMibSources`,
+        `setMibSources` and `setMibCorpus` arm it again, since any of them can
+        create a collision that did not exist before.
+
+        `FRAMEWORK_SHADOW` is left out -- pysnmp's own copies of the engine
+        modules shadowing the wheel's is what the search order is for, and a
+        stock install would otherwise warn seven times having configured
+        nothing. `shadowedModules` still reports it, being a question about
+        the sources rather than about the configuration.
+
+        Raises
+        ------
+            SmiError: `moduleConflictSeverity` is ``error`` and something is
+                shadowed, or it is not one of `CONFLICT_SEVERITIES`.
+
+        Returns
+        -------
+            What `shadowedModules` returned, so a caller can act on it without
+            enumerating a second time.
+        """
+        if self.moduleConflictSeverity not in CONFLICT_SEVERITIES:
+            raise error.SmiError(
+                f"moduleConflictSeverity is {self.moduleConflictSeverity!r}, "
+                f"expected one of {', '.join(CONFLICT_SEVERITIES)}"
+            )
+
+        shadowed = {
+            modName: found
+            for modName, found in self.shadowedModules().items()
+            if {kind for kind, _ in found} != FRAMEWORK_SHADOW
+        }
+
+        if self.__shadowsReported or not shadowed:
+            self.__shadowsReported = True
+            return shadowed
+
+        self.__shadowsReported = True
+
+        # Counted apart from the per-module lines. A deployment whose second
+        # corpus mostly repeats the first is paying for both and getting one,
+        # and at that scale the per-module lines are too many to read -- the
+        # total is what makes it visible.
+        overlapping = sum(
+            1
+            for found in shadowed.values()
+            if sum(1 for kind, _ in found if kind is MibSourceKind.DB) > 1
+        )
+
+        for modName, found in sorted(shadowed.items()):
+            first, *rest = found
+            line = (
+                f"{modName} is carried by {len(found)} sources: "
+                f"{first[0].value}:{first[1]} is searched first, shadowing "
+                + ", ".join(f"{kind.value}:{name}" for kind, name in rest)
+            )
+
+            debug.logger & debug.flagBld and debug.logger(
+                f"reportShadowedModules: {line}"
+            )
+
+            if self.moduleConflictSeverity == "warn":
+                warnings.warn(line, PySnmpShadowedModuleWarning, stacklevel=2)
+
+        if overlapping:
+            debug.logger & debug.flagBld and debug.logger(
+                f"reportShadowedModules: {overlapping} modules are carried by "
+                f"more than one corpus"
+            )
+
+        if self.moduleConflictSeverity == "error":
+            raise error.SmiError(
+                f"{len(shadowed)} MIB modules are carried by more than one "
+                f"source: {', '.join(sorted(shadowed))}"
+            )
+
+        return shadowed
 
     # Legacy/compatibility methods (won't work for .eggs)
     def setMibPath(self, *mibPaths: str) -> None:
@@ -867,6 +1150,7 @@ class MibBuilder:
                 ) from e
 
             self.__modSeen[modName] = modPath
+            self.__modProvenance[modName] = mibSource.provenance
 
             debug.logger & debug.flagBld and debug.logger(
                 f"loadModule: loaded {modPath}"
@@ -896,6 +1180,13 @@ class MibBuilder:
                 for modName in mibSource.listdir():
                     found[modName] = None
             names = tuple(found)
+
+            # Enumerating every source is the whole cost of the shadow report
+            # and this path has just paid it, so it is the one place the
+            # report is free. Before loading anything, so that a deployment
+            # configured to treat shadowing as fatal fails before it has half
+            # a MIB set in memory.
+            self.reportShadowedModules()
 
         if not names:
             raise error.MibNotFoundError(f"No MIB module to load at {self}")
@@ -944,6 +1235,7 @@ class MibBuilder:
             self.unexportSymbols(modName)
             self.__modPathsSeen.remove(self.__modSeen[modName])
             del self.__modSeen[modName]
+            self.__modProvenance.pop(modName, None)
 
             debug.logger & debug.flagBld and debug.logger(f"unloadModules: {modName}")
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,474 @@
+"""Which source a module came from, and which sources were passed over.
+
+Two questions a deployment part-way through the corpus migration has to be able
+to ask, and could not:
+
+**Where did this module come from?** `getModulePath` answers with a path, which
+is what a person reads and not what a program acts on -- a wheel and a directory
+of overrides are both directories, and a corpus is not a path in that sense at
+all. `getModuleProvenance` answers `(kind, source_id)`.
+
+**What else could have answered?** A module carried by two sources resolves from
+one of them and the other is silently passed over. That is often deliberate --
+a local copy placed ahead of the bundled one -- and sometimes a leftover `.py`
+that a corpus was supposed to replace, and the two are indistinguishable until
+something reports them.
+
+The compatibility promise runs through all of it: a stock install configures
+seven shadowed modules before a caller has done anything, because pysnmp carries
+its own copies of the engine MIBs and the wheel carries them too. Reporting that
+would mean the default install warns, so it is excluded by name and the
+exclusion is tested as carefully as the reporting is.
+"""
+
+import os
+import shutil
+import warnings
+
+import pytest
+from pysmi.corpus import conformance as pysmi_conformance
+
+from pysnmp.error import PySnmpShadowedModuleWarning
+from pysnmp.smi import error
+from pysnmp.smi.builder import (
+    FRAMEWORK_SHADOW,
+    DirMibSource,
+    MibBuilder,
+    MibSourceKind,
+    ZipMibSource,
+)
+from pysnmp.smi.corpus import MibCorpus, open_corpora
+
+#: A module the engine loads on its own account, carried by both
+#: `defaultCoreMibs` and the wheel -- so it is the one to ask about when the
+#: question is which of those two answered.
+ENGINE_MODULE = "SNMP-FRAMEWORK-MIB"
+
+
+@pytest.fixture
+def mibDir(tmp_path):
+    """A directory carrying one real generated module, as a caller's would."""
+    source = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "pysnmp",
+        "smi",
+        "mibs",
+        f"{ENGINE_MODULE}.py",
+    )
+
+    directory = tmp_path / "mibs"
+    directory.mkdir()
+    shutil.copy(source, directory / f"{ENGINE_MODULE}.py")
+
+    return str(directory)
+
+
+@pytest.fixture(scope="module")
+def corpusPath(tmp_path_factory):
+    """pysmi's conformance corpus, built fresh."""
+    directory = tmp_path_factory.mktemp("provenance")
+
+    return pysmi_conformance.build_fixture(str(directory / "conformance.db"))
+
+
+@pytest.fixture
+def corpusModule(corpusPath):
+    """A module the conformance corpus carries and no MIB source does."""
+    corpus = MibCorpus(corpusPath)
+
+    try:
+        modules = sorted(corpus.modules())
+
+    finally:
+        corpus.close()
+
+    builder = MibBuilder()
+    carried = {name for source in builder.getMibSources() for name in source.listdir()}
+
+    for name in modules:
+        if name not in carried:
+            return name
+
+    raise AssertionError("the conformance corpus carries nothing a source does not")
+
+
+class TestModuleProvenance:
+    """`(kind, source_id)` for a module that is loaded."""
+
+    def test_engine_modules_come_from_the_overrides(self):
+        """The arrangement `defaultCoreMibs` exists to produce.
+
+        pysnmp ships its own copies of the modules the engine needs and
+        searches them first, precisely so the wheel's copies cannot displace
+        them. That is invisible from a path -- both are directories inside
+        site-packages -- and is exactly what provenance is for.
+        """
+        builder = MibBuilder()
+        builder.loadModule(ENGINE_MODULE)
+
+        assert builder.getModuleProvenance(ENGINE_MODULE) == (
+            MibSourceKind.OVERRIDE,
+            "pysnmp.smi.mibs",
+        )
+
+    def test_a_registered_directory_reports_itself(self, mibDir):
+        # Ahead of the defaults rather than instead of them: the module IMPORTS
+        # from SNMPv2-SMI and ASN1, so replacing the search path outright would
+        # fail to load for a reason that has nothing to do with provenance.
+        builder = MibBuilder()
+        builder.setMibSources(DirMibSource(mibDir), *builder.getMibSources())
+        builder.loadModule(ENGINE_MODULE)
+
+        assert builder.getModuleProvenance(ENGINE_MODULE) == (
+            MibSourceKind.DIR,
+            mibDir,
+        )
+
+    def test_an_unloaded_module_has_none(self):
+        builder = MibBuilder()
+
+        assert builder.getModuleProvenance(ENGINE_MODULE) is None
+        assert builder.getModuleProvenance("NO-SUCH-MIB") is None
+
+    def test_unloading_forgets_where_it_came_from(self):
+        """Provenance describes what is loaded, not what once was.
+
+        A module that was unloaded and reloaded may well come back from a
+        different source -- that is the whole reason `unloadModules` exists
+        alongside best-match selection -- so a record that outlived the load
+        would be answering about the wrong copy.
+        """
+        builder = MibBuilder()
+        builder.loadModule(ENGINE_MODULE)
+        assert builder.getModuleProvenance(ENGINE_MODULE) is not None
+
+        builder.unloadModules(ENGINE_MODULE)
+
+        assert builder.getModuleProvenance(ENGINE_MODULE) is None
+
+    def test_a_corpus_module_names_the_corpus_that_carried_it(
+        self, corpusPath, corpusModule
+    ):
+        builder = MibBuilder()
+        builder.setMibCorpus(MibCorpus(corpusPath))
+        builder.loadModule(corpusModule)
+
+        assert builder.getModuleProvenance(corpusModule) == (
+            MibSourceKind.DB,
+            corpusPath,
+        )
+
+    def test_a_composite_names_the_owning_corpus_not_the_search_path(
+        self, corpusPath, corpusModule, tmp_path
+    ):
+        """Which corpus, not which composite.
+
+        A module resolves from exactly one corpus, and naming the whole
+        configured path would leave provenance unable to tell a distro corpus
+        from a customer one -- which is most of what a deployment wants it
+        for.
+        """
+        second = str(tmp_path / "second.db")
+        shutil.copy(corpusPath, second)
+
+        builder = MibBuilder()
+        builder.setMibCorpus(open_corpora([corpusPath, second]))
+        builder.loadModule(corpusModule)
+
+        kind, sourceId = builder.getModuleProvenance(corpusModule)
+
+        assert kind is MibSourceKind.DB
+        assert sourceId in (corpusPath, second)
+        assert os.pathsep not in sourceId
+
+
+class TestSourceKinds:
+    """What a source says it is, before any module is loaded from it."""
+
+    def test_a_directory_is_a_directory_and_a_package_is_a_package(self, mibDir):
+        assert DirMibSource(mibDir).mibSourceKind is MibSourceKind.DIR
+        assert ZipMibSource("pysnmp.smi.mibs").mibSourceKind is MibSourceKind.PKG
+
+    def test_a_substituted_source_keeps_the_kind_it_was_given(self):
+        """The wheel is a wheel whether or not it was installed zipped.
+
+        `ZipMibSource.init` hands back a `DirMibSource` for an ordinary
+        install, since that is what a wheel unpacks to. Letting the substitute
+        take a directory's kind would make the same wheel report `wheel` on a
+        zip install and `dir` on a normal one -- an installation detail
+        leaking into an answer about configuration.
+        """
+        source = ZipMibSource("pysnmp.smi.mibs", kind=MibSourceKind.WHEEL)
+        opened = source.init()
+
+        assert opened.mibSourceKind is MibSourceKind.WHEEL
+        assert opened.sourceId == "pysnmp.smi.mibs"
+
+    def test_the_source_id_survives_the_rewrite_of_the_path(self):
+        """`init` rewrites `_srcName`; the id names what the caller registered."""
+        source = ZipMibSource("pysnmp.smi.mibs")
+
+        assert source.sourceId == "pysnmp.smi.mibs"
+
+        source.init()
+
+        assert source.sourceId == "pysnmp.smi.mibs"
+
+    def test_a_compiler_destination_is_its_own_kind(self, tmp_path):
+        """Compiled output is not a directory a caller chose to register.
+
+        It is a cache the compiler filled, and a deployment auditing where its
+        MIBs come from wants to see that difference -- a module resolving from
+        `compiled` is one nothing shipped.
+        """
+
+        class _Compiler:
+            def compile(self, *args, **kwargs):
+                return {}
+
+        destination = str(tmp_path / "compiled")
+        os.makedirs(destination)
+
+        builder = MibBuilder()
+        builder.setMibCompiler(_Compiler(), destination)
+
+        kinds = {
+            source.sourceId: source.mibSourceKind for source in builder.getMibSources()
+        }
+
+        assert kinds[destination] is MibSourceKind.COMPILED
+
+
+class TestShadowedModules:
+    """What more than one source carries, stated without reading any of it."""
+
+    def test_the_stock_install_shadows_the_engine_modules(self):
+        """Reported as fact, because it is one.
+
+        `reportShadowedModules` leaves this out; `shadowedModules` does not.
+        The distinction is deliberate -- one answers a question about the
+        sources, the other about whether the configuration deserves comment.
+        """
+        shadowed = MibBuilder().shadowedModules()
+
+        assert ENGINE_MODULE in shadowed
+        assert {kind for kind, _ in shadowed[ENGINE_MODULE]} == FRAMEWORK_SHADOW
+
+    def test_a_registered_directory_shadows_the_bundled_copy(self, mibDir):
+        builder = MibBuilder()
+        builder.addMibSources(DirMibSource(mibDir))
+
+        found = builder.shadowedModules()[ENGINE_MODULE]
+
+        assert (MibSourceKind.DIR, mibDir) in found
+
+    def test_nothing_is_shadowed_when_one_source_carries_it(self, mibDir):
+        builder = MibBuilder()
+        builder.setMibSources(DirMibSource(mibDir))
+
+        assert builder.shadowedModules() == {}
+
+    def test_a_corpus_shadows_a_source_carrying_the_same_module(
+        self, corpusPath, corpusModule, tmp_path
+    ):
+        """The case the migration creates, and the one an operator gets wrong.
+
+        A deployment adding a corpus keeps its `.py` directory for a while, so
+        anything in both is shadowed -- and since `.py` outranks a corpus, the
+        corpus is the copy being passed over. That is the opposite of what
+        adding one usually means, which is why it has to be reported rather
+        than left to be noticed.
+
+        The collision is built rather than looked for: a name-level check reads
+        no module, so a file with the right name is the whole of what makes
+        this case, and the conformance corpus happens to share no name with the
+        default sources.
+        """
+        directory = tmp_path / "leftovers"
+        directory.mkdir()
+        (directory / f"{corpusModule}.py").write_text("# a leftover, never loaded\n")
+
+        corpus = MibCorpus(corpusPath)
+
+        try:
+            builder = MibBuilder()
+            builder.addMibSources(DirMibSource(str(directory)))
+            builder.setMibCorpus(corpus)
+
+            found = builder.shadowedModules()[corpusModule]
+
+            assert found == [
+                (MibSourceKind.DIR, str(directory)),
+                (MibSourceKind.DB, corpusPath),
+            ]
+
+        finally:
+            corpus.close()
+
+    def test_two_corpora_carrying_one_module_are_both_named(self, corpusPath, tmp_path):
+        """The redundant-corpus case, which costs memory and buys nothing."""
+        second = str(tmp_path / "second.db")
+        shutil.copy(corpusPath, second)
+
+        builder = MibBuilder()
+        builder.setMibCorpus(open_corpora([corpusPath, second]))
+
+        shadowed = builder.shadowedModules()
+        doubled = [
+            name
+            for name, found in shadowed.items()
+            if sum(1 for kind, _ in found if kind is MibSourceKind.DB) > 1
+        ]
+
+        assert doubled
+        assert {kind for kind, _ in shadowed[doubled[0]]} >= {MibSourceKind.DB}
+
+
+class TestReportShadowedModules:
+    """When shadowing is said out loud, and how loudly."""
+
+    def test_a_stock_install_says_nothing(self):
+        """The compatibility promise, as a test.
+
+        Seven modules are shadowed on every install pysnmp has ever produced.
+        A warning here would fire for every user who changed nothing, which is
+        both noise and a claim that something is wrong when nothing is.
+        """
+        builder = MibBuilder()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            assert builder.reportShadowedModules() == {}
+
+    def test_a_registered_directory_is_warned_about(self, mibDir):
+        builder = MibBuilder()
+        builder.addMibSources(DirMibSource(mibDir))
+
+        with pytest.warns(PySnmpShadowedModuleWarning) as caught:
+            reported = builder.reportShadowedModules()
+
+        assert ENGINE_MODULE in reported
+        assert any(ENGINE_MODULE in str(warning.message) for warning in caught)
+
+    def test_the_line_names_the_winner_and_the_losers(self, mibDir):
+        builder = MibBuilder()
+        builder.addMibSources(DirMibSource(mibDir))
+
+        with pytest.warns(PySnmpShadowedModuleWarning) as caught:
+            builder.reportShadowedModules()
+
+        line = next(
+            str(warning.message)
+            for warning in caught
+            if ENGINE_MODULE in str(warning.message)
+        )
+
+        # Never "duplicate", never "differs": nothing was read, so nothing
+        # about the contents can be claimed.
+        assert "shadowing" in line
+        assert "duplicate" not in line
+        assert mibDir in line
+
+    def test_it_reports_once(self, mibDir):
+        """A program loading in several passes should not re-warn each time."""
+        builder = MibBuilder()
+        builder.addMibSources(DirMibSource(mibDir))
+
+        with pytest.warns(PySnmpShadowedModuleWarning):
+            builder.reportShadowedModules()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            assert builder.reportShadowedModules() != {}
+
+    def test_adding_a_source_arms_it_again(self, mibDir):
+        """A source added later can create a collision that did not exist."""
+        builder = MibBuilder()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            builder.reportShadowedModules()
+
+        builder.addMibSources(DirMibSource(mibDir))
+
+        with pytest.warns(PySnmpShadowedModuleWarning):
+            builder.reportShadowedModules()
+
+    def test_severity_error_raises_before_anything_is_loaded(self, mibDir):
+        """What a deployment sets once it has finished migrating off `.py`."""
+        builder = MibBuilder()
+        builder.moduleConflictSeverity = "error"
+        builder.addMibSources(DirMibSource(mibDir))
+
+        with pytest.raises(error.SmiError) as raised:
+            builder.reportShadowedModules()
+
+        assert ENGINE_MODULE in str(raised.value)
+        assert builder.mibSymbols == {}
+
+    def test_severity_silent_says_nothing_but_still_answers(self, mibDir):
+        builder = MibBuilder()
+        builder.moduleConflictSeverity = "silent"
+        builder.addMibSources(DirMibSource(mibDir))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            assert ENGINE_MODULE in builder.reportShadowedModules()
+
+    def test_an_unknown_severity_is_refused(self, mibDir):
+        """Refused rather than treated as one of the three.
+
+        A typo defaulting to `silent` turns off a report the deployment asked
+        for, and defaulting to `error` breaks one that did not.
+        """
+        builder = MibBuilder()
+        builder.moduleConflictSeverity = "warning"
+
+        with pytest.raises(error.SmiError) as raised:
+            builder.reportShadowedModules()
+
+        assert "moduleConflictSeverity" in str(raised.value)
+
+    def test_loading_everything_reports_on_the_way_past(self, mibDir):
+        """The one path where the report costs nothing.
+
+        `loadModules()` with no names already enumerates every source, which is
+        the whole cost of the report, so that is where it runs. Asserted
+        through the severity knob rather than the warning, since loading every
+        module in the search path is not something a test should do.
+        """
+        builder = MibBuilder()
+        builder.moduleConflictSeverity = "error"
+        builder.setMibSources(DirMibSource(mibDir))
+        builder.addMibSources(DirMibSource(mibDir))
+
+        with pytest.raises(error.SmiError) as raised:
+            builder.loadModules()
+
+        assert "more than one source" in str(raised.value)
+
+
+class TestUnchangedWithoutConfiguration:
+    """None of this changes what a builder that was configured with nothing does."""
+
+    def test_default_severity_is_warn(self):
+        assert MibBuilder.moduleConflictSeverity == "warn"
+
+    def test_loading_a_module_by_name_reports_nothing(self):
+        """Only the enumerate-everything path pays for the report.
+
+        A caller loading modules by name never enumerates the sources, and
+        making the report happen there anyway would put a `listdir` of every
+        source in front of the first `loadModule` of every program.
+        """
+        builder = MibBuilder()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            builder.loadModules(ENGINE_MODULE)
+
+        assert builder.getModuleProvenance(ENGINE_MODULE) is not None


### PR DESCRIPTION
Three of the remaining stories on #144: `MibSourceKind` and `source_id`,
`getModuleProvenance()`, and startup shadow detection with a shared severity
knob. Additive throughout — a builder configured with nothing behaves exactly as
before.

## Why

A deployment part-way through the corpus migration has two questions it cannot
currently ask.

**Where did this module come from?** `getModulePath()` answers with a path,
which is what a person reads and not what a program acts on: a wheel and a
directory of overrides are both directories under `site-packages`, and a corpus
is not a path in that sense at all.

**What else could have answered?** A module carried by two sources resolves from
one of them and the other is passed over silently. That is deliberate as often
as it is a leftover `.py` that a corpus was meant to replace — and the two are
indistinguishable until something reports them. A leftover `.py` outranks the
corpus, so the corpus is the copy being skipped, which is the opposite of what
adding one usually means.

## What is added

`getModuleProvenance(modName)` → `(kind, source_id)`. Kinds are `override`
(pysnmp's own copies of the engine MIBs), `wheel`, `dir`, `pkg`, `db`,
`compiled`; the id tells a distro corpus from a customer one. Tracked per module,
not per node — a module resolves from exactly one source, so per-node would
repeat one answer across every OID in it. A corpus-built module names the corpus
that owned it, never the composite it was reached through.

`shadowedModules()` → every module more than one source carries. Name-level
only, deliberately: answering whether two copies *differ* means reading and
normalizing both, which is the work a corpus exists to avoid. It reports that a
second copy exists and will be passed over, and never claims the copies match or
differ.

`reportShadowedModules()` says it out loud, once per builder, at
`moduleConflictSeverity`:

| | |
|---|---|
| `warn` (default) | one `PySnmpShadowedModuleWarning` per module |
| `error` | `SmiError` before anything is loaded — for a deployment that has finished migrating off `.py` |
| `silent` | says nothing, still returns the answer |

It runs by itself inside `loadModules()` called with no names, since that path
already enumerates every source and the enumeration is the whole cost. Loading
by name does not trigger it. Corpora carrying the same module are counted
separately, because a redundant corpus costs memory and buys nothing and at that
scale the per-module lines are too many to read.

## The one thing it stays quiet about

Every stock install shadows seven modules: pysnmp carries its own copies of the
engine MIBs and searches them ahead of the wheel's, which is exactly what
`defaultCoreMibs` is for. Reporting it would mean the default install warns
about an arrangement pysnmp made itself. `FRAMEWORK_SHADOW` excludes that one
combination from the report — and only from the report, since `shadowedModules()`
is a question about the sources rather than about the configuration.

Tested as carefully as the reporting is: `test_a_stock_install_says_nothing`
runs with `simplefilter("error")`.

## Also

A `ZipMibSource` that hands back a `DirMibSource` substitute for an ordinary
install now passes its kind and id along. Which of them serves a package is an
installation detail, and provenance that changed with it would report `dir` for
the same wheel a zip install reports `wheel` for.

## Checks

- ruff check, ruff format, mypy (147 files) clean
- `sphinx-build -n -W` clean, with two new sections in `mib-corpus.rst`
- 1391 passed, 17 skipped — 26 new

## Left on #144

`MibStore` ABC, `DbMibSource`, the OID cache-miss hook, and `PYSNMP_MIB_SOURCES`.