### PR TITLE
chore: point the legacy URLs at our own, and fix what had rotted

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -69,7 +69,7 @@
       "@semantic-release/changelog",
       {
         "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog\n\nGenerated from the commit history at release time. The narrative history\nthrough 5.x is in [CHANGES.md](https://github.com/pysnmp/pysnmp/blob/main/CHANGES.md)."
+        "changelogTitle": "# Changelog\n\nGenerated from the commit history at release time. The narrative history\nthrough 5.x is [published with the documentation](https://pysnmp.github.io/pysnmp/latest/changelog-history.html)."
       }
     ],
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 Generated from the commit history at release time. The narrative history
-through 5.x is in [CHANGES.md](https://github.com/pysnmp/pysnmp/blob/main/CHANGES.md).
+through 5.x is [published with the documentation](https://pysnmp.github.io/pysnmp/latest/changelog-history.html).
 
 ## [6.0.0-rc.11](https://github.com/pysnmp/pysnmp/compare/v6.0.0-rc.10...v6.0.0-rc.11) (2026-09-11)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -319,8 +319,8 @@ texinfo_documents = [
 # was pinned at 3.4 here, seven releases below the 3.10 this package requires.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "pyasn1": ("https://pyasn1.readthedocs.io/en/latest/", None),
-    "pysmi": ("https://www.pysnmp.com/pysmi/", None),
+    "pyasn1": ("https://pysnmp.github.io/pyasn1/stable/", None),
+    "pysmi": ("https://pysnmp.github.io/pysmi/stable/", None),
 }
 
 # this merges constructor docstring with class docstring

--- a/docs/source/docs/pysnmp-hlapi-tutorial.rst
+++ b/docs/source/docs/pysnmp-hlapi-tutorial.rst
@@ -242,7 +242,7 @@ in `SNMPv2-MIB <https://pysnmp.github.io/mibs/asn1/SNMPv2-MIB>`_ module.
 By default PySNMP will search your local filesystem for ASN.1 MIB files
 you refer to. It can also be configured to automatically download
 them from remote hosts, as shown in the examples. We maintain a
-`collection <https://pysnmp.github.io/mibs/asn1/>`_ of ASN.1 MIB modules
+`collection <https://pysnmp.github.io/mibs/>`_ of ASN.1 MIB modules
 that you can use in your SNMP projects.
 
 .. note::

--- a/docs/source/docs/snmp-design.rst
+++ b/docs/source/docs/snmp-design.rst
@@ -218,8 +218,8 @@ Both SNMP managed and managing entities could consume MIB information.
   + Implements MIB objects in code
 
 From human perspective, MIB is a text file written in a subset of
-ASN.1 language. We maintain `a collection
-<https://pysnmp.github.io/mibs/asn1/>`_ of 9000+ MIB modules that you can
+ASN.1 language. We maintain `a distribution
+<https://pysnmp.github.io/mibs/>`_ of over 5,000 MIB modules that you can
 use for your projects.
 
 PySNMP converts ASN.1 MIB files into Python modules, then SNMP

--- a/docs/source/examples/contents.rst
+++ b/docs/source/examples/contents.rst
@@ -93,7 +93,7 @@ SNMP credentials of your SNMP Agent in the examples to let them work.
 
 Should you want to use a MIB to make SNMP operations more human-friendly,
 you are welcome to search for it and possibly download one from our
-`public MIB repository <https://pysnmp.github.io/mibs/asn1/>`_. Alternatively,
+`public MIB repository <https://pysnmp.github.io/mibs/>`_. Alternatively,
 you can configure PySNMP to fetch and cache required MIBs from there
 automatically.
 

--- a/docs/source/faq/pass-custom-mib-to-manager.rst
+++ b/docs/source/faq/pass-custom-mib-to-manager.rst
@@ -22,7 +22,7 @@ A. Starting from PySNMP 4.3.x, plain-text (ASN.1) MIBs can be
    importing something outside that set needs. As for remote
    MIB repos, you are welcome to use our collection of ASN.1
    MIB files at
-   `https://pysnmp.github.io/mibs/asn1/ <https://pysnmp.github.io/mibs/asn1/>`_
+   `https://pysnmp.github.io/mibs/ <https://pysnmp.github.io/mibs/>`_
    as shown below.
 
 .. code-block:: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "6.0.0-rc.11"
 description = "Pure-Python SNMP v1/v2c/v3 engine"
 authors = [
     { name = "omrozowicz", email = "omrozowicz@splunk.com" },
-    { name = "rfaircloth-splunk", email = "rfaircloth-splunk@splunk.com" },
+    { name = "Ryan Faircloth", email = "actual@rfaircloth.com" },
 ]
 license = "BSD-2-Clause"
 requires-python = ">=3.10"

--- a/pysnmp/proto/secmod/eso/priv/aesbase.py
+++ b/pysnmp/proto/secmod/eso/priv/aesbase.py
@@ -66,12 +66,12 @@ class AbstractAesReeder(aes.Aes):
 
     Many vendors (including Cisco) do not use:
 
-    https://tools.itef.org/pdf/draft_bluementhal-aes-usm-04.txt
+    https://datatracker.ietf.org/doc/html/draft-blumenthal-aes-usm-04
 
     for key localization instead, they use the procedure for 3DES key localization
     specified in:
 
-    https://tools.itef.org/pdf/draft_reeder_snmpv3-usm-3desede-00.pdf
+    https://datatracker.ietf.org/doc/html/draft-reeder-snmpv3-usm-3desede-00
 
     The difference between the two is that the Reeder draft does key extension by repeating
     the steps in the password to key algorithm (hash phrase, then localize with SNMPEngine ID).
@@ -80,7 +80,7 @@ class AbstractAesReeder(aes.Aes):
     serviceID: tuple[int, ...] = ()
     keySize = 0
 
-    # 2.1 of https://tools.itef.org/pdf/draft_bluementhal-aes-usm-04.txt
+    # 2.1 of https://datatracker.ietf.org/doc/html/draft-blumenthal-aes-usm-04
     def localizeKey(self, authProtocol, privKey, snmpEngineID):
         """Localize by re-running the passphrase hash, as Reeder's draft has it.
 

--- a/pysnmp/smi/corpus.py
+++ b/pysnmp/smi/corpus.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
-# License: https://www.pysnmp.com/pysnmp/license.html
+# License: https://github.com/pysnmp/pysnmp/blob/main/LICENSE.rst
 #
 """Reading a MIB corpus, and building MIB objects from its rows.
 

--- a/pysnmp/smi/synthesis.py
+++ b/pysnmp/smi/synthesis.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2019, Ilya Etingof deceased
-# License: https://www.pysnmp.com/pysnmp/license.html
+# License: https://github.com/pysnmp/pysnmp/blob/main/LICENSE.rst
 #
 """Building MIB objects from corpus rows instead of executing generated Python.
 


### PR DESCRIPTION
Follow-on to #243, which merged before this was pushed.

## Legacy sites

**`www.pysnmp.com` is not ours.** It redirects to `docs.lextudio.com` — a different fork's documentation, which this organization's `SUPPORT.md` and history page already tell people is a different project. Two source headers and the pysmi intersphinx target pointed there.

**pyasn1's intersphinx pointed at `pyasn1.readthedocs.io`**, upstream's rather than the fork this package depends on. Both intersphinx targets are now our own published inventories; both fetched, 200.

**Two IETF draft links named `tools.itef.org`** — a typo for ietf.org that has never resolved. Now datatracker links, both 200.

## Two claims that had drifted

**"9000+ MIB modules"** was off by most of itself: `index-v2.csv` names 5,346 modules and the corpus database counts 5,510. The page now says over 5,000 and links the distribution rather than a number that will drift again.

**`CHANGELOG.md` pointed at `CHANGES.md` on `main`, where it does not exist** — it is on `next` and reaches `main` at the next general release, so the link is broken for everyone reading today. Both the file and the `changelogTitle` in `.releaserc`, which regenerates that header on every release, now point at the history as published with the documentation.

Five documentation pages also linked `https://pysnmp.github.io/mibs/asn1/`, a generated tree with no index that answers 404 for the directory. Links to a specific module under it (`asn1/SNMPv2-MIB`) resolve and are untouched, as is the `asn1/@mib@` source template.

## Identity

The package author moves from the old `rfaircloth-splunk` / `@splunk.com` identity to the current one, matching pyasn1, pysmi and mibs. **omrozowicz's entry is left alone** — it is not mine to change.

## One thing deliberately left

The committed modules under `smi/mibs/` still carry pysmi's old `(http://snmplabs.com/pysmi)` banner. That string comes from the compiler, and `tests/test_generated_mibs.py` recompiles each module and compares it to the committed copy — so it can only change here after a pysmi release carries the fix. Changing it now turns CI red; I tried it, saw the ten failures, and reverted.

## Verification

`sphinx-build -n -W --keep-going` succeeds. 1426 tests pass, 18 skipped. `ruff check` and `ruff format --check` are clean. Every URL touched was fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXV6V9HjgVwfUTKuMrzqsE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXV6V9HjgVwfUTKuMrzqsE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelog links to the hosted release history.
  - Refreshed links to stable PyASN1, PySMI, and MIB documentation.
  - Corrected MIB distribution wording and updated the stated module count.
  - Updated references to current IETF Datatracker pages.
  - Revised license links in project materials.

- **Chores**
  - Updated maintainer attribution and contact details in project metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->