### PR TITLE
feat(smi): resolve an unknown OID by loading the module a corpus names

### DIFF
--- a/docs/source/docs/mib-corpus.rst
+++ b/docs/source/docs/mib-corpus.rst
@@ -263,6 +263,46 @@ calling ``loadModules()`` on whatever it named. That pattern works and is not
 going away yet, but it needs a second file, a full ASN.1 compile per module on
 the trap path, and it cannot answer either of the questions above.
 
+Without asking the corpus yourself
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A receiver that decodes through ``ObjectIdentity`` or ``MibViewController``
+does not have to do any of that. When a lookup runs out of MIB and a corpus is
+configured, the view asks the corpus which module owns the OID, loads it, and
+resolves again:
+
+.. code-block:: python
+
+   builder.setMibCorpus(MibCorpus("/mibs/core.db"))
+   mibView = MibViewController(builder)
+
+   # ACME-MIB has not been loaded, and nothing asked for it.
+   mibView.getNodeNameByOid((1, 3, 6, 1, 4, 1, 9999, 2, 1, 9, 1, 2, 3))
+   # -> ((1,3,6,1,4,1,9999,2,1,9), ('iso',...,'acmeDescr'), (1, 2, 3))
+
+Before this, the same call answered with ``enterprises`` and seven raw arcs:
+the corpus held the answer, was configured, and was never consulted.
+
+Two things keep it off the hot path.
+
+**Only where a module could be.** The longest known prefix is what a lookup
+resolves to, so an unknown vendor OID and an ordinary instance OID both come
+back with a suffix. They are told apart by what the prefix resolved to: below a
+scalar, table, row or column the remaining arcs are instance arcs and no module
+could claim them, so the corpus is not asked. Below a bare registration point
+-- ``enterprises``, ``mib-2``, an unloaded vendor subtree -- they are
+unregistered territory, and it is. A walk of ten thousand instance OIDs asks
+nothing.
+
+**Once per OID.** An OID the corpus cannot place is remembered, so a receiver
+hearing the same unknown trap every thirty seconds asks once. Giving the
+builder a different corpus discards that record.
+
+The module-scoped form, ``getNodeNameByOid(oid, "ACME-MIB")``, is unaffected:
+that asks what one module says about an OID, and loading a different one cannot
+answer it. Agent instrumentation is unaffected too -- what an agent serves is
+what it was configured to serve, and a corpus does not add to it.
+
 
 What a corpus does not carry
 ----------------------------

--- a/pysnmp/smi/view.py
+++ b/pysnmp/smi/view.py
@@ -34,6 +34,20 @@ class MibViewController:
         self.lastBuildId = -1
         self.__mibSymbolsIdx = OrderedDict()
 
+        # OIDs a corpus has already been asked about and could not place, so
+        # that a receiver hearing the same unknown trap every thirty seconds
+        # asks once rather than every time. Bounded by the number of distinct
+        # unresolvable prefixes a deployment actually sees, which is small.
+        # Discarded when the builder is given a different corpus, since the
+        # answer may well have changed.
+        self.__corpusMisses = set()
+        self.__corpusSeen = None
+
+        # Resolved lazily, and only on the path that needs it -- importing a
+        # symbol here would load SNMPv2-SMI when the controller is built,
+        # which nothing else about it requires.
+        self.__objectType = None
+
     # Indexing part
 
     def indexMib(self):
@@ -42,6 +56,14 @@ class MibViewController:
         Every lookup calls this first, so the builder's build counter is what keeps it
         from re-indexing on each one.
         """
+        # A different corpus may well place an OID this one could not, so the
+        # record of what it could not place does not outlive it.
+        corpus = self.mibBuilder.getMibCorpus()
+
+        if corpus is not self.__corpusSeen:
+            self.__corpusSeen = corpus
+            self.__corpusMisses.clear()
+
         if self.lastBuildId == self.mibBuilder.lastBuildId:
             return
 
@@ -210,13 +232,121 @@ class MibViewController:
             return resOid, oidToLabelIdx[resOid], ()
         return oid, label, suffix
 
+    def __worthAskingCorpus(self, oid, label, suffix, mibMod):
+        """Whether an incomplete resolution is one a corpus could improve on.
+
+        `__getOidLabel` always answers with the longest prefix it knows, so a
+        miss is rarely total: an unknown vendor OID lands on ``enterprises``
+        with the rest as suffix, exactly as a legitimate instance OID lands on
+        its column. Telling those apart is what keeps this off the hot path.
+
+        What separates them is the node the prefix resolved to. Below an
+        `ObjectType` -- a scalar, a table, a row, a column -- the remaining
+        arcs are instance arcs, the MIB says nothing further about them and no
+        module could. Below a bare registration point -- `MibIdentifier`,
+        `ObjectIdentity`, and the arcs under an unloaded vendor subtree -- the
+        remaining arcs are unregistered territory, which is precisely where a
+        module the corpus carries would sit.
+
+        So a walk of ten thousand instance OIDs asks the corpus nothing, and
+        an OID under an unloaded subtree asks once.
+        """
+        if not suffix:
+            return False
+
+        if oid == label:
+            # Nothing resolved at all, so there is no node to classify.
+            return True
+
+        modName = mibMod["oidToModIdx"].get(oid)
+
+        if modName is None:
+            return True
+
+        if self.__objectType is None:
+            # ObjectType itself is not a symbol a MIB module exports, so the
+            # three exported classes that descend from it stand in for it.
+            # MibTableColumn is a MibScalar and needs no entry of its own.
+            self.__objectType = self.mibBuilder.importSymbols(
+                "SNMPv2-SMI", "MibScalar", "MibTable", "MibTableRow"
+            )
+
+        node = self.mibBuilder.mibSymbols.get(modName, {}).get(label[-1])
+
+        return not isinstance(node, self.__objectType)
+
+    def _corpusModuleFor(self, nodeName, modName):
+        """Load the module a corpus says answers for an OID, if one does.
+
+        The gap this closes: a corpus can resolve an arbitrary OID to a module
+        by longest prefix, but until now nothing asked it to. A trap naming a
+        module that is carried by the corpus and simply not loaded resolved to
+        nothing, and the receiver saw raw arcs.
+
+        Only for the merged view (``modName=""``). Asking a named module about
+        an OID it does not carry is a different question, and loading some
+        other module cannot answer it.
+
+        Only for OIDs. A label tuple is not something a corpus indexes, and
+        `getNodeName` reaches here with one on its way to trying the symbol
+        form.
+
+        Returns
+        -------
+            Whether a module was loaded, and so whether re-indexing and
+            retrying is worth it.
+        """
+        if modName:
+            return False
+
+        corpus = self.mibBuilder.getMibCorpus()
+
+        if corpus is None:
+            return False
+
+        try:
+            arcs = tuple(int(x) for x in nodeName)
+
+        except (TypeError, ValueError):
+            return False
+
+        if not arcs or arcs in self.__corpusMisses:
+            return False
+
+        # Recorded before the lookup, not after: a corpus that cannot place
+        # this OID cannot place it on the next trap either, and a module that
+        # fails to build should not be retried on every packet.
+        self.__corpusMisses.add(arcs)
+
+        found = corpus.find_module(arcs)
+
+        if found is None or found in self.mibBuilder.mibSymbols:
+            return False
+
+        try:
+            self.mibBuilder.loadModules(found)
+
+        except error.SmiError:
+            debug.logger & debug.flagMIB and debug.logger(
+                f"_corpusModuleFor: corpus named {found} for {arcs} but it "
+                f"could not be loaded"
+            )
+            return False
+
+        debug.logger & debug.flagMIB and debug.logger(
+            f"_corpusModuleFor: loaded {found} for {arcs} from the corpus"
+        )
+
+        return True
+
     def getNodeNameByOid(self, nodeName, modName=""):
         """Resolve an OID or a label to `(oid, label, suffix)`.
 
         An OID need not name an object exactly: the longest known prefix is what
         resolves, and the rest comes back as the suffix, which is how an instance under
         a column is named. An OID that resolves to nothing but itself is not in this
-        MIB view at all.
+        MIB view at all -- unless a corpus can say which module would have carried it,
+        in which case that module is loaded and the lookup is tried once more.
         """
         self.indexMib()
         if modName in self.__mibSymbolsIdx:
@@ -226,6 +356,14 @@ class MibViewController:
         oid, label, suffix = self.__getOidLabel(
             nodeName, mibMod["oidToLabelIdx"], mibMod["labelToOidIdx"]
         )
+        if self.__worthAskingCorpus(oid, label, suffix, mibMod) and (
+            self._corpusModuleFor(nodeName, modName)
+        ):
+            self.indexMib()
+            mibMod = self.__mibSymbolsIdx[modName]
+            oid, label, suffix = self.__getOidLabel(
+                nodeName, mibMod["oidToLabelIdx"], mibMod["labelToOidIdx"]
+            )
         if oid == label:
             raise error.NoSuchObjectError(
                 str=f"Can't resolve node name {modName}::{nodeName} at {self}"

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1074,6 +1074,182 @@ class TestTrapPath:
         assert left["syntax"] is right["syntax"]
 
 
+class TestViewResolvesFromTheCorpus:
+    """The other half of the trap path: the view, not the corpus.
+
+    `MibCorpus.find_module` could always place an arbitrary OID, and nothing
+    called it. A receiver decoding a trap goes through `MibViewController`,
+    which answers out of what the builder has loaded -- so an OID belonging to
+    a module the corpus carries and nobody asked for resolved to nothing, and
+    the trap was reported as raw arcs. The corpus was configured, held the
+    answer, and was never consulted.
+    """
+
+    @pytest.fixture
+    def mibView(self, corpus):
+        from pysnmp.smi.view import MibViewController
+
+        built = MibBuilder()
+        built.setMibCorpus(corpus)
+
+        return MibViewController(built)
+
+    #: An instance OID under a column of FIXTURE-MIB: column OID plus index
+    #: arcs, which is the shape a trap actually carries and appears in no MIB.
+    INSTANCE = (1, 3, 6, 1, 4, 1, 99999, 2, 1, 9, 1, 2, 3)
+
+    def test_an_oid_of_an_unloaded_module_pulls_the_module_in(self, mibView):
+        oid, label, suffix = mibView.getNodeNameByOid(self.INSTANCE)
+
+        assert label[-1] == "fixtureDescr"
+        assert oid == (1, 3, 6, 1, 4, 1, 99999, 2, 1, 9)
+        assert suffix == (1, 2, 3)
+        assert "FIXTURE-MIB" in mibView.mibBuilder.mibSymbols
+
+    def test_without_a_corpus_the_oid_stops_at_the_last_known_arc(self):
+        """What the receiver saw before this: the enterprise arc and raw numbers.
+
+        `__getOidLabel` answers with the longest prefix it knows, so an OID
+        under an unloaded vendor subtree is not an error -- it resolves to
+        ``enterprises`` and hands back the rest. That is a decoded trap with
+        no object name in it, which is the defect, and it is not visible as a
+        failure anywhere.
+        """
+        from pysnmp.smi.view import MibViewController
+
+        mibView = MibViewController(MibBuilder())
+
+        _oid, label, suffix = mibView.getNodeNameByOid(self.INSTANCE)
+
+        assert label[-1] == "enterprises"
+        assert suffix == (99999, 2, 1, 9, 1, 2, 3)
+        assert "FIXTURE-MIB" not in mibView.mibBuilder.mibSymbols
+
+    def test_an_oid_no_corpus_claims_is_left_where_it_was(self, mibView):
+        _oid, label, suffix = mibView.getNodeNameByOid((1, 3, 6, 1, 4, 1, 1, 1))
+
+        assert label[-1] == "enterprises"
+        assert suffix == (1, 1)
+
+    def test_an_instance_oid_of_a_loaded_module_asks_nothing(self, mibView, corpus):
+        """The hot path, and the reason the classification exists.
+
+        Every varbind in a walk resolves to a scalar or a column with index
+        arcs left over. Taking each of those to the corpus would mean a query
+        per varbind, chopping an arc at a time, for an answer that is always
+        the module already loaded.
+        """
+        mibView.mibBuilder.loadModules("SNMPv2-MIB")
+
+        asked = []
+        original = corpus.find_module
+        corpus.find_module = lambda oid: asked.append(oid) or original(oid)
+
+        try:
+            # sysDescr.0 -- a scalar plus its instance arc.
+            _oid, label, suffix = mibView.getNodeNameByOid((1, 3, 6, 1, 2, 1, 1, 1, 0))
+
+        finally:
+            corpus.find_module = original
+
+        assert label[-1] == "sysDescr"
+        assert suffix == (0,)
+        assert asked == []
+
+    def test_an_unplaceable_oid_is_asked_about_once(self, mibView, corpus):
+        """A receiver hearing the same unknown trap every thirty seconds.
+
+        The corpus answering ``None`` is the expensive case -- `find_module`
+        chops an arc and queries again for every arc in the OID -- and it is
+        also the case that repeats, since nothing about it will change until
+        the corpus does.
+        """
+        asked = []
+        original = corpus.find_module
+        corpus.find_module = lambda oid: asked.append(oid) or original(oid)
+
+        try:
+            for _ in range(3):
+                mibView.getNodeNameByOid((1, 3, 6, 1, 4, 1, 1, 1))
+
+        finally:
+            corpus.find_module = original
+
+        assert len(asked) == 1
+
+    def test_a_label_is_not_taken_to_the_corpus(self, mibView, corpus):
+        """`getNodeName` arrives here with a symbol tuple on its way past.
+
+        It is not an OID and a corpus indexes nothing by it, so asking would
+        be a query per resolution failure that could never succeed.
+        """
+        asked = []
+        original = corpus.find_module
+        corpus.find_module = lambda oid: asked.append(oid) or original(oid)
+
+        try:
+            with pytest.raises(error.NoSuchObjectError):
+                mibView.getNodeNameByOid(("fixtureScalar",))
+
+        finally:
+            corpus.find_module = original
+
+        assert asked == []
+
+    def test_a_named_module_is_not_answered_from_a_different_one(self, mibView):
+        """Asking FIXTURE-MIB about an OID is not asking who owns the OID.
+
+        The module-scoped view is a question about one module, and loading
+        some other module cannot answer it -- so the miss stands, and it
+        stands as the error that says the module is not in this view.
+        """
+        with pytest.raises(error.SmiError):
+            mibView.getNodeNameByOid(self.INSTANCE, "FIXTURE-MIB")
+
+    def test_a_new_corpus_gets_asked_again(self, mibView, corpus_path):
+        """What one corpus could not place, another may.
+
+        Replacing the corpus is the deployment saying the answer has changed,
+        so the record of what the old one could not answer does not survive
+        it.
+        """
+        unknown = (1, 3, 6, 1, 4, 1, 1, 1)
+
+        mibView.getNodeNameByOid(unknown)
+
+        replacement = MibCorpus(corpus_path)
+        mibView.mibBuilder.setMibCorpus(replacement)
+
+        asked = []
+        original = replacement.find_module
+        replacement.find_module = lambda oid: asked.append(oid) or original(oid)
+
+        try:
+            mibView.getNodeNameByOid(unknown)
+
+        finally:
+            replacement.find_module = original
+            replacement.close()
+
+        assert asked == [unknown]
+
+    def test_a_module_that_will_not_build_leaves_the_oid_where_it_was(
+        self, mibView, corpus
+    ):
+        """The corpus names a module and loading it then fails.
+
+        The caller gets the resolution it would have got without a corpus,
+        rather than whatever synthesis raised -- otherwise every consumer of
+        `getNodeNameByOid` has to handle corpus-build failures.
+        """
+        corpus.find_module = lambda oid: "NO-SUCH-MODULE-IN-THE-CORPUS"
+
+        _oid, label, _suffix = mibView.getNodeNameByOid(self.INSTANCE)
+
+        assert label[-1] == "enterprises"
+        assert "NO-SUCH-MODULE-IN-THE-CORPUS" not in mibView.mibBuilder.mibSymbols
+
+
 class TestCompositeResolution:
     """Two corpora searched as one, and the rule that decides which answers.
 


### PR DESCRIPTION
One of the remaining stories on #144: `find_module()` could always place an arbitrary OID, and nothing called it.

A receiver decoding a trap goes through `MibViewController`, which answers out of what the builder has loaded. An OID belonging to a module the corpus carries and nobody asked for resolved to the longest arc the view did know — `enterprises`, then raw numbers. The corpus was configured, held the answer, and was never consulted.

```python
builder.setMibCorpus(MibCorpus("/mibs/core.db"))
mibView = MibViewController(builder)

# ACME-MIB has not been loaded, and nothing asked for it.
mibView.getNodeNameByOid((1, 3, 6, 1, 4, 1, 9999, 2, 1, 9, 1, 2, 3))
# before -> (..., ('iso', ..., 'enterprises'), (9999, 2, 1, 9, 1, 2, 3))
# after  -> (..., ('iso', ..., 'acmeDescr'),   (1, 2, 3))
```

## Keeping it off the hot path

The longest known prefix is what every lookup resolves to, so a miss is rarely total: an unknown vendor OID and an ordinary instance OID both come back with a suffix.

They are told apart by the node the prefix resolved to. Below an `ObjectType` — scalar, table, row, column — the remaining arcs are instance arcs and no module could claim them. Below a bare registration point (`enterprises`, `mib-2`, an unloaded vendor subtree) they are unregistered territory. **A walk of ten thousand instance OIDs asks the corpus nothing.**

Then once per OID: what the corpus could not place is remembered, so a receiver hearing the same unknown trap every thirty seconds asks once. Handing the builder a different corpus discards that record.

## Deliberately not covered

- **The module-scoped form.** `getNodeNameByOid(oid, "ACME-MIB")` asks what one module says about an OID; loading some other module cannot answer it.
- **Label tuples.** `getNodeName()` passes through here on its way to trying the symbol form, and a corpus indexes nothing by them.
- **Agent instrumentation.** What an agent serves is what it was configured to serve. Pulling modules in on a GET would let a manager decide which OIDs an agent answers for.

A module the corpus names but cannot build leaves the caller with the resolution it would have had without a corpus, rather than whatever synthesis raised.

## Verification

9 new tests, including the two that pin the cost: an instance OID of a loaded module asks nothing, an unplaceable OID asks once across three lookups. Full suite 1349 passed / 12 skipped; ruff, mypy (147 files), sphinx `-n -W` clean.

Refs #144