### PR TITLE
docs: reconcile with what this project actually ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This version is a fork of Ilya Etingof deceased's project [etingof/pysnmp](https
 - USM Extended Security Options support (3DES, 192/256-bit AES encryption)
 - Extensible network transports framework (UDP/IPv4, UDP/IPv6)
 - [Asyncio](https://docs.python.org/3/library/asyncio.html) integration
-- [PySMI](https://github.com/pysnmp/pysmi) integration for dynamic MIB compilation
+- [pysmi](https://pysnmp.github.io/pysmi/) integration for dynamic MIB compilation
 - Built-in instrumentation exposing protocol engine operations
 - 100% Python, supports Python 3.10 and later
 - MT-safe (if SnmpEngine is thread-local)
@@ -54,7 +54,7 @@ That pulls in what an SNMP engine needs to run:
 - [PyCryptodomex](https://pycryptodome.readthedocs.io) (required for SNMPv3 encryption; imported lazily, so
   SNMPv1, SNMPv2c and the SNMPv3 noAuthNoPriv/authNoPriv security levels work without it)
 
-[PySMI](https://github.com/pysnmp/pysmi) is *not* pulled in. It compiles ASN.1 MIB
+[pysmi](https://pysnmp.github.io/pysmi/) is *not* pulled in. It compiles ASN.1 MIB
 sources at run time, which some deployments do and most do not, so it is an extra:
 
 ```bash
@@ -65,19 +65,10 @@ Without it everything except run-time MIB compilation works — including SNMPv3
 resolution and the standard MIBs an engine needs, which PySNMP ships. Asking for a MIB
 compiler when the extra is not installed raises `SmiError` naming the missing import.
 
-Besides the library, command-line [SNMP utilities](https://github.com/etingof/snmpclitools)
-written in pure-Python could be installed via:
-
-```bash
-$ pip install snmpclitools
-```
-
-and used in the very similar manner as conventional Net-SNMP tools:
-
-```bash
-$ snmpget.py -v3 -l authPriv -u usr-md5-des -A authkey1 -X privkey1 localhost sysDescr.0
-SNMPv2-MIB::sysDescr.0 = STRING: Linux localhost 5.15.0
-```
+MIB *content* is a separate thing again, and not a pip install: module
+definitions come from the [MIB distribution](https://pysnmp.github.io/mibs/),
+used live over HTTPS or installed locally from a release archive or an OCI
+image. PySNMP starts without it, on the standard modules it ships.
 
 ## Examples
 
@@ -151,13 +142,16 @@ SNMPv2-MIB::sysName.0 = system name
 
 Other than that, PySNMP is capable to automatically fetch and use required MIBs from HTTP, FTP sites
 or local directories. You could configure any MIB source available to you (including
-[this one](https://pysnmp.github.io/mibs/asn1/)) for that purpose.
+[the MIB distribution](https://pysnmp.github.io/mibs/)) for that purpose.
 
 For more example scripts please refer to the `examples/` directory in this repository.
 
 ## Documentation
 
-Library documentation and examples can be found in the `docs/` directory in this repository.
+The rendered documentation is at <https://pysnmp.github.io/pysnmp/>, built from
+the `docs/` directory in this repository. The
+[organization site](https://pysnmp.github.io/) describes how pysnmp, the MIB
+distribution, pysmi and pyasn1 fit together.
 
 If something does not work as expected, please
 [open an issue](https://github.com/pysnmp/pysnmp/issues) at GitHub or

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -17,21 +17,28 @@ multilingual capabilities, remote configuration and other features.
 PySNMP implementation closely follows intricate system details and features 
 bringing most possible power and flexibility to its users.
 
-Current PySNMP stable version is 6.0. It requires Python 3.10 or later
-and is recommended for new applications as well as for migration from
-older, now obsolete, PySNMP releases. All site documentation and
-examples are written for the 6.0 and later versions in mind.
+.. note::
 
-Besides the libraries, a set of pure-Python 
-`command-line tools <https://pypi.python.org/pypi/snmpclitools/>`_
-are shipped along with the system. Those tools mimic the interface
-and behaviour of popular Net-SNMP snmpget/snmpset/snmpwalk utilities.
-They may be useful in a cross-platform situations as well as a testing
-and prototyping instrument for pysnmp users.
+   ``snmpclitools``, which older documentation described as shipping with
+   PySNMP, is a separate project and is **not** part of this one. The release
+   on PyPI depends on the ``pysnmp`` distribution, which is a different fork
+   from a different repository -- installing it beside ``pysnmplib`` puts two
+   SNMP engines in one environment.
 
-PySNMP software is free and open-source. Source code is hosted in 
-a `Github repo <https://github.com/pysnmp/pysnmp>`_.
-The library is being distributed under 2-clause BSD-style license.
+PySNMP is free and open-source software, distributed under a 2-clause
+BSD-style license. The source is at `pysnmp/pysnmp
+<https://github.com/pysnmp/pysnmp>`_.
+
+Three other projects are maintained alongside it, and the
+`organization site <https://pysnmp.github.io/>`_ describes how they fit
+together:
+
+* the `MIB distribution <https://pysnmp.github.io/mibs/>`_, which supplies the
+  module definitions an engine resolves names against;
+* `pysmi <https://pysnmp.github.io/pysmi/>`_, the MIB compiler, installed with
+  the ``compile`` extra;
+* `pyasn1 <https://pysnmp.github.io/pyasn1/>`_, the ASN.1 codec underneath
+  both, installed with PySNMP itself.
 
 PySNMP library development has been initially sponsored 
 by a `PSF <http://www.python.org/psf/>`_ grant.

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -63,7 +63,7 @@ Stand-alone PySNMP-based tools
    include extensive configuration facilities, fine-graned access 
    control and logging.
 
-   **Done:** see `SNMP Proxy Forwarder <https://pypi.org/project/snmpclitools/>`__.
+   **Done:** see `SNMP Proxy Forwarder <https://pypi.org/project/snmpfwd/>`__.
 
 #. SNMP Trap Receiver. We see this application as a simple yet flexible 
    SNMP TRAP collector. It would listen on network sockets of different 

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -7,7 +7,8 @@ Download PySNMP
 The PySNMP software is provided under terms and conditions of BSD-style 
 license, and can be freely downloaded from 
 `PyPI <https://pypi.org/project/pysnmplib/>`_ or
-GitHub (`main branch <https://github.com/pysnmp/pysnmp/archive/refs/heads/main.zip>`_).
+GitHub (`main branch <https://github.com/pysnmp/pysnmp/archive/refs/heads/main.zip>`_,
+which carries the released line; ``next`` is where work integrates).
 
 
 Besides official releases, it's advisable to try the cutting-edge
@@ -26,9 +27,10 @@ In case you are installing PySNMP on an off-line system, the following
 packages need to be downloaded and installed for PySNMP to become 
 operational:
 
-* `PyASN1 <https://pypi.python.org/pypi/pyasn1>`_,
-  used for handling ASN.1 objects
-* `PySNMP <https://pypi.python.org/pypi/pysnmplib/>`_,
+* `pysnmp-pyasn1 <https://pypi.org/project/pysnmp-pyasn1/>`_,
+  used for handling ASN.1 objects. This is the fork maintained here; the
+  ``pyasn1`` distribution on PyPI is a different project
+* `pysnmplib <https://pypi.org/project/pysnmplib/>`_,
   SNMP engine implementation
 * `PyCryptodomex <https://pypi.python.org/pypi/pycryptodomex/>`_,
   used by SNMPv3 crypto features. It is a declared dependency, but its
@@ -41,10 +43,12 @@ Optional, and installed by asking for the ``compile`` extra:
 
    $ pip install 'pysnmplib[compile]'
 
-* `PySMI <https://pypi.python.org/pypi/pysmi/>`_ for automatic
-  MIB download and compilation. That helps visualizing more SNMP objects
-* `Ply <https://pypi.python.org/pypi/ply/>`_, parser generator
-  required by PySMI
+* `pysnmp-pysmi <https://pypi.org/project/pysnmp-pysmi/>`_ for automatic
+  MIB download and compilation. That helps visualizing more SNMP objects.
+  As with pyasn1, this is the fork maintained here rather than the ``pysmi``
+  distribution
+* `Ply <https://pypi.org/project/ply/>`_, parser generator
+  required by pysmi
 
 PySMI is not a required dependency. PySNMP ships a rendering of the standard
 modules an engine resolves while starting up and while being configured, so
@@ -58,6 +62,12 @@ Install previously downloaded packages with pip, for example:
 .. code-block:: bash
 
    $ python -m pip install --no-index --find-links /path/to/packages pysnmplib
+
+Neither the extra nor an off-line install gives you MIB *content*. Module
+definitions come from the `MIB distribution <https://pysnmp.github.io/mibs/>`_,
+which is used live over HTTPS or installed locally from a release archive or an
+OCI image -- none of which is a pip install. PySNMP starts without it, on the
+standard modules it ships.
 
 In case of any issues, please open a `GitHub issue <https://github.com/pysnmp/pysnmp/issues/new>`_ so we could try to help out.
 

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -48,7 +48,7 @@ To send a trivial TRAP message to our hosted Notification Receiver at
 :download:`Download</../../examples/hlapi/asyncio/agent/ntforg/default-v1-trap.py>` script.
 
 Many ASN.1 MIB files could be downloaded from
-`pysnmp.github.io <https://pysnmp.github.io/mibs/asn1/>`_ or PySNMP could
+`the MIB distribution <https://pysnmp.github.io/mibs/>`_ or PySNMP could
 be :doc:`configured <docs/api-reference>` to download them automatically.
 
 For more sophisticated examples and use cases please refer to


### PR DESCRIPTION
Part of a pass across all four projects' documentation, plus a sweep of the legacy site URLs.

## Four things the documentation asserted that are not true

**`snmpclitools` is not part of this.** `contents.rst` said a set of pure-Python command-line tools "are shipped along with the system", and the README offered `pip install snmpclitools`. It is a separate project, and the current release (0.7.2) declares `pysnmp>=6.0.0,<7.0.0` — the **`pysnmp` distribution**, a different fork from a different repository. Following that instruction puts two SNMP engines in one environment.

**The off-line install named the wrong distributions.** `download.rst` told anyone installing without a network to fetch `pyasn1` and `pysmi` from PyPI. This package depends on `pysnmp-pyasn1` and `pysnmp-pysmi`; the upstream names are different projects. That list could not have worked.

**The proxy forwarder link pointed at the command-line tools.** `development.rst` marks "SNMP Proxy Forwarder" done and linked `snmpclitools`. It is `snmpfwd`.

**MIB content had no name.** Links went to `https://pysnmp.github.io/mibs/asn1/`, a generated tree with no index that answers 404 for the directory itself. They now point at the MIB distribution's documentation, and both the README and `download.rst` say plainly that module definitions are **not** a pip install and that pysnmp starts without them.

## Legacy sites

**`www.pysnmp.com` is not ours.** It redirects to `docs.lextudio.com` — a different fork's documentation, which this organization's `SUPPORT.md` and history page already tell people is a different project. Two source headers and the pysmi intersphinx target pointed there.

**pyasn1's intersphinx pointed at `pyasn1.readthedocs.io`**, upstream's rather than the fork this package depends on. Both intersphinx targets are now our own published inventories; both fetched, 200.

**Two IETF draft links named `tools.itef.org`** — a typo for ietf.org that has never resolved. Now datatracker links, both 200.

## Two more that had drifted

**"9000+ MIB modules"** was off by most of itself: `index-v2.csv` names 5,346 modules and the corpus database counts 5,510. The page now says over 5,000 and links the distribution rather than a number that will drift again.

**`CHANGELOG.md` pointed at `CHANGES.md` on `main`, where it does not exist** — it is on `next` and reaches `main` at the next general release, so the link is broken for everyone reading today. Both the file and the `changelogTitle` in `.releaserc`, which regenerates that header on every release, now point at the history as published with the documentation.

Also removed "Current PySNMP stable version is 6.0…": this page is published per release, so a version in its prose is wrong from the next release onwards, and the documentation already carries its own version.

## Identity

The package author moves from the old `rfaircloth-splunk` / `@splunk.com` identity to the current one, matching pyasn1 and pysmi. **omrozowicz's entry is left alone** — it is not mine to change.

## One thing deliberately left

The committed modules under `smi/mibs/` still carry pysmi's old `(http://snmplabs.com/pysmi)` banner. That string comes from the compiler, and `tests/test_generated_mibs.py` recompiles each module and compares it to the committed copy — so it can only change here after a pysmi release carries the fix (pysnmp/pysmi#272). Changing it now turns CI red; I tried it, saw the ten failures, and reverted.

## Verification

`sphinx-build -n -W --keep-going` succeeds. 1426 tests pass, 18 skipped. `ruff check` and `ruff format --check` are clean. Every URL touched was fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXV6V9HjgVwfUTKuMrzqsE