### PR TITLE
build: resolve final releases only, never a prerelease

### DIFF
--- a/.github/copilot/copilot-instructions.md
+++ b/.github/copilot/copilot-instructions.md
@@ -27,8 +27,10 @@ Before generating code, scan the codebase to identify:
    - Never suggest features not available in the detected framework versions
 
 3. **Library Versions**: Note the exact versions of key libraries and dependencies
-   - Runtime dependencies (from `pyproject.toml`): `pysnmp-pysmi >=2.0.1,<3.0.0`, `pycryptodomex >=3.11.0,<4.0.0`, `pysnmp-pyasn1 >=1.3.0rc2,<2.0.0`
-   - Dev dependencies (from `pyproject.toml` `[project.optional-dependencies]`): `sphinx >=7.0.0,<9.0.0`, `pytest >=9.0.3,<10.0.0`, `coverage[toml] >=7.2.0,<8.0.0`, `mypy >=1.15.0,<3.0.0`, `ruff >=0.4.0,<1.0.0`
+   - Runtime dependencies (from `pyproject.toml` `[project].dependencies`): `pycryptodomex >=3.11.0,<4.0.0`, `pysnmp-pyasn1 >=2.0.2,<3.0.0`. pysmi is **not** one of them — the engine path never imports it (`tests/test_no_pysmi.py` holds that line)
+   - Optional dependencies (from `pyproject.toml` `[project.optional-dependencies]`): the `compile` extra, `pysnmp-pysmi >=4.0.0,<5.0.0`, which is what `pysnmp.smi.compiler` needs and nothing else does
+   - Dev dependencies (from `pyproject.toml` `[dependency-groups]`, PEP 735): `pysnmp-pysmi >=4.0.0,<5.0.0`, `sphinx >=7.0.0,<9.0.0`, `myst-parser >=4.0.0,<5.0.0`, `pytest >=9.0.3,<10.0.0`, `coverage[toml] >=7.2.0,<8.0.0`, `mypy >=1.15.0,<3.0.0`, `ruff >=0.4.0,<1.0.0`
+   - Every one of those floors names a final release, and `[tool.uv] prerelease = "disallow"` keeps it that way: never propose a requirement that names a prerelease (`4.0.0rc4`, `2.0.1rc1`), and never relax that setting to make one resolve
    - Generate code compatible with these specific versions
    - The project depends on the **pysnmp-pyasn1** fork, not upstream pyasn1. Import from `pyasn1.type`, `pyasn1.codec.ber`, `pyasn1.error`, and `pyasn1.compat.octets` as seen throughout `pysnmp/proto/` and `pysnmp/smi/`
    - Cryptography uses **pycryptodomex** (the `Cryptodome` namespace), imported under `pysnmp/proto/secmod/` for USM auth/priv protocols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,31 +43,25 @@ dependencies = [
 # missing import, which is what it already did for anyone who had not installed
 # pysmi.
 #
-# The floor names a release candidate on purpose, and naming one is the only way
-# to say this: dependabot offers a prerelease when the current version is
-# already one OR when a requirement string names one, and there is no
-# configuration key for it (dependabot/dependabot-core#1926, closed as not
-# planned). PEP 440 admits prereleases per specifier, so this puts pysmi on the
-# rc stream, and this repository integrates against the sibling rc it is
-# released alongside instead of against its last GA.
+# The floor is a final release and stays one. It named a release candidate
+# through the 4.0.0 cycle, because naming one is the only way to put a
+# requirement on the rc stream -- dependabot offers a prerelease when the
+# current version is already one OR when a requirement string names one, and
+# there is no configuration key for it (dependabot/dependabot-core#1926, closed
+# as not planned) -- and that bought integration against the sibling rc this
+# repository was cut alongside. pysmi 4.0.0 final is on PyPI, so there is no
+# longer a sibling rc to integrate against, and nothing here resolves to a
+# prerelease. See [tool.uv] below, which is what holds that.
 #
-# 4.0.0rc2 names an rc of the next *major*, so it outranks pysmi's newest GA
-# (3.0.0) and is what resolves. The major is pysmi dropping its mibs/behavior
-# splice (pysnmp/pysmi#245): a module it generates no longer carries the
-# runtime behavior no code generator can derive from ASN.1, because pysnmp
-# owns that now and applies it from pysnmp/smi/mibs/behavior (#215). Anything
-# still on pysmi 3.x gets that behavior twice, which is harmless -- the
-# fragments are idempotent -- and anything on 4.x gets it once, from here.
-#
-# So the floor is not a preference. Below 4.0.0rc1 pysmi splices behavior that
-# pysnmp also splices; at or above it, pysnmp is the only source. Regenerating
-# with a 3.x pysmi would write those fragments back into the committed modules
-# and tests/test_generated_mibs.py would fail against a 4.x one.
-#
-# pyasn1 is off that stream: 2.0.2 is a GA and is what the floor names. Put this
-# floor back on a GA before cutting the 6.0.0 GA -- an extra resolving to a
-# sibling release candidate is better than a required dependency doing it, but
-# it is still not what a GA should ship.
+# 4.0.0 rather than 3.x is a separate question from the rc one, and the answer
+# has not changed: the major is pysmi dropping its mibs/behavior splice
+# (pysnmp/pysmi#245). A module it generates no longer carries the runtime
+# behavior no code generator can derive from ASN.1, because pysnmp owns that now
+# and applies it from pysnmp/smi/mibs/behavior (#215). Anything still on pysmi
+# 3.x gets that behavior twice, which is harmless -- the fragments are
+# idempotent -- and anything on 4.x gets it once, from here. Regenerating with a
+# 3.x pysmi would write those fragments back into the committed modules and
+# tests/test_generated_mibs.py would fail against a 4.x one.
 [project.optional-dependencies]
 compile = ["pysnmp-pysmi >=4.0.0,<5.0.0"]
 
@@ -95,6 +89,26 @@ dev = [
     "mypy >=1.15.0,<3.0.0",
     "ruff >=0.4.0,<1.0.0",
 ]
+
+# General availability only, enforced rather than reviewed.
+#
+# Every requirement above names a final release -- pysnmp-pyasn1 2.0.2 and
+# pysnmp-pysmi 4.0.0 are both GA -- but a specifier is a statement about one
+# requirement, and the thing worth guaranteeing is a property of the whole
+# resolution: nothing this repository installs is a prerelease, including
+# something a transitive dependency asks for. "disallow" is that guarantee. uv
+# refuses to resolve a prerelease for any package, whatever a requirement string
+# says, so an rc cannot re-enter the lockfile by way of a dependabot bump or a
+# `uv lock --upgrade`; CI resolves with --locked, so it cannot enter unnoticed
+# either.
+#
+# This is the setting to relax -- drop it, and uv goes back to its default of
+# admitting a prerelease where a specifier names one -- to deliberately reopen
+# an rc integration stream with a sibling, which is what the 4.0.0 cycle above
+# needed. Until then, a GA cannot depend on a prerelease and neither can the rc
+# line leading to it.
+[tool.uv]
+prerelease = "disallow"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+prerelease-mode = "disallow"
+
 [[package]]
 name = "alabaster"
 version = "1.0.0"


### PR DESCRIPTION
## What this changes

`next` no longer has any way to resolve a prerelease. The requirement strings already named finals — `ee5e199` moved the `pysnmp-pysmi` floor to `4.0.0` in both the `compile` extra and the dev group, and `pysnmp-pyasn1` has been on `2.0.2` — but that was a per-requirement statement, and nothing stopped an rc from re-entering by another route. `[tool.uv] prerelease = "disallow"` closes that: uv refuses to resolve a prerelease for any package, direct or transitive, whatever a specifier says. The lockfile records the mode and no resolved version moves, because none was a prerelease to begin with. The two places that still *described* this repository as being on the rc stream are corrected to match.

## Why

`ee5e199` moved the floors but left the rationale above them standing, so `pyproject.toml` still explained that the floor "names a release candidate on purpose", still cited `4.0.0rc2` as what resolves, and still closed with an instruction — "Put this floor back on a GA before cutting the 6.0.0 GA" — that the very same commit had already carried out. Read today it says this package is on the rc stream. It is not, and the comment is now the most likely reason someone would put it back.

`.github/copilot/copilot-instructions.md` was worse than stale: it listed the runtime dependencies as `pysnmp-pysmi >=2.0.1,<3.0.0` and `pysnmp-pyasn1 >=1.3.0rc2,<2.0.0` — several majors out of date, naming a prerelease floor, and naming pysmi as a runtime dependency when the whole point of `tests/test_no_pysmi.py` is that the engine path never imports it. An agent reading that file had every reason to restore a prerelease requirement.

Then there is the part a comment cannot do. Prereleases were never forbidden here, only unrequested, and the two mechanisms that change requirements without review would each have brought one back: dependabot offers a prerelease once the current version is one (with no configuration key to refuse — [dependabot/dependabot-core#1926](https://github.com/dependabot/dependabot-core/issues/1926), closed as not planned), and `uv lock --upgrade` follows whatever a transitive requirement asks for. `pysnmp-pysmi 4.1.0rc1` is already on PyPI. A GA cannot depend on a prerelease, and neither can the rc line leading to one, so the constraint belongs in the resolver rather than in review.

## How it was checked

- [x] `uv run --locked --group dev pytest` passes — 1426 passed, 18 skipped
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv lock --check` passes, and the lockfile diff is the three-line `[options] prerelease-mode = "disallow"` stanza and nothing else — no resolved version changes
- [x] `uv sync --locked` and `uv build` both still work; the project's own `6.0.0rc11` version is unaffected, since the setting governs what is resolved for dependencies, not what this package is
- [ ] New or changed behaviour is covered by a test that fails without this change — nothing executable changed; the lockfile is the artifact, and CI's `--locked` resolution is what enforces it
- [ ] Documentation updated — no user-facing docs changed; `download.rst` and `README.md` never mentioned prereleases

## Notes for the reviewer

**One prerelease pull is left in the org, and it is not here.** `pysmi`'s dev group requires `pysnmplib>=6.0.0rc5` (for `setReference()` on the conformance classes, pysnmp/pysnmp#133), which resolves `6.0.0rc9` in its committed lock. That one cannot move to a final today — `pysnmplib` has no 6.x GA, its newest final is `5.0.24` — so it clears when 6.0.0 ships, not before. Same for `prerelease = true` on the pysnmp entry in `pysnmp/.github`'s `projects.toml`, which is what puts `--pre` in the org profile's install command; its comment already says to drop it once 6.0 is generally available.

**The floor argument was doing two jobs and only one of them was about rcs.** The rewritten comment keeps the other: `>=4.0.0` rather than `>=3.x` is about pysmi dropping its mibs/behavior splice (pysnmp/pysmi#245) in that major, which is why regenerating with a 3.x pysmi would write those fragments back and fail `tests/test_generated_mibs.py`. That reasoning is unchanged and is now stated separately from the rc question, so a future reader does not have to untangle the two.

**`disallow` is one line to relax.** If a sibling ever needs an rc integration stream again — which is exactly what the 4.0.0 cycle needed — dropping the `[tool.uv]` stanza restores uv's default of honouring a specifier that names a prerelease. The comment above it says so.

**The lockfile was regenerated with uv 0.12.13.** An older uv rewrites unrelated marker normalisations across ~40 lines; CI uses `astral-sh/setup-uv@v7` unpinned, so the lock is written by a uv contemporary with it and the diff stays at the three lines that are actually the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoBTeY84Bt3JpbRVy5UK9n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated dependency documentation to distinguish runtime requirements from the optional compilation tooling.
  - Clarified versioning guidance and documented that dependency minimums target final releases.

- **Chores**
  - Refined development dependency grouping, including updated documentation tooling.
  - Configured dependency resolution to disallow prerelease package versions.
  - Updated package versioning rationale to reflect the current release policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->