### PR TITLE
fix(smi): rank a contested arc by the corpus rule, not by revision alone

### DIFF
--- a/docs/source/docs/mib-corpus.rst
+++ b/docs/source/docs/mib-corpus.rst
@@ -114,17 +114,40 @@ then, rather than being skipped: a skipped corpus leaves a deployment resolving
 fewer modules than it asked for, and the only symptom is a MIB that used to be
 found and now is not.
 
-**The newest MODULE-IDENTITY revision wins; configured order only breaks the
-tie.** This is the rule ``MibBuilder`` already applies to two MIB sources
-carrying one module, and the rule pysmi's compiler applies to two copies of one
-MIB, applied here to corpora. Two corpora carrying a module are carrying the
-same specification at two revisions, and the newer one is the answer wherever
-it sits in the search path -- so configuring a corpus that happens to carry an
-older copy cannot silently roll that module back.
+**Two corpora carrying the same module: the newest MODULE-IDENTITY revision
+wins, and configured order only breaks the tie.** This is the rule
+``MibBuilder`` already applies to two MIB sources carrying one module, and the
+rule pysmi's compiler applies to two copies of one MIB. Two corpora carrying a
+module are carrying the same specification at two revisions, and the newer one
+is the answer wherever it sits in the search path -- so configuring a corpus
+that happens to carry an older copy cannot silently roll that module back.
 
 Order settles what revisions cannot: when a candidate states no revision at all
 -- every SMIv1 module, and the SMI modules themselves -- or when they all state
 the same one.
+
+**Two corpora anchoring one arc with different modules: the corpus rule.** That
+is a different question, and appealing to revision alone answers it badly. A
+vendor tree bundles its own copy of a standard MIB, so an operator adding a
+vendor corpus has two corpora anchoring the same arcs -- and the vendor copy,
+republished last week, would take the arc from the standard definition of it.
+
+So the arc is ranked the way pysmi's ``rank_index`` ranks it *inside* a corpus,
+as far as a corpus carries the terms:
+
+1. a live module before one whose every object is obsolete,
+2. then tier -- ``standard``, then ``draft``, then ``vendor``,
+3. then the newest revision, an undated module losing outright,
+4. then the module name, so that the rule is total.
+
+Two of pysmi's terms are missing: how strongly a module claims the arc
+(MODULE-IDENTITY over OBJECT-IDENTITY) is settled at build time and not carried
+into the corpus, and the publishing RFC number is not a corpus column at all. A
+contest turning on either falls through to the module name.
+
+The rule is total and reads nothing about the search path, so unlike the
+same-module case, **configured order plays no part here**: reordering
+``PYSNMP_MIB_DBS`` cannot change which module owns an arc.
 
 **By OID, the longest prefix wins first.** Given a site subtree under an arc the
 core corpus already anchors, first-match-wins would resolve every OID beneath it

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -53,15 +53,31 @@ from typing import Any, Final, Union
 from pysnmp.smi import error
 
 __all__ = [
+    "OBJECT_CLASSES",
+    "TIERS",
     "CompositeMibCorpus",
     "MibCorpus",
     "MibCorpusCycleError",
+    "best_by_corpus_rank",
     "best_by_revision",
     "oid_from_key",
     "oid_key",
     "open_corpora",
+    "revision_rank",
     "subtree_bound",
 ]
+
+#: Where a namespace ranks when two modules from different ones claim an arc,
+#: best first. pysmi's ``namespace.TIERS``, which is where the order is
+#: settled; repeated rather than imported because pysmi is optional and this
+#: module is on the no-compiler path.
+TIERS: Final[tuple[str, ...]] = ("standard", "draft", "vendor")
+
+#: Node classes that count as objects when asking whether a module is wholly
+#: obsolete. A module's registration points staying current while every object
+#: under them is obsolete does not make it a live module. pysmi's
+#: ``index.OBJECT_CLASSES``.
+OBJECT_CLASSES: Final[tuple[str, ...]] = ("objecttype", "notificationtype")
 
 
 class MibCorpusCycleError(error.SmiError):
@@ -244,6 +260,42 @@ def best_by_revision(candidates: "list[tuple[Any, str | None]]") -> Any:
     # max() returns the first maximal element, so candidates sharing the
     # newest revision keep the order they were configured in.
     return max(candidates, key=lambda pair: pair[1] or "")[0]
+
+
+def revision_rank(revision: "str | None") -> int:
+    """A MODULE-IDENTITY revision as a number that sorts newest first.
+
+    Args:
+        revision: the corpus ``module.revision`` column, ``YYYYMMDDHHMM``
+            followed by a ``Z``, or ``None``
+
+    Returns
+    -------
+        The negated stamp, so a later date sorts lower in a rule where lower
+        wins, and 0 for a module stating no revision -- which therefore sorts
+        after every module that states one. pysmi's ``index.revision_rank``.
+    """
+    if not revision or not revision[:12].isdigit():
+        return 0
+
+    return -int(revision[:12])
+
+
+def best_by_corpus_rank(candidates: "list[tuple[str, tuple[Any, ...]]]") -> str | None:
+    """The module that owns an arc, by the corpus rule, lower rank winning.
+
+    Args:
+        candidates: ``(module, rank)``, the rank as
+            :py:meth:`~pysnmp.smi.corpus.CompositeMibCorpus.rank_of` builds it
+
+    Returns
+    -------
+        The winning module name, or ``None`` for no candidates.
+    """
+    if not candidates:
+        return None
+
+    return min(candidates, key=lambda pair: pair[1])[0]
 
 
 class MibCorpus:
@@ -700,7 +752,7 @@ class MibCorpus:
 
 
 class CompositeMibCorpus:
-    """Several corpora searched as one, ranked by revision.
+    """Several corpora searched as one, ranked by the corpus rule.
 
     A deployment rarely has a single corpus. It has the distribution's, which
     covers the standard modules and whatever vendors were published with it,
@@ -708,13 +760,22 @@ class CompositeMibCorpus:
     nobody else ships. Both have to be readable at once, and which one answers
     has to be decided by a rule rather than by whichever was configured last.
 
-    One rule decides, and it is the one the rest of pysnmp and pysmi already
-    use: **the newest MODULE-IDENTITY revision wins, and configured order only
-    breaks the tie** -- :py:func:`best_by_revision`. Precedence by position
-    would make configuring a corpus that happens to carry an older copy of a
-    module a silent downgrade, which is the reason
-    :py:meth:`~pysnmp.smi.builder.MibBuilder._candidates` does not work that
-    way either.
+    **Two different questions, two rules.** Two corpora carrying *the same
+    module* carry one specification at two revisions, so the newest wins and
+    configured order only breaks the tie -- :py:func:`best_by_revision`, which
+    is what :py:meth:`~pysnmp.smi.builder.MibBuilder._candidates` does with two
+    MIB sources and what pysmi's ``PRECEDENCE_NEWEST_REVISION`` does with two
+    copies of one file. That is :py:meth:`owner`.
+
+    Two corpora anchoring one arc with *different modules* is not that
+    question. There is no shared specification and no symmetry to appeal to: a
+    wholly obsolete module is not an earlier draft of a live one, and a vendor
+    tree bundling its own copy of a standard MIB is not a later revision of it.
+    So the arc goes to pysmi's ``rank_index`` rule as far as a corpus carries
+    it -- ``(obsolete, tier, revision, name)``, :py:meth:`rank_of` -- which is
+    the same rule that decides the arc *inside* a corpus at build time. That is
+    :py:meth:`anchor`, and pysnmp/pysnmp#234 is where the two terms a corpus
+    cannot carry are recorded.
 
     **Both paths reach the same copy.** Resolving a name and resolving an OID
     are one question asked twice, so an OID is resolved to a module *name* and
@@ -727,9 +788,9 @@ class CompositeMibCorpus:
     ``enterprises.9`` resolves to the core corpus's anchor for
     ``enterprises.9`` and never reaches the customer corpus that anchors the
     subtree itself, no matter how the two are ordered. Every corpus is asked
-    at each prefix length before the OID is shortened; the revision rule
-    settles only what a shorter prefix cannot, which is two corpora naming
-    different modules at the *same* length.
+    at each prefix length before the OID is shortened; ranking settles only
+    what a shorter prefix cannot, which is two corpora naming different
+    modules at the *same* length.
 
     **One module resolves from exactly one corpus.** Where two carry the same
     module, every name-keyed lookup for it routes to the same one, and the
@@ -758,6 +819,11 @@ class CompositeMibCorpus:
         self._corpora: tuple[MibCorpus, ...] = tuple(corpora)
         self._modules: frozenset[str] | None = None
         self._owners: dict[str, MibCorpus | None] = {}
+
+        # Ranks are read once per module: the obsolete term costs a scan of
+        # every node the module declares, and a contested arc asks for the
+        # same handful of modules over and over.
+        self._ranks: dict[str, tuple[Any, ...]] = {}
 
     def __repr__(self) -> str:
         """The composite and what it was built from, in order."""
@@ -863,14 +929,76 @@ class CompositeMibCorpus:
 
         return owner.module(name) if owner else None
 
+    def rank_of(self, module: str) -> "tuple[Any, ...]":
+        """How a module ranks for an arc it registers, lower winning.
+
+        ``(obsolete, tier, revision, name)``: pysmi's ``index.module_rank``
+        less the two terms a corpus cannot supply.
+
+        A module whose every object is obsolete describes an arc nothing
+        should decode against, and republishing it later does not change that,
+        so obsolete ranks below live whatever the dates say. Tier then settles
+        the ordinary case this rule exists for: a vendor tree bundling its own
+        copy of a standard MIB does not take the arc from the standard
+        definition by having been republished more recently.
+
+        Two of pysmi's terms are missing and cannot be recovered here. How
+        strongly a module claims an arc -- MODULE-IDENTITY over
+        OBJECT-IDENTITY over neither -- is settled at build time and not
+        carried into ``oid_index``. The publishing RFC number is not a corpus
+        column at all. Both are noted in pysnmp/pysnmp#234; a contest that
+        turns on either falls through to the module name, which is arbitrary
+        but total.
+
+        Args:
+            module: the module's descriptor
+
+        Returns
+        -------
+            Its rank, comparable against any other module's.
+        """
+        if module not in self._ranks:
+            record = self.module(module) or {}
+            owner = self.owner(module)
+
+            statuses = [
+                node["status"]
+                for node in (owner.nodes_of(module) if owner else [])
+                if node["class"] in OBJECT_CLASSES
+            ]
+
+            obsolete = 1 if statuses and all(x == "obsolete" for x in statuses) else 0
+
+            tier = record.get("tier")
+            rank = TIERS.index(tier) if tier in TIERS else len(TIERS)
+
+            self._ranks[module] = (
+                obsolete,
+                rank,
+                revision_rank(record.get("revision")),
+                module,
+            )
+
+        return self._ranks[module]
+
     def anchor(self, oid: Union[str, "tuple[int, ...]"]) -> str | None:
         """Which module registers exactly this OID, across all corpora.
 
         Corpora usually agree, naming one module between them. Where they name
-        *different* modules for one OID the contest is settled the way every
-        other one here is, by :py:func:`best_by_revision` over those modules --
-        each read at the revision :py:meth:`owner` would give it, so the answer
-        does not depend on which corpus was asked.
+        *different* modules for one arc, the contest is the one pysmi's
+        ``rank_index`` settles inside a single corpus, so it is settled the
+        same way here: by :py:meth:`rank_of`, not by revision alone and not by
+        which corpus was configured first.
+
+        This is a different question from :py:meth:`owner`, which is asked of
+        two *copies of one module* and stays on
+        :py:func:`best_by_revision`. Two copies of one specification differ by
+        revision and nothing else, and configured order is a reasonable
+        fallback where the revisions cannot separate them. Two different
+        modules claiming one arc have no such symmetry: a wholly obsolete
+        module and a vendor module are not later drafts of the standard one,
+        and an undated module loses outright here rather than sending the
+        decision to order.
 
         Args:
             oid: the OID, matched as given
@@ -879,19 +1007,15 @@ class CompositeMibCorpus:
         -------
             The module name, or ``None``.
         """
-        candidates: list[tuple[str, str | None]] = []
         seen: set[str] = set()
 
         for corpus in self._corpora:
             found = corpus.anchor(oid)
 
-            if found is None or found in seen:
-                continue
+            if found is not None:
+                seen.add(found)
 
-            seen.add(found)
-            candidates.append((found, (self.module(found) or {}).get("revision")))
-
-        return best_by_revision(candidates)
+        return best_by_corpus_rank([(x, self.rank_of(x)) for x in seen])
 
     def find_module(self, oid: Union[str, "tuple[int, ...]"]) -> str | None:
         """Which module answers for an OID, by longest prefix across all corpora.

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1360,12 +1360,16 @@ class TestCompositeResolution:
     def test_a_deeper_anchor_wins_from_an_earlier_corpus_too(self, reversed_composite):
         assert reversed_composite.find_module(f"{PRIVATE_OID}.1.2") == "PRIVATE-MIB"
 
-    def test_equal_anchors_are_separated_by_order_when_undated(self, composite):
-        # SMIV1-MIB states no revision, so this contest cannot be decided on
-        # one and falls to configured order.
-        assert composite.find_module(f"{CONTESTED_OID}.1") == "SMIV1-MIB"
+    def test_an_undated_module_loses_the_arc_outright(self, composite):
+        # SMIV1-MIB states no revision. Inside one corpus that makes it lose
+        # to any module that does, and #234 made the composite agree: a
+        # corpus contest between two *different* modules is not the same
+        # question as two copies of one module, and has no configured order
+        # to fall back on.
+        assert composite.find_module(f"{CONTESTED_OID}.1") == "PRIVATE-MIB"
 
-    def test_equal_anchors_the_other_way_round(self, reversed_composite):
+    def test_it_loses_from_the_other_position_too(self, reversed_composite):
+        # The point of ranking rather than taking the first match.
         assert reversed_composite.find_module(f"{CONTESTED_OID}.1") == "PRIVATE-MIB"
 
     def test_equal_anchors_are_separated_by_revision_when_dated(

--- a/tests/test_precedence.py
+++ b/tests/test_precedence.py
@@ -40,9 +40,10 @@ consumer half (``pysnmp/pysmi#248``, pysnmp/pysnmp#232). What is asserted here:
 
     Running them also answered a question nobody had asked: how much of that
     rule survives a search across *several* corpora, where there is no build to
-    have ranked anything. Six of the seven vectors resolve differently there,
-    because the composite reads only the revision term. That is pysnmp/pysnmp#234,
-    and :py:class:`TestCrossCorpusDivergence` pins it rather than skipping it.
+    have ranked anything. Six of the seven vectors resolved differently, which
+    became pysnmp/pysnmp#234; the composite now applies the rule as far as a
+    corpus carries it, and :py:class:`TestCrossCorpusDivergence` holds the two
+    vectors that remain -- both turning on a term no corpus column records.
 
 The vectors ``why`` field is the failure message throughout, so a break says
 what decision was violated rather than which tuple did not match.
@@ -60,7 +61,7 @@ from pysmi.corpus.index import rank_index
 from pysmi.corpus.namespace import TIERS
 
 from pysnmp.smi.builder import MODULE_REVISION, MibBuilder, revisionOf
-from pysnmp.smi.corpus import MibCorpus, best_by_revision
+from pysnmp.smi.corpus import CompositeMibCorpus, MibCorpus, best_by_revision
 
 
 def _vectors(operation):
@@ -335,117 +336,106 @@ class TestCrossCorpusDivergence:
 
     Within one corpus the answer is pysmi's, computed over every module the
     build saw and stored in ``oid_index``. Across corpora there is no such
-    build: ``CompositeMibCorpus`` asks each corpus who anchors the arc and
-    ranks the answers with ``best_by_revision``, the module-name rule, because
-    revision is the only term it reads. Of the seven terms the corpus rule
-    turns on, six are therefore not applied between corpora, and the answers
-    differ -- a vendor corpus republished last week takes an arc from the
-    standard definition of it, which is the outcome within a corpus is
-    specifically ordered to prevent.
+    build, so ``CompositeMibCorpus`` has to rank the answers itself.
 
-    This is a gap, not a decision, and it is pysnmp/pysnmp#234. It is pinned
-    here rather than skipped so that the day it is closed, these assertions
-    fail and say so: an unasserted gap and a regression look identical.
+    Since pysnmp/pysnmp#234 it ranks them by the corpus rule rather than by
+    revision alone: ``(obsolete, tier, revision, name)``. Two of pysmi's seven
+    terms cannot be recovered from a corpus at all, and the vectors that turn
+    on those two are recorded below. Everything else now agrees.
     """
 
-    #: Every ``oid_precedence`` vector the composite answers differently, and
-    #: the term it turns on that the composite does not read. A vector added
-    #: later for a term the composite also cannot carry fails
+    #: The ``oid_precedence`` vectors a composite still answers differently,
+    #: and why the term cannot be read. A vector added later for a term the
+    #: composite also cannot carry fails
     #: :py:meth:`test_divergence_is_exactly_what_is_recorded` rather than
     #: passing unnoticed, and a term that starts being read fails it too.
     DIVERGES = {
-        "oid-obsolete-loses-to-live-however-new-it-is": (
-            "status: a module whose every object is obsolete describes an arc "
-            "nobody should decode against, and the composite reads no status"
-        ),
-        "oid-lower-tier-wins-over-a-newer-revision": (
-            "tier: the corpus module table carries one, and the composite "
-            "does not compare it -- so a vendor corpus outranks the standard "
-            "definition by being newer, which is the case that matters most"
-        ),
         "oid-module-identity-anchor-beats-object-identity": (
             "anchor class: how strongly a module claims the arc is settled at "
-            "build time and is not carried into oid_index"
+            "build time and is not carried into oid_index, so no reader can "
+            "recover it -- pysnmp/pysmi would have to add a column"
         ),
         "oid-higher-rfc-breaks-an-equal-revision": (
             "publishing RFC: not a corpus column at all, so no reader can "
             "apply this one"
         ),
-        "oid-module-name-makes-the-rule-total": (
-            "module name as final term: equal revisions fall to configured "
-            "order instead, so the answer is stable but is the caller's order "
-            "rather than the rule's"
-        ),
-        "oid-anchorless-module-loses-to-an-anchored-one": (
-            "undated candidate: within a corpus it loses, across corpora it "
-            "disables the comparison entirely, because a composite has the "
-            "configured order to fall back on and a corpus has nothing"
-        ),
     }
 
-    def _byRevisionOnly(self, vector):
-        """What the composite answers for a vector, ranking on revision alone."""
-        return best_by_revision(
-            [
-                (
-                    module["module"],
-                    module["document"].get("identity", {}).get("lastupdated"),
-                )
-                for module in vector["modules"]
-            ]
-        )
+    def _acrossCorpora(self, directory, vector):
+        """What a composite answers, with each module in a corpus of its own.
 
-    @pytest.mark.parametrize("vector", _vectors("oid_precedence"), ids=_identify)
-    def test_divergence_is_exactly_what_is_recorded(self, vector):
-        agrees = self._byRevisionOnly(vector) == vector["expect"]
-
-        assert agrees is (vector["id"] not in self.DIVERGES), (
-            f"{vector['id']}: across corpora this resolves to "
-            f"{self._byRevisionOnly(vector)} and within one corpus to "
-            f"{vector['expect']}. DIVERGES records this vector as "
-            f"{'diverging' if vector['id'] in self.DIVERGES else 'agreeing'}, "
-            f"so either #234 moved or a term was added. {vector['why']}"
-        )
-
-    def test_the_one_term_that_does_carry_is_revision(self):
-        """The half that works, stated on its own.
-
-        Whatever else is missing, two corpora carrying the same module at two
-        revisions resolve to the newer one, which is the case an operator
-        actually creates by adding a corpus to an existing deployment.
+        One corpus per module is the shape the rule exists for -- a
+        distribution corpus and a vendor one anchoring the same arc -- and it
+        is the only way to ask a composite anything, since two modules in one
+        corpus are ranked by pysmi at build time instead.
         """
-        vector = next(
-            vector
-            for vector in _vectors("oid_precedence")
-            if vector["id"] == "oid-newest-revision-wins"
-        )
+        corpora = [
+            _build_corpus(str(directory / f"{m['module']}.db"), {"modules": [m]})
+            for m in vector["modules"]
+        ]
 
-        assert self._byRevisionOnly(vector) == vector["expect"], vector["why"]
-
-    def test_tier_is_readable_even_though_it_is_not_read(self, tmp_path):
-        """#234 is implementable, and this is the evidence for that claim.
-
-        The gap above would be permanent if the terms it turns on were absent
-        from a corpus. Tier is not: it is a column on the ``module`` table and
-        this reader already returns it, so a composite that wanted to compare
-        tiers before revisions has the value in hand. Recording that here keeps
-        the issue from being closed as won't-fix on a false premise.
-        """
-        vector = next(
-            vector
-            for vector in _vectors("oid_precedence")
-            if vector["id"] == "oid-lower-tier-wins-over-a-newer-revision"
-        )
-
-        corpus = _build_corpus(str(tmp_path / "tiers.db"), vector)
+        composite = CompositeMibCorpus(*corpora)
 
         try:
-            tiers = {
-                module["module"]: corpus.module(module["module"])["tier"]
-                for module in vector["modules"]
-            }
+            return composite.anchor(pysmi_precedence.CONTESTED)
+
+        finally:
+            composite.close()
+
+    @pytest.mark.parametrize("vector", _vectors("oid_precedence"), ids=_identify)
+    def test_divergence_is_exactly_what_is_recorded(self, tmp_path, vector):
+        found = self._acrossCorpora(tmp_path, vector)
+        agrees = found == vector["expect"]
+
+        assert agrees is (vector["id"] not in self.DIVERGES), (
+            f"{vector['id']}: across corpora this resolves to {found} and "
+            f"within one corpus to {vector['expect']}. DIVERGES records this "
+            f"vector as "
+            f"{'diverging' if vector['id'] in self.DIVERGES else 'agreeing'}, "
+            f"so either a term started being read or one stopped. "
+            f"{vector['why']}"
+        )
+
+    @pytest.mark.parametrize(
+        "vector_id",
+        [
+            "oid-obsolete-loses-to-live-however-new-it-is",
+            "oid-lower-tier-wins-over-a-newer-revision",
+        ],
+    )
+    def test_the_two_terms_that_matter_are_applied(self, tmp_path, vector_id):
+        """Tier and obsolete, named individually rather than left to the sweep.
+
+        These are the two #234 was filed for. A vendor tree bundling its own
+        copy of a standard MIB is the ordinary case, not a corner, and before
+        #234 the newer copy took the arc. The sweep above would go on passing
+        if either of these regressed and the vector were quietly added to
+        DIVERGES, so they are asserted where that would be conspicuous.
+        """
+        vector = next(x for x in _vectors("oid_precedence") if x["id"] == vector_id)
+
+        assert self._acrossCorpora(tmp_path, vector) == vector["expect"], vector["why"]
+
+    def test_the_terms_that_cannot_be_read_are_still_absent(self, tmp_path):
+        """Evidence that DIVERGES is a schema limit, not an unfinished job.
+
+        Anchor class and RFC number are the two, and neither is a column a
+        reader could consult. Asserting that here keeps the pair honest: if
+        pysnmp/pysmi ever carries them, this fails and DIVERGES shrinks.
+        """
+        vector = next(
+            x
+            for x in _vectors("oid_precedence")
+            if x["id"] == "oid-module-identity-anchor-beats-object-identity"
+        )
+
+        corpus = _build_corpus(str(tmp_path / "anchor.db"), vector)
+
+        try:
+            record = corpus.module(vector["modules"][0]["module"])
 
         finally:
             corpus.close()
 
-        assert tiers == {"VENDOR-MIB": "vendor", "STANDARD-MIB": "standard"}
+        assert "anchor" not in record
+        assert "rfc" not in record


### PR DESCRIPTION
Closes #234.

## The gap

Inside one corpus, who owns an OID is pysmi's answer: `rank_index` runs at build time over every
module the build saw and writes one `oid_index` row per OID, on a seven-term rule.

Across corpora there is no such build. `CompositeMibCorpus.anchor()` asked each corpus who anchored
the arc and ranked the answers with `best_by_revision()` — the *same-module* rule, which reads
revision and nothing else. Six of pysmi's seven `oid_precedence` vectors therefore resolved
differently depending on whether the two modules sat in one corpus or two.

The tier row is the one that bites. Vendor trees bundle their own copies of standard MIBs, so an
operator who adds a vendor corpus alongside the standard one has two corpora anchoring the same
arcs — the ordinary case. Whichever copy was newer won, so a vendor republished last week took the
arc from the standard definition of it.

## The change

`anchor()` now ranks with `(obsolete, tier, revision, name)` — pysmi's `module_rank` less the two
terms a corpus cannot supply. Four of the six diverging vectors are recovered, including both that
matter.

`owner()` stays on `best_by_revision()`, deliberately. Two copies of one module and two different
modules claiming one arc are not the same question:

| | `owner()` | `anchor()` |
|---|---|---|
| asks about | two copies of one module | two different modules |
| rule | newest revision | `(obsolete, tier, revision, name)` |
| undated candidate | falls to configured order | loses outright |
| configured order | breaks ties | plays no part |

A wholly obsolete module is not an earlier draft of a live one, and a vendor MIB is not a later
revision of the standard one, so there is no symmetry to appeal to and nothing order should settle.
One consequence worth stating: **reordering `PYSNMP_MIB_DBS` can no longer change who owns an arc.**

## What is still unreachable

Anchor class (MODULE-IDENTITY over OBJECT-IDENTITY) is settled at build time and not carried into
`oid_index`. The publishing RFC number is not a corpus column at all. Both would need pysmi/mibs
schema work; both are stated in the composite's docstring and pinned by the two vectors left in
`TestCrossCorpusDivergence`, so closing that gap fails a test rather than passing silently.

## Tests

`TestCrossCorpusDivergence` previously ranked vectors through a bare `best_by_revision()` call. It
now builds one corpus per module and asks a real `CompositeMibCorpus`, which is the shape the rule
exists for. Tier and obsolete are additionally asserted by name, so a regression quietly added back
to `DIVERGES` would be conspicuous.

Two tests in `test_corpus.py` asserted that an undated candidate fell to configured order. That is
the behaviour this changes, so they are replaced by ones asserting it loses from either position.

## Verified

`ruff check` + `format`, `mypy` (147 files), `sphinx -n -W`, 1427 passed / 17 skipped.