### PR TITLE
feat(smi): read PYSNMP_MIB_SOURCES for where the ASN.1 is

### DIFF
--- a/docs/source/docs/mib-corpus.rst
+++ b/docs/source/docs/mib-corpus.rst
@@ -316,6 +316,27 @@ compiler.
 So a corpus cannot satisfy ``loadTexts``. What happens when it is asked to
 depends on whether anything else can.
 
+Saying where the ASN.1 is
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``PYSNMP_MIB_SOURCES`` is the compile-side counterpart of ``PYSNMP_MIB_DIRS``
+and ``PYSNMP_MIB_DBS``: where a compiler looks for the ASN.1 it renders.
+
+.. code-block:: shell
+
+   PYSNMP_MIB_SOURCES=/opt/vendor/mibs:https://mibs.example.org/asn1
+
+It is read by ``addMibCompiler()`` and so is only meaningful with the
+``[compile]`` extra installed. Set, it **replaces** the two shipped defaults
+(``/usr/share/snmp/mibs`` and ``/usr/share/mibs``) rather than adding to them --
+the rule ``PYSNMP_MIB_DIRS`` already follows, and the one that lets a container
+image state where its MIBs are without also searching two host paths that do
+not exist in it. An explicit ``sources=`` argument still wins.
+
+Entries may be directories, ``.zip`` archives or URLs; a URL keeps its scheme
+even though ``os.pathsep`` is the same colon that follows it.
+
+
 Corpus for speed, compiler for prose
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pysnmp/smi/compiler.py
+++ b/pysnmp/smi/compiler.py
@@ -9,11 +9,76 @@ pysmi is an optional dependency: install `pysnmplib[compile]` to get it.
 Without it `addMibCompiler` raises `SmiError` naming the missing import.
 """
 
+import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
 
 defaultSources = ["file:///usr/share/snmp/mibs", "file:///usr/share/mibs"]
+
+#: Where to look for ASN.1 to compile, as `os.pathsep`-separated entries.
+#:
+#: The compile-side counterpart of `PYSNMP_MIB_DIRS` and `PYSNMP_MIB_DBS`,
+#: which name generated `.py` and corpora respectively. Only meaningful with
+#: the `[compile]` extra installed, since without pysmi nothing compiles.
+#:
+#: Set, it replaces `defaultSources` rather than adding to it -- the same rule
+#: `PYSNMP_MIB_DIRS` follows, and the one that lets a container image say where
+#: its MIBs are without inheriting two paths from the host distribution that do
+#: not exist in it. An explicit ``sources=`` still wins: a caller who passed a
+#: value meant it.
+SOURCES_ENV = "PYSNMP_MIB_SOURCES"
+
+#: A URL scheme at the start of an entry, so that splitting does not cut
+#: ``https://example.org/mibs`` in half on POSIX, where `os.pathsep` is the
+#: colon that follows the scheme. A scheme is never a single character -- that
+#: is a Windows drive letter, which pysmi's reader factory already recognises
+#: as a local path.
+_SCHEME = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]+$")
+
+
+def sourcesFromEnvironment(value: "str | None" = None) -> "list[str] | None":
+    """The ASN.1 sources named by `PYSNMP_MIB_SOURCES`, or ``None`` if unset.
+
+    Args:
+        value: the raw variable, read from the environment when not given.
+            Passed in by the tests, which have no business editing `os.environ`
+            for something this small.
+
+    Returns
+    -------
+        The entries in the order they were written, or ``None`` where the
+        variable is unset or holds nothing but separators -- which is not the
+        same as an empty list, and has to stay distinguishable from it, since
+        an empty list would mean "compile from nowhere".
+    """
+    if value is None:
+        value = os.environ.get(SOURCES_ENV)
+
+    if value is None:
+        return None
+
+    parts = value.split(os.pathsep)
+    sources: list[str] = []
+
+    for part in parts:
+        # A bare scheme followed by an entry starting "//" is one URL that the
+        # split cut at its colon; put it back together.
+        if (
+            sources
+            and part.startswith("//")
+            and _SCHEME.match(sources[-1])
+            and os.pathsep == ":"
+        ):
+            sources[-1] = f"{sources[-1]}:{part}"
+            continue
+
+        if part:
+            sources.append(part)
+
+    return sources or None
+
 
 if sys.platform[:3] == "win":
     defaultDest = str(Path.home() / "PySNMP Configuration" / "mibs")
@@ -59,6 +124,9 @@ else:
         Without pysmi installed this raises `SmiError` naming the missing import,
         unless `ifAvailable` is set. `ifNotAdded` makes the call a no-op where a
         compiler is already attached.
+
+        Where to compile from is settled in three steps: an explicit
+        ``sources=``, then `PYSNMP_MIB_SOURCES`, then `defaultSources`.
         """
         if kwargs.get("ifNotAdded") and mibBuilder.getMibCompiler():
             return
@@ -70,7 +138,9 @@ else:
         )
 
         compiler.add_sources(
-            *getReadersFromUrls(*kwargs.get("sources") or defaultSources)
+            *getReadersFromUrls(
+                *kwargs.get("sources") or sourcesFromEnvironment() or defaultSources
+            )
         )
 
         compiler.add_searchers(StubSearcher(*baseMibs))

--- a/tests/test_compiler_sources.py
+++ b/tests/test_compiler_sources.py
@@ -1,0 +1,228 @@
+"""Where the compiler looks for ASN.1, and how the environment says so.
+
+`PYSNMP_MIB_SOURCES` is the compile-side counterpart of `PYSNMP_MIB_DIRS` and
+`PYSNMP_MIB_DBS`: generated `.py`, corpora, and now the ASN.1 a compiler renders
+from. A container image can say where its MIBs are without inheriting two paths
+from the host distribution that do not exist in it.
+
+The awkward part is the separator. `os.pathsep` is a colon on POSIX, and a
+colon is also what follows a URL scheme -- so a naive split turns one
+``https://example.org/mibs`` into ``https`` and ``//example.org/mibs``, and
+pysmi is handed a scheme it does not know plus a path that does not exist. That
+is what most of this file is about.
+"""
+
+import os
+
+import pytest
+
+from pysnmp.smi.compiler import SOURCES_ENV, defaultSources, sourcesFromEnvironment
+
+POSIX = os.pathsep == ":"
+
+
+class TestUnset:
+    """Unset has to stay distinguishable from set-to-nothing."""
+
+    def test_unset_is_none(self):
+        assert sourcesFromEnvironment(None) is None
+
+    def test_empty_is_none_not_an_empty_list(self):
+        """``PYSNMP_MIB_SOURCES=`` means nothing was said, not "compile from nowhere".
+
+        An empty list would be a truthy-falsy trap in `addMibCompiler`, where
+        the three-step fallback is ``sources= or environment or defaults``: a
+        list that is empty falls through to the defaults anyway, and returning
+        one would only make the intent harder to read.
+        """
+        assert sourcesFromEnvironment("") is None
+
+    def test_nothing_but_separators_is_none(self):
+        assert sourcesFromEnvironment(os.pathsep * 3) is None
+
+
+class TestPaths:
+    """The ordinary case: directories."""
+
+    def test_one_directory(self):
+        assert sourcesFromEnvironment("/mibs") == ["/mibs"]
+
+    def test_order_is_kept(self):
+        value = os.pathsep.join(("/first", "/second", "/third"))
+
+        assert sourcesFromEnvironment(value) == ["/first", "/second", "/third"]
+
+    def test_empty_entries_are_dropped(self):
+        value = os.pathsep.join(("", "/mibs", "", "/more", ""))
+
+        assert sourcesFromEnvironment(value) == ["/mibs", "/more"]
+
+    def test_a_relative_path_is_left_alone(self):
+        """pysmi's reader factory takes a bare path as a local one.
+
+        Resolving it here would mean guessing what it is relative to, and the
+        answer is the working directory of whatever process reads the variable
+        -- which pysmi already applies.
+        """
+        assert sourcesFromEnvironment("mibs") == ["mibs"]
+
+
+@pytest.mark.skipif(not POSIX, reason="os.pathsep is not a colon on this platform")
+class TestUrlsOnPosix:
+    """The colon that is a separator and the colon that is part of a URL."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://example.org/mibs",
+            "https://example.org/mibs",
+            "file:///usr/share/snmp/mibs",
+            "zip://example.org/mibs.zip",
+        ],
+    )
+    def test_a_url_survives_the_split(self, url):
+        assert sourcesFromEnvironment(url) == [url]
+
+    def test_a_url_beside_a_directory(self):
+        value = os.pathsep.join(("https://example.org/mibs", "/mibs"))
+
+        assert sourcesFromEnvironment(value) == [
+            "https://example.org/mibs",
+            "/mibs",
+        ]
+
+    def test_a_directory_beside_a_url(self):
+        value = os.pathsep.join(("/mibs", "https://example.org/mibs"))
+
+        assert sourcesFromEnvironment(value) == [
+            "/mibs",
+            "https://example.org/mibs",
+        ]
+
+    def test_two_urls(self):
+        value = os.pathsep.join(
+            ("https://example.org/mibs", "http://mirror.example.org/mibs")
+        )
+
+        assert sourcesFromEnvironment(value) == [
+            "https://example.org/mibs",
+            "http://mirror.example.org/mibs",
+        ]
+
+    def test_the_defaults_survive_a_round_trip(self):
+        """The shipped defaults are `file://` URLs, so they are the case to check."""
+        assert sourcesFromEnvironment(os.pathsep.join(defaultSources)) == list(
+            defaultSources
+        )
+
+    def test_a_single_letter_is_not_a_scheme(self):
+        """A Windows drive letter, which pysmi's reader factory takes as a path.
+
+        Rejoining ``c`` with what follows would turn ``c:\\mibs`` into a URL
+        with a one-character scheme, which is exactly the reading pysmi went
+        out of its way to avoid.
+        """
+        value = os.pathsep.join(("c", "//mibs"))
+
+        assert sourcesFromEnvironment(value) == ["c", "//mibs"]
+
+    def test_a_bare_double_slash_is_not_glued_to_a_path(self):
+        """Only a scheme is rejoined, and ``/mibs`` is not one."""
+        value = os.pathsep.join(("/mibs", "//share/mibs"))
+
+        assert sourcesFromEnvironment(value) == ["/mibs", "//share/mibs"]
+
+
+class TestPrecedence:
+    """Explicit beats environment beats default, and the environment is read late."""
+
+    def test_the_environment_is_read_when_no_value_is_passed(self, monkeypatch):
+        monkeypatch.setenv(SOURCES_ENV, "/from-the-environment")
+
+        assert sourcesFromEnvironment() == ["/from-the-environment"]
+
+    def test_an_unset_environment_reads_as_none(self, monkeypatch):
+        monkeypatch.delenv(SOURCES_ENV, raising=False)
+
+        assert sourcesFromEnvironment() is None
+
+    def test_it_replaces_the_defaults_rather_than_adding_to_them(self, monkeypatch):
+        """The rule `PYSNMP_MIB_DIRS` already follows.
+
+        An image that states where its MIBs are should not also be searching
+        two host paths that do not exist in it -- and a deployment that wants
+        both can say both, which it cannot do the other way round.
+        """
+        monkeypatch.setenv(SOURCES_ENV, "/only-here")
+
+        found = sourcesFromEnvironment()
+
+        assert found == ["/only-here"]
+        assert not set(found) & set(defaultSources)
+
+
+class TestReachesTheCompiler:
+    """The variable is worth nothing if `addMibCompiler` does not read it."""
+
+    def _readers(self, mibBuilder):
+        """What the attached compiler will actually read from, as strings.
+
+        pysmi's readers have no public accessor and their ``str`` carries the
+        path, which is all this needs -- the question is whether the directory
+        arrived, not what class wraps it. (``repr`` does not: it is the default
+        object one.)
+        """
+        compiler = mibBuilder.getMibCompiler()
+
+        return [str(x) for x in compiler._sources]
+
+    def test_the_environment_directory_is_searched(self, monkeypatch, tmp_path):
+        from pysnmp.smi.builder import MibBuilder
+        from pysnmp.smi.compiler import addMibCompiler
+
+        directory = tmp_path / "asn1"
+        directory.mkdir()
+        monkeypatch.setenv(SOURCES_ENV, str(directory))
+
+        builder = MibBuilder()
+        addMibCompiler(builder)
+
+        assert any(str(directory) in x for x in self._readers(builder))
+
+    def test_an_explicit_argument_wins(self, monkeypatch, tmp_path):
+        """A caller who passed ``sources=`` meant it.
+
+        The environment is how a deployment states a default; an argument is a
+        program stating a requirement, and the two disagreeing means the
+        program is right.
+        """
+        from pysnmp.smi.builder import MibBuilder
+        from pysnmp.smi.compiler import addMibCompiler
+
+        fromEnv = tmp_path / "environment"
+        fromArg = tmp_path / "argument"
+        fromEnv.mkdir()
+        fromArg.mkdir()
+
+        monkeypatch.setenv(SOURCES_ENV, str(fromEnv))
+
+        builder = MibBuilder()
+        addMibCompiler(builder, sources=[str(fromArg)])
+
+        readers = self._readers(builder)
+
+        assert any(str(fromArg) in x for x in readers)
+        assert not any(str(fromEnv) in x for x in readers)
+
+    def test_unset_leaves_the_shipped_defaults(self, monkeypatch):
+        from pysnmp.smi.builder import MibBuilder
+        from pysnmp.smi.compiler import addMibCompiler
+
+        monkeypatch.delenv(SOURCES_ENV, raising=False)
+
+        builder = MibBuilder()
+        addMibCompiler(builder)
+
+        readers = self._readers(builder)
+
+        assert len(readers) == len(defaultSources)


### PR DESCRIPTION
The last of the configuration stories on #144.

`PYSNMP_MIB_DIRS` names generated `.py`, `PYSNMP_MIB_DBS` names corpora, and nothing named the ASN.1 a compiler renders from — so a deployment that had to move it said so in code, or shipped it to one of the two paths pysnmp was built expecting.

```shell
PYSNMP_MIB_SOURCES=/opt/vendor/mibs:https://mibs.example.org/asn1
```

Read by `addMibCompiler()`, so only meaningful with the `[compile]` extra.

## Replaces rather than extends

Set, it replaces `defaultSources` — the rule `PYSNMP_MIB_DIRS` already follows, and the one that lets a container image state where its MIBs are without also searching two host paths that do not exist in it. A deployment wanting both can name both; it cannot subtract the other way round. An explicit `sources=` still wins, because a caller who passed one meant it.

## The separator

`os.pathsep` is a colon on POSIX, and a colon is also what follows a URL scheme — so a plain split turns one `https://example.org/mibs` into a scheme pysmi does not know plus a path that does not exist. An entry beginning `//` whose predecessor is a bare scheme is rejoined to it. Two characters minimum: a one-character scheme is a Windows drive letter, which pysmi's reader factory already goes out of its way to read as a local path.

Unset stays distinguishable from set-to-empty — the function answers `None` rather than `[]`, so the three-step fallback (`sources=` → environment → defaults) reads as what it is.

## Verification

23 tests, including every shipped default surviving a round trip through the splitter, and the end-to-end check that the directory reaches the compiler's readers. Full suite 1372 passed / 12 skipped; ruff, mypy (147 files), sphinx `-n -W` clean.

Refs #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring ASN.1 MIB compile sources through the `PYSNMP_MIB_SOURCES` environment variable.
  * Sources can be directories, ZIP archives, or URLs, with URL formats preserved correctly.
  * Explicitly provided sources take precedence over environment and default sources.

* **Documentation**
  * Added guidance on configuring compile-time MIB locations, supported source types, precedence, and environment-variable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->